### PR TITLE
ci: disable setup-go cache on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - name: Run govulncheck
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Smoke test
         run: |
           go build ./...


### PR DESCRIPTION
Same fix as SebTardifLabs/kube-rightsize#18.

All self-hosted runners share the same filesystem, so `~/go/pkg/mod` and `~/.cache/go-build` are already shared natively. The `actions/setup-go` cache compresses and uploads these directories redundantly per runner, wasting CPU, RAM, and I/O for zero benefit.

Set `cache: false` on all 5 `actions/setup-go@v6` steps across `ci.yml` and `release.yml`.