### PR TITLE
Handle database create refresh failures safely

### DIFF
--- a/internal/service/database/backup/resource.go
+++ b/internal/service/database/backup/resource.go
@@ -222,6 +222,39 @@ func (r *databaseBackupResource) Create(ctx context.Context, req resource.Create
 	// the full backup object. Save partial state immediately so the
 	// resource is tracked even if the follow-up read fails.
 	plan.UUID = types.StringValue(created.UUID)
+	if plan.ID.IsUnknown() {
+		plan.ID = types.Int64Null()
+	}
+	if plan.Enabled.IsUnknown() {
+		plan.Enabled = types.BoolNull()
+	}
+	if plan.SaveS3.IsUnknown() {
+		plan.SaveS3 = types.BoolNull()
+	}
+	if plan.DumpAll.IsUnknown() {
+		plan.DumpAll = types.BoolNull()
+	}
+	if plan.RetainAmountLocally.IsUnknown() {
+		plan.RetainAmountLocally = types.Int64Null()
+	}
+	if plan.RetainDaysLocally.IsUnknown() {
+		plan.RetainDaysLocally = types.Int64Null()
+	}
+	if plan.RetainMaxStorageLocal.IsUnknown() {
+		plan.RetainMaxStorageLocal = types.Int64Null()
+	}
+	if plan.RetainAmountS3.IsUnknown() {
+		plan.RetainAmountS3 = types.Int64Null()
+	}
+	if plan.RetainDaysS3.IsUnknown() {
+		plan.RetainDaysS3 = types.Int64Null()
+	}
+	if plan.RetainMaxStorageS3.IsUnknown() {
+		plan.RetainMaxStorageS3 = types.Int64Null()
+	}
+	if plan.Timeout.IsUnknown() {
+		plan.Timeout = types.Int64Null()
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -232,7 +265,10 @@ func (r *databaseBackupResource) Create(ctx context.Context, req resource.Create
 	// then do a full GET to populate all fields.
 	backups, listErr := r.client.ListDatabaseBackups(ctx, dbUUID)
 	if listErr != nil {
-		resp.Diagnostics.AddError("Error listing database backups after create", fmt.Sprintf("backup %s for database %s: %s", created.UUID, dbUUID, listErr))
+		resp.Diagnostics.AddError(
+			"Database backup created but refresh failed",
+			fmt.Sprintf("Coolify created database backup %s for database %s, but the provider could not read it back: Could not list database backups for %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, dbUUID, dbUUID, listErr),
+		)
 		return
 	}
 	var found *client.DatabaseBackup
@@ -243,7 +279,10 @@ func (r *databaseBackupResource) Create(ctx context.Context, req resource.Create
 		}
 	}
 	if found == nil {
-		resp.Diagnostics.AddError("Error resolving database backup", fmt.Sprintf("backup %s not found in list for database %s", created.UUID, dbUUID))
+		resp.Diagnostics.AddError(
+			"Database backup created but refresh failed",
+			fmt.Sprintf("Coolify created database backup %s for database %s, but the provider could not read it back: Could not resolve backup %s from the database %s backup list after create. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, dbUUID, created.UUID, dbUUID),
+		)
 		return
 	}
 

--- a/internal/service/database/backup/resource_test.go
+++ b/internal/service/database/backup/resource_test.go
@@ -205,6 +205,58 @@ func TestDatabaseBackupResource_Create(t *testing.T) {
 	})
 }
 
+func TestDatabaseBackupResource_CreateListFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const dbUUID = "eeee0001-0001-4000-8000-000000000001"
+	const backupUUID = "bkp-readback-uuid-001"
+
+	var forceListFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s/backups", dbUUID):
+			forceListFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":    backupUUID,
+				"message": "Backup configuration created successfully.",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s/backups", dbUUID):
+			if forceListFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode([]map[string]interface{}{{
+				"id": 42, "uuid": backupUUID, "database_uuid": dbUUID, "frequency": "0 2 * * *", "enabled": true,
+			}})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s/backups/%s", dbUUID, backupUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testBackupConfig(srv.URL, `
+				database_uuid = "eeee0001-0001-4000-8000-000000000001"
+				frequency     = "0 2 * * *"
+				enabled       = true
+			`),
+			ExpectError: regexp.MustCompile(`(?s)Database backup created but refresh failed.*Could not list database backups.*partial Terraform state was saved`),
+		}},
+	})
+}
+
 func TestDatabaseBackupResource_Update(t *testing.T) {
 	t.Parallel()
 	srv, _ := newMockBackupServer()

--- a/internal/service/database/clickhouse/resource.go
+++ b/internal/service/database/clickhouse/resource.go
@@ -76,6 +76,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.ClickhouseAdminUser)
+	pg.NormalizeUnknownString(&p.ClickhouseAdminPassword)
+	pg.NormalizeUnknownString(&p.ClickhouseDB)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -94,7 +98,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading ClickHouse database", fmt.Sprintf("ClickHouse database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "ClickHouse database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/clickhouse/resource_test.go
+++ b/internal/service/database/clickhouse/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -228,6 +230,62 @@ resource "coolify_clickhouse_database" "test" {
 				),
 			},
 		},
+	})
+}
+
+func TestClickhouseDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const clickhouseUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/clickhouse":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": clickhouseUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", clickhouseUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":                      clickhouseUUID,
+				"name":                      "ch-readback-db",
+				"project_uuid":              "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":               "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":          "production",
+				"image":                     "clickhouse/clickhouse-server:latest",
+				"is_public":                 false,
+				"clickhouse_admin_user":     "default",
+				"clickhouse_admin_password": "secret123",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", clickhouseUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_clickhouse_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)ClickHouse database created but refresh failed.*Could not read ClickHouse database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/dragonfly/resource.go
+++ b/internal/service/database/dragonfly/resource.go
@@ -69,6 +69,8 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.DragonflyPassword)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -87,7 +89,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Dragonfly database", fmt.Sprintf("Dragonfly database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "Dragonfly database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/dragonfly/resource_test.go
+++ b/internal/service/database/dragonfly/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -185,6 +187,60 @@ resource "coolify_dragonfly_database" "test" {
 				ImportStateVerifyIdentifierAttribute: "uuid",
 			},
 		},
+	})
+}
+
+func TestDragonflyDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const dragonflyUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/dragonfly":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": dragonflyUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", dragonflyUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             dragonflyUUID,
+				"name":             "dragonfly-readback-db",
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"image":            "docker.dragonflydb.io/dragonflydb/dragonfly:latest",
+				"is_public":        false,
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", dragonflyUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_dragonfly_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)Dragonfly database created but refresh failed.*Could not read Dragonfly database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/keydb/resource.go
+++ b/internal/service/database/keydb/resource.go
@@ -71,6 +71,9 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.KeydbPassword)
+	pg.NormalizeUnknownString(&p.KeydbConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -91,7 +94,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading KeyDB database", fmt.Sprintf("KeyDB database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "KeyDB database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/keydb/resource_test.go
+++ b/internal/service/database/keydb/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -185,6 +187,60 @@ resource "coolify_keydb_database" "test" {
 				ImportStateVerifyIdentifierAttribute: "uuid",
 			},
 		},
+	})
+}
+
+func TestKeydbDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const keydbUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/keydb":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": keydbUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", keydbUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             keydbUUID,
+				"name":             "keydb-readback-db",
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"image":            "eqalpha/keydb:latest",
+				"is_public":        false,
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", keydbUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_keydb_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)KeyDB database created but refresh failed.*Could not read KeyDB database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/mariadb/resource.go
+++ b/internal/service/database/mariadb/resource.go
@@ -81,6 +81,12 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.MariadbUser)
+	pg.NormalizeUnknownString(&p.MariadbPassword)
+	pg.NormalizeUnknownString(&p.MariadbDatabase)
+	pg.NormalizeUnknownString(&p.MariadbRootPassword)
+	pg.NormalizeUnknownString(&p.MariadbConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -100,7 +106,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading MariaDB database", fmt.Sprintf("MariaDB database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "MariaDB database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/mariadb/resource_test.go
+++ b/internal/service/database/mariadb/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -159,6 +160,64 @@ resource "coolify_mariadb_database" "test" {
 				ImportStateVerifyIgnore: []string{"mariadb_password", "mariadb_root_password"},
 			},
 		},
+	})
+}
+
+func TestMariadbDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const mariadbUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/mariadb":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": mariadbUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mariadbUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":                  mariadbUUID,
+				"name":                  "mariadb-readback-db",
+				"project_uuid":          "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":           "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":      "production",
+				"image":                 "mariadb:11",
+				"is_public":             false,
+				"mariadb_user":          "mariauser",
+				"mariadb_password":      "mariapass",
+				"mariadb_database":      "mariadb",
+				"mariadb_root_password": "rootpwd",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mariadbUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_mariadb_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)MariaDB database created but refresh failed.*Could not read MariaDB database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/mongodb/resource.go
+++ b/internal/service/database/mongodb/resource.go
@@ -78,6 +78,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.MongoInitdbRootUsername)
+	pg.NormalizeUnknownString(&p.MongoInitdbRootPassword)
+	pg.NormalizeUnknownString(&p.MongoInitdbDatabase)
+	pg.NormalizeUnknownString(&p.MongoConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -97,7 +102,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading MongoDB database", fmt.Sprintf("MongoDB database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "MongoDB database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/mongodb/resource_test.go
+++ b/internal/service/database/mongodb/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -155,6 +157,63 @@ resource "coolify_mongodb_database" "test" {
 				ImportStateVerifyIgnore: []string{"mongo_initdb_root_password"},
 			},
 		},
+	})
+}
+
+func TestMongodbDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const mongoUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/mongodb":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": mongoUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mongoUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":                       mongoUUID,
+				"name":                       "mongo-readback-db",
+				"project_uuid":               "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":                "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":           "production",
+				"image":                      "mongo:7",
+				"is_public":                  false,
+				"mongo_initdb_root_username": "root",
+				"mongo_initdb_root_password": "mongosecret",
+				"mongo_initdb_database":      "admin",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mongoUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_mongodb_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)MongoDB database created but refresh failed.*Could not read MongoDB database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/mysql/resource.go
+++ b/internal/service/database/mysql/resource.go
@@ -89,6 +89,12 @@ func (r *mysqlDatabaseResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	pg.NormalizeCommonCreateState(&plan.CommonModel)
+	pg.NormalizeUnknownString(&plan.MysqlUser)
+	pg.NormalizeUnknownString(&plan.MysqlPassword)
+	pg.NormalizeUnknownString(&plan.MysqlDatabase)
+	pg.NormalizeUnknownString(&plan.MysqlRootPassword)
+	pg.NormalizeUnknownString(&plan.MysqlConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -108,7 +114,7 @@ func (r *mysqlDatabaseResource) Create(ctx context.Context, req resource.CreateR
 
 	db, err := r.client.GetDatabase(ctx, created.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading MySQL database after creation", fmt.Sprintf("MySQL database %s: %s", created.UUID, err))
+		pg.AddCreateReadBackError(resp, "MySQL database", created.UUID, err)
 		return
 	}
 	flattenDatabase(db, &plan)

--- a/internal/service/database/mysql/resource_test.go
+++ b/internal/service/database/mysql/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -159,6 +161,64 @@ resource "coolify_mysql_database" "test" {
 				ImportStateVerifyIgnore: []string{"mysql_password", "mysql_root_password"},
 			},
 		},
+	})
+}
+
+func TestMysqlDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const mysqlUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/mysql":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": mysqlUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mysqlUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":                mysqlUUID,
+				"name":                "mysql-readback-db",
+				"project_uuid":        "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":         "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":    "production",
+				"image":               "mysql:8",
+				"is_public":           false,
+				"mysql_user":          "mysqluser",
+				"mysql_password":      "mysqlpass",
+				"mysql_database":      "mydb",
+				"mysql_root_password": "rootsecret",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", mysqlUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_mysql_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)MySQL database created but refresh failed.*Could not read MySQL database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/postgresql/resource.go
+++ b/internal/service/database/postgresql/resource.go
@@ -190,6 +190,14 @@ func (r *postgresqlDatabaseResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	NormalizeCommonCreateState(&plan.CommonModel)
+	NormalizeUnknownString(&plan.PostgresUser)
+	NormalizeUnknownString(&plan.PostgresPassword)
+	NormalizeUnknownString(&plan.PostgresDB)
+	NormalizeUnknownString(&plan.PostgresConf)
+	NormalizeUnknownString(&plan.PostgresInitdbArgs)
+	NormalizeUnknownString(&plan.PostgresHostAuthMethod)
+	NormalizeUnknownString(&plan.InitScripts)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -214,7 +222,7 @@ func (r *postgresqlDatabaseResource) Create(ctx context.Context, req resource.Cr
 
 	db, err := r.client.GetDatabase(ctx, created.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading PostgreSQL database after creation", fmt.Sprintf("PostgreSQL database %s: %s", created.UUID, err))
+		AddCreateReadBackError(resp, "PostgreSQL database", created.UUID, err)
 		return
 	}
 	flattenDatabase(db, &plan)
@@ -394,6 +402,41 @@ func DeleteDatabase(ctx context.Context, c *client.Client, uuid string) error {
 		return err
 	}
 	return nil
+}
+
+func NormalizeUnknownString(v *types.String) {
+	if v != nil && v.IsUnknown() {
+		*v = types.StringNull()
+	}
+}
+
+func NormalizeUnknownBool(v *types.Bool) {
+	if v != nil && v.IsUnknown() {
+		*v = types.BoolNull()
+	}
+}
+
+func NormalizeUnknownInt64(v *types.Int64) {
+	if v != nil && v.IsUnknown() {
+		*v = types.Int64Null()
+	}
+}
+
+func NormalizeCommonCreateState(m *CommonModel) {
+	NormalizeUnknownString(&m.Name)
+	NormalizeUnknownString(&m.Description)
+	NormalizeUnknownString(&m.EnvironmentName)
+	NormalizeUnknownString(&m.Image)
+	NormalizeUnknownBool(&m.IsPublic)
+	NormalizeUnknownInt64(&m.PublicPort)
+	NormalizeUnknownString(&m.Status)
+}
+
+func AddCreateReadBackError(resp *resource.CreateResponse, label, identifier string, err error) {
+	resp.Diagnostics.AddError(
+		fmt.Sprintf("%s created but refresh failed", label),
+		fmt.Sprintf("Coolify created %s %s, but the provider could not read it back: Could not read %s %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", label, identifier, label, identifier, err),
+	)
 }
 
 // ImportDatabaseState validates the import ID as a UUID and passes it through

--- a/internal/service/database/postgresql/resource_test.go
+++ b/internal/service/database/postgresql/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -252,6 +253,63 @@ resource "coolify_postgresql_database" "test" {
 				),
 			},
 		},
+	})
+}
+
+func TestPostgresqlDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const pgUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/postgresql":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": pgUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", pgUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":              pgUUID,
+				"name":              "pg-readback-db",
+				"project_uuid":      "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":       "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":  "production",
+				"image":             "postgres:16",
+				"is_public":         false,
+				"postgres_user":     "postgres",
+				"postgres_password": "secret123",
+				"postgres_db":       "defaultdb",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", pgUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_postgresql_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)PostgreSQL database created but refresh failed.*Could not read PostgreSQL database.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -67,6 +67,8 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	p.UUID = types.StringValue(c.UUID)
+	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.RedisConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -86,7 +88,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	db, err := r.client.GetDatabase(ctx, c.UUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Redis database", fmt.Sprintf("Redis database %s: %s", c.UUID, err))
+		pg.AddCreateReadBackError(resp, "Redis database", c.UUID, err)
 		return
 	}
 	flattenDatabase(db, &p)

--- a/internal/service/database/redis/resource_test.go
+++ b/internal/service/database/redis/resource_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -145,6 +147,60 @@ resource "coolify_redis_database" "test" {
 				ImportStateVerify: true, ImportStateVerifyIdentifierAttribute: "uuid",
 			},
 		},
+	})
+}
+
+func TestRedisDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	const redisUUID = "aaaa0009-0009-4000-8000-000000000009"
+
+	var forceReadFailure atomic.Bool
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/databases/redis":
+			forceReadFailure.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": redisUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", redisUUID):
+			if forceReadFailure.Load() {
+				http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             redisUUID,
+				"name":             "redis-readback-db",
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"image":            "redis:7",
+				"is_public":        false,
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", redisUUID):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_redis_database" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)Redis database created but refresh failed.*Could not read Redis database.*partial Terraform state was saved`),
+		}},
 	})
 }
 


### PR DESCRIPTION
## Summary
- preserve safe partial Terraform state when database resource create refresh fails
- align database backup create refresh failures with the same diagnostic and computed-state normalization behavior
- add focused regression tests across database resources and database backup

## Testing
- go test -race -count=1 -timeout=8m ./internal/service/database/backup ./internal/service/database/clickhouse ./internal/service/database/dragonfly ./internal/service/database/keydb ./internal/service/database/mariadb ./internal/service/database/mongodb ./internal/service/database/mysql ./internal/service/database/postgresql ./internal/service/database/redis
- go build ./...