### PR TITLE
test: validate mock path parameters

### DIFF
--- a/internal/service/deployment/resource_test.go
+++ b/internal/service/deployment/resource_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+func requireRestartApplicationUUID(w http.ResponseWriter, r *http.Request, expectedAppUUID string) bool {
+	if r.PathValue("uuid") == expectedAppUUID {
+		return true
+	}
+
+	http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	return false
+}
+
 func TestDeploymentResource_Create(t *testing.T) {
 	t.Parallel()
 	deploymentUUID := "aaaa0001-0001-4000-8000-000000000001"
@@ -21,6 +30,9 @@ func TestDeploymentResource_Create(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
+		if !requireRestartApplicationUUID(w, r, appUUID) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"deployment_uuid": deploymentUUID,
@@ -86,11 +98,15 @@ resource "coolify_deployment" "test" {
 
 func TestDeploymentResource_TriggersForceNew(t *testing.T) {
 	t.Parallel()
+	appUUID := "cccc0001-0001-4000-8000-000000000001"
 	mu := sync.Mutex{}
 	deploymentCount := 0
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
+		if !requireRestartApplicationUUID(w, r, appUUID) {
+			return
+		}
 		mu.Lock()
 		deploymentCount++
 		uuid := fmt.Sprintf("dep-uuid-%d", deploymentCount)
@@ -124,12 +140,12 @@ provider "coolify" {
 }
 
 resource "coolify_deployment" "test" {
-  application_uuid = "cccc0001-0001-4000-8000-000000000001"
+  application_uuid = %q
   triggers = {
     version = "1"
   }
 }
-`, srv.URL),
+`, srv.URL, appUUID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", "dep-uuid-1"),
 					resource.TestCheckResourceAttr("coolify_deployment.test", "triggers.version", "1"),
@@ -143,12 +159,12 @@ provider "coolify" {
 }
 
 resource "coolify_deployment" "test" {
-  application_uuid = "cccc0001-0001-4000-8000-000000000001"
+  application_uuid = %q
   triggers = {
     version = "2"
   }
 }
-`, srv.URL),
+`, srv.URL, appUUID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", "dep-uuid-2"),
 					resource.TestCheckResourceAttr("coolify_deployment.test", "triggers.version", "2"),
@@ -165,6 +181,9 @@ func TestDeploymentResource_Import(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
+		if !requireRestartApplicationUUID(w, r, appUUID) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"deployment_uuid": deploymentUUID,
@@ -213,6 +232,7 @@ resource "coolify_deployment" "test" {
 
 func TestDeploymentResource_Disappears(t *testing.T) {
 	t.Parallel()
+	appUUID := "cccc0001-0001-4000-8000-000000000001"
 	deploymentUUID := "dep-disappear-uuid"
 
 	mu := sync.Mutex{}
@@ -220,6 +240,9 @@ func TestDeploymentResource_Disappears(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
+		if !requireRestartApplicationUUID(w, r, appUUID) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"deployment_uuid": deploymentUUID,
@@ -255,9 +278,9 @@ provider "coolify" {
 }
 
 resource "coolify_deployment" "test" {
-  application_uuid = "cccc0001-0001-4000-8000-000000000001"
+  application_uuid = %q
 }
-`, srv.URL),
+`, srv.URL, appUUID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", deploymentUUID),
 					func(s *terraform.State) error {

--- a/internal/service/githubapp/resource_test.go
+++ b/internal/service/githubapp/resource_test.go
@@ -118,6 +118,21 @@ func (s *mockGitHubAppStore) List() []*mockGitHubApp {
 	return result
 }
 
+func requireMockGitHubApp(w http.ResponseWriter, r *http.Request, store *mockGitHubAppStore) bool {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, `{"error":"invalid id"}`, http.StatusBadRequest)
+		return false
+	}
+
+	if _, ok := store.Get(id); !ok {
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		return false
+	}
+
+	return true
+}
+
 // newMockCoolifyServer creates an httptest.Server that simulates the Coolify API for GitHub Apps.
 func newMockCoolifyServer(auditT ...testing.TB) (*httptest.Server, *mockGitHubAppStore) {
 	store := &mockGitHubAppStore{
@@ -199,6 +214,9 @@ func newMockCoolifyServer(auditT ...testing.TB) (*httptest.Server, *mockGitHubAp
 	})
 
 	mux.HandleFunc("GET /api/v1/github-apps/{id}/repositories", func(w http.ResponseWriter, r *http.Request) {
+		if !requireMockGitHubApp(w, r, store) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode([]client.GitHubRepository{
 			{Name: "repo-1", FullName: "testowner/repo-1", Private: false},
@@ -207,6 +225,13 @@ func newMockCoolifyServer(auditT ...testing.TB) (*httptest.Server, *mockGitHubAp
 	})
 
 	mux.HandleFunc("GET /api/v1/github-apps/{id}/repositories/{owner}/{repo}/branches", func(w http.ResponseWriter, r *http.Request) {
+		if !requireMockGitHubApp(w, r, store) {
+			return
+		}
+		if r.PathValue("owner") != "testowner" || r.PathValue("repo") != "repo-1" {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode([]client.GitHubBranch{
 			{Name: "main"},


### PR DESCRIPTION
## Summary
- validate deployment restart mock handlers against the requested application UUID
- validate GitHub App repository and branch mock handlers against requested path parameters

## Testing
- go test -race -count=1 ./internal/service/deployment ./internal/service/githubapp
- go build ./...

Closes #56