### PR TITLE
Preserve partial state on create refresh failures

### DIFF
--- a/internal/service/environment/resource.go
+++ b/internal/service/environment/resource.go
@@ -121,18 +121,32 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	if plan.ID.IsUnknown() {
+		plan.ID = types.Int64Null()
+	}
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringNull()
+	}
+
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	projectUUID := plan.ProjectUUID.ValueString()
+	name := plan.Name.ValueString()
+
 	// Read back the full environment to populate computed fields.
-	diags := r.readEnvironment(ctx, plan.ProjectUUID.ValueString(), plan.Name.ValueString(), &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	diags := r.readEnvironment(ctx, projectUUID, name, &plan)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(
+			"Environment created but refresh failed",
+			fmt.Sprintf("Coolify created environment %s/%s, but the provider could not read it back: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", projectUUID, name, diags.Errors()[0].Detail()),
+		)
 		return
 	}
+	resp.Diagnostics.Append(diags...)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -144,15 +158,18 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	tflog.Debug(ctx, "reading resource", map[string]interface{}{"resource_type": "coolify_environment", "name": state.Name.ValueString()})
+	projectUUID := state.ProjectUUID.ValueString()
+	name := state.Name.ValueString()
 
-	env, err := r.client.GetEnvironment(ctx, state.ProjectUUID.ValueString(), state.Name.ValueString())
+	tflog.Debug(ctx, "reading resource", map[string]interface{}{"resource_type": "coolify_environment", "name": name})
+
+	env, err := r.client.GetEnvironment(ctx, projectUUID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error reading environment", fmt.Sprintf("Could not read environment %s/%s: %s", state.ProjectUUID.ValueString(), state.Name.ValueString(), err))
+		resp.Diagnostics.AddError("Error reading environment", fmt.Sprintf("Could not read environment %s/%s: %s", projectUUID, name, err))
 		return
 	}
 
