### PR TITLE
Preserve app partial state on readback failure

### DIFF
--- a/internal/service/application/common.go
+++ b/internal/service/application/common.go
@@ -994,9 +994,66 @@ func setImportDefaults(ctx context.Context, resp *resource.ImportStateResponse) 
 	set("use_build_server", false)
 }
 
-// readBackAfterCreate reads the application after creation and handles the
-// 404-on-readback case (server not SSH-reachable). Returns nil if an error
-// was added to diagnostics.
+// normalizeUnknown* converts unknown planned values to null before saving
+// partial state after create.
+func normalizeUnknownString(v *types.String) {
+	if v != nil && v.IsUnknown() {
+		*v = types.StringNull()
+	}
+}
+
+func normalizeUnknownBool(v *types.Bool) {
+	if v != nil && v.IsUnknown() {
+		*v = types.BoolNull()
+	}
+}
+
+func normalizeUnknownInt64(v *types.Int64) {
+	if v != nil && v.IsUnknown() {
+		*v = types.Int64Null()
+	}
+}
+
+func normalizeCommonAppCreateState(m *applicationCommonModel) {
+	normalizeUnknownString(&m.Name)
+	normalizeUnknownString(&m.Description)
+	normalizeUnknownString(&m.EnvironmentName)
+	normalizeUnknownString(&m.FQDN)
+	normalizeUnknownString(&m.Status)
+	normalizeUnknownBool(&m.HealthCheckEnabled)
+	normalizeUnknownBool(&m.IsAutoDeployEnabled)
+	normalizeUnknownString(&m.Redirect)
+	normalizeUnknownString(&m.StaticImage)
+	normalizeUnknownBool(&m.IsStatic)
+	normalizeUnknownBool(&m.IsSPA)
+	normalizeUnknownBool(&m.IsPreserveRepositoryEnabled)
+	normalizeUnknownBool(&m.UseBuildServer)
+	normalizeUnknownString(&m.PreviewURLTemplate)
+	normalizeUnknownString(&m.HealthCheckHost)
+	normalizeUnknownString(&m.HealthCheckMethod)
+	normalizeUnknownInt64(&m.HealthCheckReturnCode)
+	normalizeUnknownString(&m.HealthCheckScheme)
+	normalizeUnknownString(&m.HealthCheckType)
+	normalizeUnknownBool(&m.ConnectToDockerNetwork)
+	normalizeUnknownBool(&m.IsForceHTTPSEnabled)
+	normalizeUnknownBool(&m.IsHTTPBasicAuthEnabled)
+	normalizeUnknownString(&m.HTTPBasicAuthUsername)
+	normalizeUnknownString(&m.HTTPBasicAuthPassword)
+	normalizeUnknownString(&m.ManualWebhookSecretBitbucket)
+	normalizeUnknownString(&m.ManualWebhookSecretGitea)
+	normalizeUnknownString(&m.ManualWebhookSecretGitHub)
+	normalizeUnknownString(&m.ManualWebhookSecretGitLab)
+	normalizeUnknownBool(&m.ForceDomainOverride)
+	normalizeUnknownBool(&m.IsContainerLabelEscapeEnabled)
+}
+
+func addApplicationCreateReadBackError(resp *resource.CreateResponse, uuid string, err error) {
+	resp.Diagnostics.AddError(
+		"Application created but refresh failed",
+		fmt.Sprintf("Coolify created application %s, but the provider could not read it back: Could not read application %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", uuid, uuid, err),
+	)
+}
+
 func readBackAfterCreate(ctx context.Context, c *client.Client, uuid string, resp *resource.CreateResponse) *client.Application {
 	app, err := c.GetApplication(ctx, uuid)
 	if err != nil {
@@ -1010,7 +1067,7 @@ func readBackAfterCreate(ctx context.Context, c *client.Client, uuid string, res
 			)
 			return nil
 		}
-		resp.Diagnostics.AddError("Error reading application after creation", fmt.Sprintf("application %s: %s", uuid, err))
+		addApplicationCreateReadBackError(resp, uuid, err)
 		return nil
 	}
 	return app

--- a/internal/service/application/resource.go
+++ b/internal/service/application/resource.go
@@ -150,6 +150,8 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	normalizeCommonAppCreateState(&plan.applicationCommonModel)
+	normalizeUnknownString(&plan.GitBranch)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/application/resource_docker.go
+++ b/internal/service/application/resource_docker.go
@@ -122,6 +122,7 @@ func (r *dockerImageApplicationResource) Create(ctx context.Context, req resourc
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	normalizeCommonAppCreateState(&plan.applicationCommonModel)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/application/resource_dockerfile.go
+++ b/internal/service/application/resource_dockerfile.go
@@ -151,6 +151,10 @@ func (r *dockerfileApplicationResource) Create(ctx context.Context, req resource
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	normalizeCommonAppCreateState(&plan.applicationCommonModel)
+	normalizeUnknownString(&plan.GitRepository)
+	normalizeUnknownString(&plan.GitBranch)
+	normalizeUnknownString(&plan.BuildPack)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/application/resource_dockerfile_test.go
+++ b/internal/service/application/resource_dockerfile_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -97,6 +99,70 @@ func TestDockerfileApplicationResource_Create(t *testing.T) {
 				`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestDockerfileApplicationResource_CreateReadBackFailurePreservesState
+// ---------------------------------------------------------------------------
+
+func TestDockerfileApplicationResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	app := client.Application{
+		UUID:               "dockerfile-readback-failure-uuid",
+		ProjectUUID:        "aaaa0009-0009-4000-8000-000000000009",
+		ServerUUID:         "bbbb0009-0009-4000-8000-000000000009",
+		EnvironmentName:    "production",
+		DockerfileLocation: "RlJPTSBuZ2lueA==",
+		PortsExposes:       "80",
+	}
+
+	var forceReadFailure atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/dockerfile", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		forceReadFailure.Store(true)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != app.UUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		if forceReadFailure.Load() {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(app)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != app.UUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		forceReadFailure.Store(false)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDockerfileResourceConfig(srv.URL, `
+					project_uuid        = "aaaa0009-0009-4000-8000-000000000009"
+					server_uuid         = "bbbb0009-0009-4000-8000-000000000009"
+					dockerfile_location = "RlJPTSBuZ2lueA=="
+					ports_exposes       = "80"
+				`),
+				ExpectError: regexp.MustCompile(`(?s)Application created but refresh failed.*Could not read application.*partial Terraform state was saved`),
 			},
 		},
 	})

--- a/internal/service/application/resource_github_app.go
+++ b/internal/service/application/resource_github_app.go
@@ -159,6 +159,8 @@ func (r *gitHubAppApplicationResource) Create(ctx context.Context, req resource.
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	normalizeCommonAppCreateState(&plan.applicationCommonModel)
+	normalizeUnknownString(&plan.GitBranch)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/application/resource_private_git.go
+++ b/internal/service/application/resource_private_git.go
@@ -164,6 +164,8 @@ func (r *privateGitApplicationResource) Create(ctx context.Context, req resource
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
+	normalizeCommonAppCreateState(&plan.applicationCommonModel)
+	normalizeUnknownString(&plan.GitBranch)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)


### PR DESCRIPTION
## Summary
- normalize shared application create partial state before the read-back
- keep the existing 404 `Application created but not persisted` behavior, but use the newer refresh-failed diagnostic for other read-back errors
- add Dockerfile application regression coverage for non-404 create read-back failures

## Verification
- go test -race -count=1 -timeout=10m ./internal/service/application
- go build ./...

This completes #183 for supported create paths. The stale top-level `coolify_s3_storage` surface remains tracked separately in #178.