### PR TITLE
Improve cloud token create refresh diagnostics

### DIFF
--- a/internal/service/cloudtoken/resource.go
+++ b/internal/service/cloudtoken/resource.go
@@ -7,7 +7,6 @@ import (
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/client"
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/flex"
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/validate"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -106,13 +105,14 @@ func (r *cloudTokenResource) Create(ctx context.Context, req resource.CreateRequ
 		Token:    plan.Token.ValueString(),
 	}
 
-	ct, err := r.client.CreateCloudToken(ctx, input)
+	created, err := r.client.CreateCloudToken(ctx, input)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating cloud token", err.Error())
 		return
 	}
 
-	plan.UUID = types.StringValue(ct.UUID)
+	createdUUID := created.UUID
+	plan.UUID = types.StringValue(createdUUID)
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -121,10 +121,17 @@ func (r *cloudTokenResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Read back the full cloud token to populate all fields.
-	diags := r.readCloudToken(ctx, ct.UUID, &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	ct, err := r.client.GetCloudToken(ctx, createdUUID)
+	if err != nil {
+		addCreateReadBackError(resp, createdUUID, err)
 		return
+	}
+
+	plan.UUID = types.StringValue(ct.UUID)
+	plan.Name = types.StringValue(ct.Name)
+	plan.CloudProvider = types.StringValue(ct.Provider)
+	if ct.Token != "" {
+		plan.Token = types.StringValue(ct.Token)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -190,10 +197,17 @@ func (r *cloudTokenResource) Update(ctx context.Context, req resource.UpdateRequ
 	plan.UUID = state.UUID
 
 	// Read back the full cloud token to populate all fields.
-	diags := r.readCloudToken(ctx, state.UUID.ValueString(), &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	ct, err := r.client.GetCloudToken(ctx, state.UUID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading cloud token after update", fmt.Sprintf("Could not read cloud token %s after update: %s", state.UUID.ValueString(), err))
 		return
+	}
+
+	plan.UUID = types.StringValue(ct.UUID)
+	plan.Name = types.StringValue(ct.Name)
+	plan.CloudProvider = types.StringValue(ct.Provider)
+	if ct.Token != "" {
+		plan.Token = types.StringValue(ct.Token)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -218,32 +232,22 @@ func (r *cloudTokenResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 }
 
+func addCreateReadBackError(resp *resource.CreateResponse, uuid string, err error) {
+	resp.Diagnostics.AddError(
+		"Cloud token created but refresh failed",
+		fmt.Sprintf(
+			"Coolify created cloud token %s, but the provider could not read it back: Could not read cloud token %s after create: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.",
+			uuid,
+			uuid,
+			err,
+		),
+	)
+}
+
 func (r *cloudTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	if err := validate.ImportUUID(req.ID); err != nil {
 		resp.Diagnostics.AddError("Invalid Import ID", err.Error())
 		return
 	}
 	resource.ImportStatePassthroughID(ctx, path.Root("uuid"), req, resp)
-}
-
-// readCloudToken fetches the cloud token from the API and updates the model in place.
-func (r *cloudTokenResource) readCloudToken(ctx context.Context, uuid string, model *cloudTokenResourceModel) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	ct, err := r.client.GetCloudToken(ctx, uuid)
-	if err != nil {
-		diags.AddError("Error reading cloud token", fmt.Sprintf("Could not read cloud token %s after create/update: %s", uuid, err))
-		return diags
-	}
-
-	model.UUID = types.StringValue(ct.UUID)
-	model.Name = types.StringValue(ct.Name)
-	model.CloudProvider = types.StringValue(ct.Provider)
-	// Preserve token from the current model value since the API may not return
-	// sensitive fields. Only overwrite if the API actually returned a token.
-	if ct.Token != "" {
-		model.Token = types.StringValue(ct.Token)
-	}
-
-	return diags
 }

--- a/internal/service/cloudtoken/resource_test.go
+++ b/internal/service/cloudtoken/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync"
 	"testing"
 
@@ -24,6 +25,10 @@ type mockCloudToken struct {
 
 // newMockCoolifyServer creates an httptest.Server that simulates the Coolify API for cloud tokens.
 func newMockCoolifyServer(auditT ...testing.TB) (*httptest.Server, *mockCloudTokenStore) {
+	return newMockCoolifyServerWithReadFailure(false, auditT...)
+}
+
+func newMockCoolifyServerWithReadFailure(forceReadFailure bool, auditT ...testing.TB) (*httptest.Server, *mockCloudTokenStore) {
 	store := &mockCloudTokenStore{
 		cloudTokens:     make(map[string]*mockCloudToken),
 		omitTokenOnRead: make(map[string]bool),
@@ -49,6 +54,10 @@ func newMockCoolifyServer(auditT ...testing.TB) (*httptest.Server, *mockCloudTok
 	})
 
 	mux.HandleFunc("GET /api/v1/cloud-tokens/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if forceReadFailure {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
 		uuid := r.PathValue("uuid")
 		ct, ok := store.Get(uuid)
 		if !ok {
@@ -232,6 +241,26 @@ resource "coolify_cloud_token" "test" {
 				ExpectNonEmptyPlan: false,
 			},
 		},
+	})
+}
+
+func TestCloudTokenResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+	server, _ := newMockCoolifyServerWithReadFailure(true)
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(server.URL) + `
+resource "coolify_cloud_token" "test" {
+  name           = "readback-failure"
+  cloud_provider = "aws"
+  token          = "secret-token-value"
+}
+`,
+			ExpectError: regexp.MustCompile(`(?s)Cloud token created but refresh failed.*Could not read cloud token.*partial Terraform state was saved`),
+		}},
 	})
 }
 


### PR DESCRIPTION
## Summary
- align cloud token create read-back failures with the partial-state-safe diagnostic pattern used by other resources
- add focused regression coverage for a failed create read-back in `coolify_cloud_token`
- keep the update path behavior unchanged apart from leaving the create-specific recovery guidance scoped to create

Refs #184