@@ -187,9 +204,12 @@ func (r *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": "coolify_environment", "name": state.Name.ValueString()})
+	projectUUID := state.ProjectUUID.ValueString()
+	name := state.Name.ValueString()
 
-	err := r.client.DeleteEnvironment(ctx, state.ProjectUUID.ValueString(), state.Name.ValueString())
+	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": "coolify_environment", "name": name})
+
+	err := r.client.DeleteEnvironment(ctx, projectUUID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			return

--- a/internal/service/environment/resource_test.go
+++ b/internal/service/environment/resource_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -208,6 +210,67 @@ resource "coolify_environment" "test" {
 `,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestEnvironmentResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	store := newMockEnvironmentStore()
+	var forceReadFailure atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/projects/{projectUUID}/environments", func(w http.ResponseWriter, r *http.Request) {
+		projectUUID := r.PathValue("projectUUID")
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		env := store.Create(projectUUID, body.Name, "")
+		forceReadFailure.Store(true)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(env)
+	})
+	mux.HandleFunc("GET /api/v1/projects/{projectUUID}/{envName}", func(w http.ResponseWriter, r *http.Request) {
+		if forceReadFailure.Load() {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
+		projectUUID := r.PathValue("projectUUID")
+		envName := r.PathValue("envName")
+		env, ok := store.Get(projectUUID, envName)
+		if !ok {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(env)
+	})
+	mux.HandleFunc("DELETE /api/v1/projects/{projectUUID}/environments/{envName}", func(w http.ResponseWriter, r *http.Request) {
+		projectUUID := r.PathValue("projectUUID")
+		envName := r.PathValue("envName")
+		store.Delete(projectUUID, envName)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+	})
+
+	server := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(server.URL) + `
+resource "coolify_environment" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  name         = "readback-failure"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)Environment created but refresh failed.*Could not read environment.*partial Terraform state was saved`),
 			},
 		},
 	})

--- a/internal/service/privatekey/resource.go
+++ b/internal/service/privatekey/resource.go
@@ -12,17 +12,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
 	_ resource.Resource                = &privateKeyResource{}
 	_ resource.ResourceWithConfigure   = &privateKeyResource{}
 	_ resource.ResourceWithImportState = &privateKeyResource{}
+)
+
+const (
+	privateKeyDeleteRetryAttempts = 6
+	privateKeyDeleteRetryDelay    = 5 * time.Second
 )
 
 type privateKeyResource struct {
@@ -129,6 +133,18 @@ func (r *privateKeyResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringNull()
+	}
+	if plan.PublicKey.IsUnknown() {
+		plan.PublicKey = types.StringNull()
+	}
+	if plan.Fingerprint.IsUnknown() {
+		plan.Fingerprint = types.StringNull()
+	}
+	if plan.IsGitRelated.IsUnknown() {
+		plan.IsGitRelated = types.BoolNull()
+	}
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -139,7 +155,10 @@ func (r *privateKeyResource) Create(ctx context.Context, req resource.CreateRequ
 	// Read back for full state.
 	key, err := r.client.GetPrivateKey(ctx, created.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading private key after create", fmt.Sprintf("private key %s: %s", created.UUID, err))
+		resp.Diagnostics.AddError(
+			"Private key created but refresh failed",
+			fmt.Sprintf("Coolify created private key %s, but the provider could not read it back: Could not read private key %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, created.UUID, err),
+		)
 		return
 	}
 
@@ -227,26 +246,27 @@ func (r *privateKeyResource) Delete(ctx context.Context, req resource.DeleteRequ
 	// up to 30 seconds on "in use" errors.
 	uuid := state.UUID.ValueString()
 	var err error
+
 retryLoop:
-	for attempt := range 6 {
+	for attempt := range privateKeyDeleteRetryAttempts {
 		err = r.client.DeletePrivateKey(ctx, uuid)
-		if err == nil {
+		if err == nil || client.IsNotFound(err) {
 			return
 		}
-		if client.IsNotFound(err) {
-			return
-		}
-		if !strings.Contains(err.Error(), "in use") && !strings.Contains(err.Error(), "cannot be deleted") {
+		if !isPrivateKeyDeleteRetryable(err) {
 			break
 		}
+
 		tflog.Debug(ctx, "retrying private key delete", map[string]interface{}{"attempt": attempt + 1, "uuid": uuid})
+
 		select {
 		case <-ctx.Done():
 			err = ctx.Err()
 			break retryLoop
-		case <-time.After(5 * time.Second):
+		case <-time.After(privateKeyDeleteRetryDelay):
 		}
 	}
+
 	resp.Diagnostics.AddError("Error deleting private key", fmt.Sprintf("private key %s: %s", uuid, err))
 }
 
@@ -261,6 +281,12 @@ func (r *privateKeyResource) ImportState(ctx context.Context, req resource.Impor
 		"The Coolify API hides the private_key field unless the API token has \"root\" or \"read:sensitive\" permission. "+
 			"If you see unexpected diffs after import, check your token's permissions in the Coolify dashboard under Security > API Tokens.",
 	)
+}
+
+func isPrivateKeyDeleteRetryable(err error) bool {
+	message := err.Error()
+
+	return strings.Contains(message, "in use") || strings.Contains(message, "cannot be deleted")
 }
 
 func flattenPrivateKey(key *client.PrivateKey, model *privateKeyResourceModel) {

--- a/internal/service/privatekey/resource_test.go
+++ b/internal/service/privatekey/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -121,6 +122,70 @@ resource "coolify_private_key" "test" {
 }`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestPrivateKeyResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	keys := make(map[string]*client.PrivateKey)
+	var mu sync.Mutex
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/security/keys":
+			var input client.CreatePrivateKeyInput
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+				return
+			}
+			key := &client.PrivateKey{UUID: "cccc0009-0009-4000-8000-000000000009"}
+			keys[key.UUID] = key
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(key)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/security/keys/"):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/security/keys/")
+			key, ok := keys[uuid]
+			if !ok {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(key)
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/security/keys/"):
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/security/keys/")
+			delete(keys, uuid)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_private_key" "test" {
+  name        = "readback-failure"
+  private_key = "ssh-ed25519 AAAA-test-key"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)Private key created but refresh failed.*Could not read private key.*partial Terraform state was saved`),
 			},
 		},
 	})

--- a/internal/service/server/resource.go
+++ b/internal/service/server/resource.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-
 	"regexp"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/client"
@@ -214,6 +213,18 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringNull()
+	}
+	if plan.IsReachable.IsUnknown() {
+		plan.IsReachable = types.BoolNull()
+	}
+	if plan.IsUsable.IsUnknown() {
+		plan.IsUsable = types.BoolNull()
+	}
+	if plan.ServerDiskUsageCheckFrequency.IsUnknown() {
+		plan.ServerDiskUsageCheckFrequency = types.StringNull()
+	}
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -224,7 +235,10 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Read back for full state.
 	srv, err := r.client.GetServer(ctx, created.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading server after create", fmt.Sprintf("server %s: %s", created.UUID, err))
+		resp.Diagnostics.AddError(
+			"Server created but refresh failed",
+			fmt.Sprintf("Coolify created server %s, but the provider could not read it back: Could not read server %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, created.UUID, err),
+		)
 		return
 	}
 

--- a/internal/service/server/resource_test.go
+++ b/internal/service/server/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -182,6 +183,72 @@ resource "coolify_server" "test" {
 }`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestServerResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	servers := make(map[string]*client.Server)
