### PR TITLE
docs: quarantine stale S3 storage usage and clarify Hetzner test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ Acceptance tests (requires a running Coolify instance):
 ```bash
 export COOLIFY_ENDPOINT="http://localhost:8000"
 export COOLIFY_TOKEN="your-api-token"
+# Also required for cloud token and Hetzner-related acceptance tests.
+export COOLIFY_HETZNER_TOKEN="your-real-hetzner-api-token"
 make testacc
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A Terraform provider for managing resources in [Coolify](https://coolify.io/), t
 | `coolify_keydb_database` | Provision KeyDB databases (Redis-compatible) |
 | `coolify_dragonfly_database` | Provision DragonFly databases (Redis-compatible) |
 | `coolify_database_backup` | Schedule automated database backups |
-| `coolify_s3_storage` | Manage S3 storage destinations for backups |
+| `coolify_s3_storage` | Manage top-level S3 storage destinations, but current Coolify v4 may not expose the backing public CRUD API |
 | `coolify_scheduled_task` | Manage scheduled tasks on applications/services |
 | `coolify_storage` | Manage persistent storage volumes |
 | `coolify_cloud_token` | Manage cloud provider tokens (Hetzner) |
@@ -59,7 +59,7 @@ A Terraform provider for managing resources in [Coolify](https://coolify.io/), t
 | `coolify_environment_variable` / `coolify_environment_variables` | Read / list env vars for an application, service, or database |
 | `coolify_deployment` / `coolify_deployments` | Read / list deployments for an application |
 | `coolify_service` / `coolify_services` | Read service(s) |
-| `coolify_s3_storage` / `coolify_s3_storages` | Read S3 storage destination(s) |
+| `coolify_s3_storage` / `coolify_s3_storages` | Read top-level S3 storage destination(s), but current Coolify v4 may not expose the backing public API |
 | `coolify_scheduled_task` / `coolify_scheduled_tasks` / `coolify_task_executions` | Read scheduled task(s) and executions |
 | `coolify_storage` / `coolify_storages` | Read / list persistent storage volumes |
 | `coolify_cloud_token` / `coolify_cloud_tokens` | Read cloud token(s) |
@@ -178,6 +178,11 @@ make ci          # Run the aggregate local checks (acceptance tests run separate
 `make ci` does not run acceptance tests. If your change touches real Coolify
 API behavior, also run `make testacc` or targeted `TF_ACC=1 go test ...`
 commands.
+
+Cloud token and Hetzner-related acceptance tests need a real
+`COOLIFY_HETZNER_TOKEN` in addition to the normal `COOLIFY_ENDPOINT` and
+`COOLIFY_TOKEN` setup, because Coolify validates the token against Hetzner on
+create.
 
 For local provider testing with `dev_overrides`, acceptance test setup, and
 project structure details, see [CONTRIBUTING.md](CONTRIBUTING.md) and

--- a/TESTING.md
+++ b/TESTING.md
@@ -96,6 +96,9 @@ export COOLIFY_TOKEN="<your-api-token>"
 
 # Optional: set a specific server UUID (otherwise auto-discovered)
 export COOLIFY_SERVER_UUID="<server-uuid>"
+
+# Required for cloud token and Hetzner-related acceptance tests
+export COOLIFY_HETZNER_TOKEN="<real-hetzner-api-token>"
 ```
 
 #### Server validation for application tests
@@ -107,6 +110,12 @@ not persisted` when the provider cannot read the app back. See the
 for the full SSH and server setup procedure.
 
 ### Running acceptance tests
+
+Cloud token and Hetzner-related acceptance tests require a real
+`COOLIFY_HETZNER_TOKEN`. Those tests call Coolify endpoints that validate the
+provided token against Hetzner, so placeholder values will be rejected. The
+main affected packages today are `internal/service/cloudtoken` and
+`internal/service/hetzner`.
 
 **Important**: Running all tests in parallel can overwhelm the Coolify API
 and cause false timeout failures. Use `-p 1` to run packages sequentially:

--- a/docs/data-sources/s3_storage.md
+++ b/docs/data-sources/s3_storage.md
@@ -16,8 +16,9 @@ Retrieves information about a Coolify S3 storage destination.
 ## Example Usage
 
 ```terraform