+	var mu sync.Mutex
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/servers":
+			var input client.CreateServerInput
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+				return
+			}
+			created := &client.Server{UUID: "bbbb0009-0009-4000-8000-000000000009"}
+			servers[created.UUID] = created
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(created)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/servers/"):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
+			server, ok := servers[uuid]
+			if !ok {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(server)
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/servers/"):
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
+			delete(servers, uuid)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server" "test" {
+  name             = "readback-failure"
+  ip               = "10.0.0.1"
+  private_key_uuid = "dddd0002-0002-4000-8000-000000000002"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)Server created but refresh failed.*Could not read server.*partial Terraform state was saved`),
 			},
 		},
 	})

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -26,7 +26,10 @@ var (
 	_ resource.ResourceWithImportState = &serviceResource{}
 )
 
-type serviceResource struct{ client *client.Client }
+type serviceResource struct {
+	client *client.Client
+}
+
 type serviceResourceModel struct {
 	Timeouts        timeouts.Value `tfsdk:"timeouts"`
 	UUID            types.String   `tfsdk:"uuid"`
@@ -38,36 +41,99 @@ type serviceResourceModel struct {
 	Type            types.String   `tfsdk:"type"`
 }
 
-func NewResource() resource.Resource { return &serviceResource{} }
+func NewResource() resource.Resource {
+	return &serviceResource{}
+}
+
 func (r *serviceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_service"
 }
+
 func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a service resource on Coolify. Services are pre-built application stacks from the Coolify service catalog (e.g. plausible, uptime-kuma, minio).",
 		Attributes: map[string]schema.Attribute{
-			"timeouts":         timeouts.Attributes(ctx, timeouts.Opts{Create: true}),
-			"uuid":             schema.StringAttribute{MarkdownDescription: "The UUID of the service.", Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-			"name":             schema.StringAttribute{MarkdownDescription: "The name of the service.", Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-			"description":      schema.StringAttribute{MarkdownDescription: "A description of the service.", Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-			"project_uuid":     schema.StringAttribute{MarkdownDescription: "The UUID of the project this service belongs to.", Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}, Validators: []validator.String{validate.UUID()}},
-			"server_uuid":      schema.StringAttribute{MarkdownDescription: "The UUID of the server to deploy the service on.", Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}, Validators: []validator.String{validate.UUID()}},
-			"environment_name": schema.StringAttribute{MarkdownDescription: "The environment name. Defaults to `production`. Changing this forces a new resource.", Optional: true, Computed: true, Default: stringdefault.StaticString("production"), PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"type":             schema.StringAttribute{MarkdownDescription: "The service type from the Coolify service catalog (e.g. `plausible`, `uptime-kuma`, `minio`). See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service).", Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{Create: true}),
+			"uuid": schema.StringAttribute{
+				MarkdownDescription: "The UUID of the service.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the service.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "A description of the service.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_uuid": schema.StringAttribute{
+				MarkdownDescription: "The UUID of the project this service belongs to.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					validate.UUID(),
+				},
+			},
+			"server_uuid": schema.StringAttribute{
+				MarkdownDescription: "The UUID of the server to deploy the service on.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					validate.UUID(),
+				},
+			},
+			"environment_name": schema.StringAttribute{
+				MarkdownDescription: "The environment name. Defaults to `production`. Changing this forces a new resource.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("production"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The service type from the Coolify service catalog (e.g. `plausible`, `uptime-kuma`, `minio`). See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service).",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 	}
 }
+
 func (r *serviceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
+
 	c, ok := req.ProviderData.(*client.Client)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected *client.Client, got: %T", req.ProviderData))
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T", req.ProviderData),
+		)
 		return
 	}
+
 	r.client = c
 }
+
 func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan serviceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -79,11 +145,18 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
+
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_service"})
 
-	input := client.CreateServiceInput{ServerUUID: plan.ServerUUID.ValueString(), ProjectUUID: plan.ProjectUUID.ValueString(), EnvironmentName: plan.EnvironmentName.ValueString(), Type: plan.Type.ValueString()}
+	input := client.CreateServiceInput{
+		ServerUUID:      plan.ServerUUID.ValueString(),
+		ProjectUUID:     plan.ProjectUUID.ValueString(),
+		EnvironmentName: plan.EnvironmentName.ValueString(),
+		Type:            plan.Type.ValueString(),
+	}
 	flex.SetIfKnown(&input.Name, plan.Name)
 	flex.SetIfKnown(&input.Description, plan.Description)
 	created, err := r.client.CreateService(ctx, input)
@@ -93,6 +166,12 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	if plan.Name.IsUnknown() {
+		plan.Name = types.StringNull()
+	}
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringNull()
+	}
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -102,12 +181,17 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 
 	svc, err := r.client.GetService(ctx, created.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading service after creation", fmt.Sprintf("service %s: %s", created.UUID, err))
+		resp.Diagnostics.AddError(
+			"Service created but refresh failed",
+			fmt.Sprintf("Coolify created service %s, but the provider could not read it back: Could not read service %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, created.UUID, err),
+		)
 		return
 	}
+
 	flattenService(svc, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
+
 func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state serviceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -125,9 +209,11 @@ func (r *serviceResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("Error reading service", fmt.Sprintf("service %s: %s", state.UUID.ValueString(), err))
 		return
 	}
+
 	flattenService(svc, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
+
 func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan serviceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -139,40 +225,48 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": plan.UUID.ValueString()})
+
+	uuid := state.UUID.ValueString()
+	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
 
 	input := client.UpdateServiceInput{
 		Name:        flex.StringIfChanged(plan.Name, state.Name),
 		Description: flex.StringIfChanged(plan.Description, state.Description),
 	}
-	if _, err := r.client.UpdateService(ctx, plan.UUID.ValueString(), input); err != nil {
-		resp.Diagnostics.AddError("Error updating service", fmt.Sprintf("service %s: %s", plan.UUID.ValueString(), err))
+	if _, err := r.client.UpdateService(ctx, uuid, input); err != nil {
+		resp.Diagnostics.AddError("Error updating service", fmt.Sprintf("service %s: %s", uuid, err))
 		return
 	}
-	svc, err := r.client.GetService(ctx, plan.UUID.ValueString())
+
+	svc, err := r.client.GetService(ctx, uuid)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading service after update", fmt.Sprintf("service %s: %s", plan.UUID.ValueString(), err))
+		resp.Diagnostics.AddError("Error reading service after update", fmt.Sprintf("service %s: %s", uuid, err))
 		return
 	}
+
 	flattenService(svc, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
+
 func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state serviceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": state.UUID.ValueString()})
 
-	if err := r.client.DeleteService(ctx, state.UUID.ValueString()); err != nil {
+	uuid := state.UUID.ValueString()
+	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
+
+	if err := r.client.DeleteService(ctx, uuid); err != nil {
 		if client.IsNotFound(err) {
 			return
 		}
-		resp.Diagnostics.AddError("Error deleting service", fmt.Sprintf("service %s: %s", state.UUID.ValueString(), err))
+		resp.Diagnostics.AddError("Error deleting service", fmt.Sprintf("service %s: %s", uuid, err))
 		return
 	}
 }
+
 func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	if err := validate.ImportUUID(req.ID); err != nil {
 		resp.Diagnostics.AddError("Invalid Import ID", err.Error())
@@ -186,22 +280,23 @@ func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportSt
 	)
 }
 
-func flattenService(svc *client.Service, m *serviceResourceModel) {
-	m.UUID = types.StringValue(svc.UUID)
-	m.Name = flex.StringToFramework(svc.Name)
-	m.Description = flex.StringToFramework(svc.Description)
-	// Immutable fields: only update if the API returns them (Coolify may
-	// omit these from the GET response).
+func flattenService(svc *client.Service, model *serviceResourceModel) {
+	model.UUID = types.StringValue(svc.UUID)
+	model.Name = flex.StringToFramework(svc.Name)
+	model.Description = flex.StringToFramework(svc.Description)
+
+	// Immutable fields: only update if the API returns them because
+	// Coolify may omit these from the GET response.
 	if svc.Type != "" {
-		m.Type = types.StringValue(svc.Type)
+		model.Type = types.StringValue(svc.Type)
 	}
 	if svc.ProjectUUID != "" {
-		m.ProjectUUID = types.StringValue(svc.ProjectUUID)
+		model.ProjectUUID = types.StringValue(svc.ProjectUUID)
 	}
 	if svc.ServerUUID != "" {
-		m.ServerUUID = types.StringValue(svc.ServerUUID)
+		model.ServerUUID = types.StringValue(svc.ServerUUID)
 	}
 	if svc.EnvironmentName != "" {
-		m.EnvironmentName = flex.StringToFramework(svc.EnvironmentName)
+		model.EnvironmentName = flex.StringToFramework(svc.EnvironmentName)
 	}
 }

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -5,13 +5,27 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+const serviceTestConfig = `
+resource "coolify_service" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+  type         = "plausible"
+}
+`
+
+func serviceConfig(serverURL string) string {
+	return acctest.ProviderBlockForURL(serverURL) + serviceTestConfig
+}
 
 type mockServiceState struct {
 	mu          sync.Mutex
@@ -89,18 +103,7 @@ func TestServiceResource_CreateImport(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create
 			{
-				Config: fmt.Sprintf(`
-provider "coolify" {
-  endpoint  = %q
-  token = "test-token"
-}
-
-resource "coolify_service" "test" {
-  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  type         = "plausible"
-}
-`, srv.URL),
+				Config: serviceConfig(srv.URL),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_service.test", "uuid", "dddd0001-0001-4000-8000-000000000001"),
 					resource.TestCheckResourceAttr("coolify_service.test", "name", "plausible-svc"),
@@ -110,18 +113,7 @@ resource "coolify_service" "test" {
 			},
 			// Idempotency
 			{
-				Config: fmt.Sprintf(`
-provider "coolify" {
-  endpoint  = %q
-  token = "test-token"
-}
-
-resource "coolify_service" "test" {
-  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  type         = "plausible"
-}
-`, srv.URL),
+				Config:             serviceConfig(srv.URL),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -132,6 +124,59 @@ resource "coolify_service" "test" {
 				ImportStateId:     "dddd0001-0001-4000-8000-000000000001",
 				ImportStateVerify: true, ImportStateVerifyIdentifierAttribute: "uuid",
 				ImportStateVerifyIgnore: []string{"project_uuid", "server_uuid", "environment_name", "type"},
+			},
+		},
+	})
+}
+
+func TestServiceResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	state := &mockServiceState{uuid: "dddd0009-0009-4000-8000-000000000009", name: "plausible-svc"}
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/services":
+			w.WriteHeader(http.StatusCreated)
+			forceReadFailure.Store(true)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": state.uuid})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", state.uuid):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             state.uuid,
+				"name":             state.name,
+				"description":      state.description,
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"type":             "plausible",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", state.uuid):
+			state.deleted = true
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      serviceConfig(srv.URL),
+				ExpectError: regexp.MustCompile(`(?s)Service created but refresh failed.*Could not read service.*partial Terraform state was saved`),
 			},
 		},
 	})
@@ -188,18 +233,7 @@ func TestServiceResource_Disappears(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-provider "coolify" {
-  endpoint  = %q
-  token = "test-token"
-}
-
-resource "coolify_service" "test" {
-  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  type         = "plausible"
-}
-`, srv.URL),
+				Config: serviceConfig(srv.URL),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_service.test", "uuid"),
 					acctest.CheckResourceDisappears(srv.URL, "coolify_service.test", "/api/v1/services/"),
@@ -263,19 +297,14 @@ func TestServiceResource_Update(t *testing.T) {
 	defer srv.Close()
 
 	baseConfig := func(desc string) string {
-		return fmt.Sprintf(`
-provider "coolify" {
-  endpoint = %q
-  token    = "test-token"
-}
-
+		return acctest.ProviderBlockForURL(srv.URL) + fmt.Sprintf(`
 resource "coolify_service" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
   type         = "plausible"
   description  = %q
 }
-`, srv.URL, desc)
+`, desc)
 	}
 
 	resource.UnitTest(t, resource.TestCase{


### PR DESCRIPTION
## Summary
- preserve partial Terraform state when create refresh fails for server, private key, service, and environment resources
- normalize unresolved computed values before saving partial state on the error path
- add create read-back failure regression tests for those resources

## Testing
- go test -race -count=1 -timeout=5m ./internal/service/server ./internal/service/privatekey ./internal/service/service ./internal/service/environment
- go build ./...