-# Note: Current Coolify (v4) may not expose a public API for S3 storage.
-# This data source targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this data source.
+# Prefer referencing UI-managed storage UUIDs unless you have confirmed the
+# top-level storage read endpoints exist in your target version.
 
 data "coolify_s3_storage" "example" {
   uuid = "550e8400-e29b-41d4-a716-446655440007"

--- a/docs/data-sources/s3_storages.md
+++ b/docs/data-sources/s3_storages.md
@@ -16,8 +16,9 @@ Retrieves a list of all Coolify S3 storage destinations.
 ## Example Usage
 
 ```terraform
-# Note: Current Coolify (v4) may not expose a public API for S3 storage.
-# This data source targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this data source.
+# Prefer referencing UI-managed storage UUIDs unless you have confirmed the
+# top-level storage list endpoint exists in your target version.
 
 data "coolify_s3_storages" "all" {}
 

--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -32,7 +32,7 @@ The Terraform provider maps each level to a resource or data source.
 | `coolify_environment` | Environment within a project (production, staging) |
 | `coolify_server` | A Docker host registered with Coolify |
 | `coolify_private_key` | SSH key for server access or Git clone |
-| `coolify_s3_storage` | S3-compatible destination for backup storage |
+| `coolify_s3_storage` | Top-level S3-compatible backup destination, but current Coolify v4 may only support UI-managed storages rather than a public CRUD API |
 | `coolify_cloud_token` | Hetzner/cloud provider API token |
 | `coolify_github_app` | GitHub App integration for repository access |
 

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -30,6 +30,14 @@ terraform import coolify_postgresql_database.db <db-uuid>
 terraform import coolify_service.plausible <service-uuid>
 terraform import coolify_s3_storage.backups <storage-uuid>
 terraform import coolify_private_key.deploy <key-uuid>
+```
+
+~> **Note:** `coolify_s3_storage` targets a top-level public API surface that
+current Coolify v4 may not expose. If that import fails, manage the storage in
+the Coolify web UI and reference its UUID from `coolify_database_backup`
+instead.
+
+```bash
 terraform import coolify_cloud_token.hetzner <token-uuid>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ provider "coolify" {
 
 | Category | Resources |
 |----------|-----------|
-| Infrastructure | `coolify_project`, `coolify_environment`, `coolify_server`, `coolify_private_key`, `coolify_s3_storage`, `coolify_cloud_token`, `coolify_github_app` |
+| Infrastructure | `coolify_project`, `coolify_environment`, `coolify_server`, `coolify_private_key`, `coolify_s3_storage` (legacy/public API may be unavailable on current Coolify v4), `coolify_cloud_token`, `coolify_github_app` |
 | Applications | `coolify_application`, `coolify_dockerfile_application`, `coolify_docker_image_application`, `coolify_private_git_application`, `coolify_github_app_application` |
 | Databases | `coolify_postgresql_database`, `coolify_mysql_database`, `coolify_mariadb_database`, `coolify_redis_database`, `coolify_mongodb_database`, `coolify_clickhouse_database`, `coolify_keydb_database`, `coolify_dragonfly_database` |
 | Services | `coolify_service` |

--- a/docs/resources/database_backup.md
+++ b/docs/resources/database_backup.md
@@ -13,23 +13,11 @@ Manages a scheduled database backup configuration on Coolify.
 ## Example Usage
 
 ```terraform
-variable "s3_access_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "s3_secret_key" {
-  type      = string
-  sensitive = true
-}
-
-resource "coolify_s3_storage" "backups" {
-  name       = "backup-storage"
-  endpoint   = "https://s3.amazonaws.com"
-  bucket     = "coolify-backups"
-  region     = "us-east-1"
-  access_key = var.s3_access_key
-  secret_key = var.s3_secret_key
+# Warning: on current Coolify v4, create the S3 storage in the web UI first
+# and pass its UUID here. The top-level `coolify_s3_storage` API surface may
+# not be available.
+variable "existing_s3_storage_uuid" {
+  type = string
 }
 
 resource "coolify_database_backup" "daily" {
@@ -38,7 +26,7 @@ resource "coolify_database_backup" "daily" {
   enabled               = true
   save_s3               = true
   retain_amount_locally = 7 # Number of backup copies to keep (not days)
-  s3_storage_uuid       = coolify_s3_storage.backups.uuid
+  s3_storage_uuid       = var.existing_s3_storage_uuid
 }
 ```
 

--- a/docs/resources/s3_storage.md
+++ b/docs/resources/s3_storage.md
@@ -16,9 +16,9 @@ Manages a Coolify S3 storage destination.
 ## Example Usage
 
 ```terraform
-# Note: Current Coolify (v4) does not expose a public API for S3 storage CRUD.
-# S3 storages are managed through the Coolify web UI.
-# This resource targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this resource.
+# Prefer creating S3 storage in the Coolify web UI unless you have confirmed
+# your target version still exposes the top-level storage CRUD endpoints.
 
 variable "s3_access_key" {
   type      = string

--- a/examples/03-database-with-backup.tf
+++ b/examples/03-database-with-backup.tf
@@ -1,11 +1,12 @@
 # 03 - Database with Backup: provision a database and schedule backups
 #
-# Creates a PostgreSQL database, an S3 storage destination, and a
-# scheduled backup that runs daily at 2 AM UTC.
+# Creates a PostgreSQL database and a scheduled backup that targets an
+# existing UI-managed S3 storage, then runs daily at 2 AM UTC.
 #
 # Prerequisites:
 #   - Coolify with a registered server
-#   - S3-compatible storage (AWS S3, MinIO, Backblaze B2, etc.)
+#   - An existing S3-compatible storage configured in the Coolify web UI
+#     (AWS S3, MinIO, Backblaze B2, etc.)
 #
 # Run:
 #   terraform init
@@ -26,14 +27,8 @@ variable "server_uuid" {
   type = string
 }
 
-variable "s3_access_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "s3_secret_key" {
-  type      = string
-  sensitive = true
+variable "existing_s3_storage_uuid" {
+  type = string
 }
 
 resource "coolify_project" "data" {
@@ -47,18 +42,9 @@ resource "coolify_postgresql_database" "main" {
   image        = "postgres:16"
 }
 
-resource "coolify_s3_storage" "backups" {
-  name       = "db-backups"
-  access_key = var.s3_access_key
-  secret_key = var.s3_secret_key
-  bucket     = "coolify-backups"
-  endpoint   = "https://s3.amazonaws.com"
-  region     = "us-east-1"
-}
-
 resource "coolify_database_backup" "daily" {
   database_uuid         = coolify_postgresql_database.main.uuid
-  s3_storage_uuid       = coolify_s3_storage.backups.uuid
+  s3_storage_uuid       = var.existing_s3_storage_uuid
   frequency             = "0 2 * * *"
   retain_amount_locally = 7 # Number of backup copies to keep (not days)
   enabled               = true

--- a/examples/data-sources/coolify_s3_storage/data-source.tf
+++ b/examples/data-sources/coolify_s3_storage/data-source.tf
@@ -1,5 +1,6 @@
-# Note: Current Coolify (v4) may not expose a public API for S3 storage.
-# This data source targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this data source.
+# Prefer referencing UI-managed storage UUIDs unless you have confirmed the
+# top-level storage read endpoints exist in your target version.
 
 data "coolify_s3_storage" "example" {
   uuid = "550e8400-e29b-41d4-a716-446655440007"

--- a/examples/data-sources/coolify_s3_storages/data-source.tf
+++ b/examples/data-sources/coolify_s3_storages/data-source.tf
@@ -1,5 +1,6 @@
-# Note: Current Coolify (v4) may not expose a public API for S3 storage.
-# This data source targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this data source.
+# Prefer referencing UI-managed storage UUIDs unless you have confirmed the
+# top-level storage list endpoint exists in your target version.
 
 data "coolify_s3_storages" "all" {}
 

--- a/examples/resources/coolify_database_backup/resource.tf
+++ b/examples/resources/coolify_database_backup/resource.tf
@@ -1,20 +1,8 @@
-variable "s3_access_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "s3_secret_key" {
-  type      = string
-  sensitive = true
-}
-
-resource "coolify_s3_storage" "backups" {
-  name       = "backup-storage"
-  endpoint   = "https://s3.amazonaws.com"
-  bucket     = "coolify-backups"
-  region     = "us-east-1"
-  access_key = var.s3_access_key
-  secret_key = var.s3_secret_key
+# Warning: on current Coolify v4, create the S3 storage in the web UI first
+# and pass its UUID here. The top-level `coolify_s3_storage` API surface may
+# not be available.
+variable "existing_s3_storage_uuid" {
+  type = string
 }
 
 resource "coolify_database_backup" "daily" {
@@ -23,5 +11,5 @@ resource "coolify_database_backup" "daily" {
   enabled               = true
   save_s3               = true
   retain_amount_locally = 7 # Number of backup copies to keep (not days)
-  s3_storage_uuid       = coolify_s3_storage.backups.uuid
+  s3_storage_uuid       = var.existing_s3_storage_uuid
 }

--- a/examples/resources/coolify_s3_storage/resource.tf
+++ b/examples/resources/coolify_s3_storage/resource.tf
@@ -1,6 +1,6 @@
-# Note: Current Coolify (v4) does not expose a public API for S3 storage CRUD.
-# S3 storages are managed through the Coolify web UI.
-# This resource targets an API surface that may not be available in your Coolify version.
+# Warning: Current Coolify (v4) may not expose the public API used by this resource.
+# Prefer creating S3 storage in the Coolify web UI unless you have confirmed
+# your target version still exposes the top-level storage CRUD endpoints.
 
 variable "s3_access_key" {
   type      = string

--- a/examples/scenarios/acme-backups/README.md
+++ b/examples/scenarios/acme-backups/README.md
@@ -38,29 +38,23 @@ Each execution has:
 
 ### Adding S3 off-site storage
 
-To store backups in S3 (in addition to local), add an S3 storage
-resource and enable `save_s3`:
+To store backups in S3 (in addition to local), first create the S3 storage in
+the Coolify web UI, then enable `save_s3` and point the backup at that UUID:
 
 ```hcl
-resource "coolify_s3_storage" "backups" {
-  name       = "backup-storage"
-  endpoint   = "https://s3.amazonaws.com"
-  bucket     = "acme-backups"
-  region     = "us-east-1"
-  access_key = var.s3_access_key
-  secret_key = var.s3_secret_key
-}
-
 resource "coolify_database_backup" "daily" {
   database_uuid         = coolify_postgresql_database.app_db.uuid
   frequency             = "0 2 * * *"
   enabled               = true
   save_s3               = true
-  s3_storage_uuid       = coolify_s3_storage.backups.uuid
+  s3_storage_uuid       = "existing-ui-managed-s3-storage-uuid"
   retain_amount_locally = 7
   retain_amount_s3      = 30
 }
 ```
+
+Current Coolify v4 may not expose the public top-level `coolify_s3_storage`
+API surface.
 
 ## Running
 

--- a/examples/scenarios/acme-website/README.md
+++ b/examples/scenarios/acme-website/README.md
@@ -10,8 +10,8 @@ daily backups shipped to S3-compatible storage so the marketing data is never
 at risk.
 
 This scenario provisions the entire stack (project, database, application,
-environment wiring, and optional backup infrastructure) in a single
-`terraform apply`.
+environment wiring, and an optional backup schedule that targets an existing
+UI-managed S3 storage) in a single `terraform apply`.
 
 ## What Gets Created
 
@@ -22,8 +22,7 @@ environment wiring, and optional backup infrastructure) in a single
 | 3 | `coolify_application.website` | Node.js marketing site from Git |
 | 4 | `coolify_environment_variable.database_url` | Connects the app to the database |
 | 5 | `coolify_environment_variable.node_env` | Sets NODE_ENV=production for builds |
-| 6 | `coolify_s3_storage.backups` | S3 destination for backups *(optional)* |
-| 7 | `coolify_database_backup.daily` | Daily backup schedule *(optional)* |
+| 6 | `coolify_database_backup.daily` | Daily backup schedule using an existing UI-managed S3 storage *(optional)* |
 
 ## Architecture
 
@@ -51,7 +50,7 @@ environment wiring, and optional backup infrastructure) in a single
 └─────────────────────────────────────────────────────┘
 
            ┌──────────────────────────────────┐
-           │       S3-Compatible Storage       │
+           │ Existing UI-Managed S3 Storage    │
            │       "acme-backups"              │
            │                                   │
            │  ◄── Daily Backup ── PostgreSQL   │
@@ -66,9 +65,11 @@ environment wiring, and optional backup infrastructure) in a single
 2. **API token**: generate one in Coolify under *Security > API Tokens*.
 3. **Server UUID**: the UUID of the destination server registered in Coolify.
    Find it under *Servers* in the Coolify dashboard.
-4. *(Optional)* **S3-compatible storage credentials**: only needed if you
-   enable backups (`enable_backups = true`). Works with AWS S3, MinIO,
-   Backblaze B2, Cloudflare R2, etc.
+4. *(Optional)* **Existing S3 storage UUID**: only needed if you enable
+   backups (`enable_backups = true`). Create the storage in the Coolify web UI
+   first, then pass its UUID with `existing_s3_storage_uuid`. The storage can
+   target AWS S3, MinIO, Backblaze B2, Cloudflare R2, or another compatible
+   backend.
 
 ## Usage
 
@@ -96,7 +97,7 @@ terraform apply \
   -var="server_uuid=your-server-uuid"
 ```
 
-To enable daily backups to S3:
+To enable daily backups to S3, first create the storage in the Coolify web UI, then pass its UUID here:
 
 ```bash
 terraform apply \
@@ -104,11 +105,7 @@ terraform apply \
   -var="coolify_token=your-api-token" \
   -var="server_uuid=your-server-uuid" \
   -var="enable_backups=true" \
-  -var="s3_endpoint=https://s3.amazonaws.com" \
-  -var="s3_bucket=acme-backups" \
-  -var="s3_region=us-east-1" \
-  -var="s3_access_key=AKIA..." \
-  -var="s3_secret_key=wJalr..."
+  -var="existing_s3_storage_uuid=your-s3-storage-uuid"
 ```
 
 ## How It Works

--- a/examples/scenarios/acme-website/main.tf
+++ b/examples/scenarios/acme-website/main.tf
@@ -1,7 +1,8 @@
 # ACME Corp Marketing Website
 #
 # Deploys a Node.js marketing site backed by PostgreSQL on Coolify.
-# Optionally configures daily database backups to S3-compatible storage.
+# Optionally configures daily database backups using an existing UI-managed
+# S3-compatible storage.
 
 terraform {
   required_providers {
@@ -78,24 +79,13 @@ data "coolify_application" "verify" {
 }
 
 # --- Backups (optional) ---
-# Set enable_backups = true and provide S3 credentials to activate.
-
-resource "coolify_s3_storage" "backups" {
-  count = var.enable_backups ? 1 : 0
-
-  name       = "acme-backups"
-  endpoint   = var.s3_endpoint
-  bucket     = var.s3_bucket
-  region     = var.s3_region
-  access_key = var.s3_access_key
-  secret_key = var.s3_secret_key
-}
+# Set enable_backups = true and provide an existing UI-managed S3 storage UUID.
 
 resource "coolify_database_backup" "daily" {
   count = var.enable_backups ? 1 : 0
 
   database_uuid   = coolify_postgresql_database.content.uuid
-  s3_storage_uuid = coolify_s3_storage.backups[0].uuid
+  s3_storage_uuid = var.existing_s3_storage_uuid
   frequency       = "@daily"
   enabled         = true
 }

--- a/examples/scenarios/acme-website/variables.tf
+++ b/examples/scenarios/acme-website/variables.tf
@@ -19,39 +19,13 @@ variable "server_uuid" {
 # --- Backups ---
 
 variable "enable_backups" {
-  description = "Enable daily database backups to S3-compatible storage"
+  description = "Enable daily database backups using an existing UI-managed S3 storage"
   type        = bool
   default     = false
 }
 
-variable "s3_endpoint" {
-  description = "S3-compatible storage endpoint (e.g. https://s3.amazonaws.com)"
+variable "existing_s3_storage_uuid" {
+  description = "UUID of an existing S3 storage already configured in the Coolify web UI"
   type        = string
   default     = ""
-}
-
-variable "s3_bucket" {
-  description = "S3 bucket name for database backups"
-  type        = string
-  default     = ""
-}
-
-variable "s3_region" {
-  description = "S3 bucket region (e.g. us-east-1)"
-  type        = string
-  default     = ""
-}
-
-variable "s3_access_key" {
-  description = "S3 access key"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "s3_secret_key" {
-  description = "S3 secret key"
-  type        = string
-  default     = ""
-  sensitive   = true
 }

--- a/templates/guides/concepts.md.tmpl
+++ b/templates/guides/concepts.md.tmpl
@@ -32,7 +32,7 @@ The Terraform provider maps each level to a resource or data source.
 | `coolify_environment` | Environment within a project (production, staging) |
 | `coolify_server` | A Docker host registered with Coolify |
 | `coolify_private_key` | SSH key for server access or Git clone |
-| `coolify_s3_storage` | S3-compatible destination for backup storage |
+| `coolify_s3_storage` | Top-level S3-compatible backup destination, but current Coolify v4 may only support UI-managed storages rather than a public CRUD API |
 | `coolify_cloud_token` | Hetzner/cloud provider API token |
 | `coolify_github_app` | GitHub App integration for repository access |
 

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -30,6 +30,14 @@ terraform import coolify_postgresql_database.db <db-uuid>
 terraform import coolify_service.plausible <service-uuid>
 terraform import coolify_s3_storage.backups <storage-uuid>
 terraform import coolify_private_key.deploy <key-uuid>
+```
+
+~> **Note:** `coolify_s3_storage` targets a top-level public API surface that
+current Coolify v4 may not expose. If that import fails, manage the storage in
+the Coolify web UI and reference its UUID from `coolify_database_backup`
+instead.
+
+```bash
 terraform import coolify_cloud_token.hetzner <token-uuid>
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -49,7 +49,7 @@ export COOLIFY_TOKEN="your-api-token"
 
 | Category | Resources |
 |----------|-----------|
-| Infrastructure | `coolify_project`, `coolify_environment`, `coolify_server`, `coolify_private_key`, `coolify_s3_storage`, `coolify_cloud_token`, `coolify_github_app` |
+| Infrastructure | `coolify_project`, `coolify_environment`, `coolify_server`, `coolify_private_key`, `coolify_s3_storage` (legacy/public API may be unavailable on current Coolify v4), `coolify_cloud_token`, `coolify_github_app` |
 | Applications | `coolify_application`, `coolify_dockerfile_application`, `coolify_docker_image_application`, `coolify_private_git_application`, `coolify_github_app_application` |
 | Databases | `coolify_postgresql_database`, `coolify_mysql_database`, `coolify_mariadb_database`, `coolify_redis_database`, `coolify_mongodb_database`, `coolify_clickhouse_database`, `coolify_keydb_database`, `coolify_dragonfly_database` |
 | Services | `coolify_service` |


### PR DESCRIPTION
## Summary
- de-emphasize the stale top-level S3 storage surface in README, guides, and examples
- update backup examples to reference existing UI-managed S3 storage UUIDs instead of creating top-level S3 storage resources
- document `COOLIFY_HETZNER_TOKEN` for cloud token and Hetzner-related acceptance tests

## Verification
- `PATH="/home/sebtardif/go/bin:$PATH" make docs`
- `make validate`

## Related
- Closes #190
- Refs #178
