### PR TITLE
githubapp: align acceptance flow with real Coolify behavior

### DIFF
--- a/docs/resources/github_app.md
+++ b/docs/resources/github_app.md
@@ -24,6 +24,7 @@ resource "coolify_github_app" "example" {
   installation_id  = 67890
   client_id        = "Iv1.abc123def456"
   client_secret    = var.github_app_client_secret
+  webhook_secret   = "replace-me-with-a-random-secret"
   private_key_uuid = coolify_private_key.github.uuid
 }
 ```

--- a/examples/resources/coolify_github_app/resource.tf
+++ b/examples/resources/coolify_github_app/resource.tf
@@ -9,5 +9,6 @@ resource "coolify_github_app" "example" {
   installation_id  = 67890
   client_id        = "Iv1.abc123def456"
   client_secret    = var.github_app_client_secret
+  webhook_secret   = "replace-me-with-a-random-secret"
   private_key_uuid = coolify_private_key.github.uuid
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3506,6 +3506,8 @@ func TestClient_CreateGitHubApp(t *testing.T) {
 		require.NoError(t, json.Unmarshal(body, &input))
 		assert.Equal(t, "My GitHub App", input.Name)
 		assert.Equal(t, "my-org", input.OrganizationName)
+		assert.Equal(t, "https://api.github.com", input.APIURL)
+		assert.Equal(t, "https://github.com", input.HTMLURL)
 		assert.Equal(t, int64(12345), input.AppID)
 		assert.Equal(t, int64(67890), input.InstallationID)
 		assert.Equal(t, "Iv1.abc123", input.ClientID)
@@ -3523,6 +3525,8 @@ func TestClient_CreateGitHubApp(t *testing.T) {
 	app, err := c.CreateGitHubApp(context.Background(), CreateGitHubAppIntegrationInput{
 		Name:             "My GitHub App",
 		OrganizationName: "my-org",
+		APIURL:           "https://api.github.com",
+		HTMLURL:          "https://github.com",
 		AppID:            12345,
 		InstallationID:   67890,
 		ClientID:         "Iv1.abc123",
@@ -3572,7 +3576,7 @@ func TestClient_UpdateGitHubApp(t *testing.T) {
 		assert.Nil(t, input.ClientSecret)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(GitHubApp{ID: 42, UUID: "gh-upd", Name: "Updated App", OrganizationName: "new-org"})
+		json.NewEncoder(w).Encode(map[string]any{"message": "GitHub app updated successfully", "data": GitHubApp{ID: 42, UUID: "gh-upd", Name: "Updated App", OrganizationName: "new-org"}})
 	}))
 	defer srv.Close()
 
@@ -3607,7 +3611,7 @@ func TestClient_UpdateGitHubApp_PartialUpdate(t *testing.T) {
 		assert.False(t, hasClientSecret, "expected 'client_secret' to be omitted when nil")
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(GitHubApp{ID: 10, Name: "partial"})
+		json.NewEncoder(w).Encode(map[string]any{"message": "GitHub app updated successfully", "data": GitHubApp{ID: 10, Name: "partial"}})
 	}))
 	defer srv.Close()
 
@@ -3651,10 +3655,10 @@ func TestClient_ListGitHubAppRepositories(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/github-apps/42/repositories", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]GitHubRepository{
+		json.NewEncoder(w).Encode(map[string]any{"repositories": []GitHubRepository{
 			{Name: "repo-one", FullName: "org/repo-one", Private: false},
 			{Name: "repo-two", FullName: "org/repo-two", Private: true},
-		})
+		}})
 	}))
 	defer srv.Close()
 
@@ -3676,11 +3680,11 @@ func TestClient_ListGitHubAppBranches(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/v1/github-apps/42/repositories/my-org/my-repo/branches", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]GitHubBranch{
+		json.NewEncoder(w).Encode(map[string]any{"branches": []GitHubBranch{
 			{Name: "main"},
 			{Name: "develop"},
 			{Name: "feature/new-thing"},
-		})
+		}})
 	}))
 	defer srv.Close()
 
@@ -3700,7 +3704,7 @@ func TestClient_ListGitHubAppBranches_URLEscape(t *testing.T) {
 		// owner "my org" and repo "my repo" should be URL-escaped
 		assert.Equal(t, "/api/v1/github-apps/10/repositories/my%20org/my%20repo/branches", r.URL.EscapedPath())
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]GitHubBranch{{Name: "main"}})
+		json.NewEncoder(w).Encode(map[string]any{"branches": []GitHubBranch{{Name: "main"}}})
 	}))
 	defer srv.Close()
 

--- a/internal/client/github_apps.go
+++ b/internal/client/github_apps.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,6 +22,8 @@ type GitHubApp struct {
 type CreateGitHubAppIntegrationInput struct {
 	Name             string `json:"name"`
 	OrganizationName string `json:"organization,omitempty"`
+	APIURL           string `json:"api_url"`
+	HTMLURL          string `json:"html_url"`
 	AppID            int64  `json:"app_id"`
 	InstallationID   int64  `json:"installation_id"`
 	ClientID         string `json:"client_id"`
@@ -48,6 +51,19 @@ type GitHubRepository struct {
 
 type GitHubBranch struct {
 	Name string `json:"name"`
+}
+
+type gitHubAppEnvelope struct {
+	Message string     `json:"message,omitempty"`
+	Data    *GitHubApp `json:"data,omitempty"`
+}
+
+type gitHubRepositoriesEnvelope struct {
+	Repositories []GitHubRepository `json:"repositories"`
+}
+
+type gitHubBranchesEnvelope struct {
+	Branches []GitHubBranch `json:"branches"`
 }
 
 func (c *Client) ListGitHubApps(ctx context.Context) ([]GitHubApp, error) {
@@ -80,11 +96,15 @@ func (c *Client) CreateGitHubApp(ctx context.Context, input CreateGitHubAppInteg
 }
 
 func (c *Client) UpdateGitHubApp(ctx context.Context, id int64, input UpdateGitHubAppIntegrationInput) (*GitHubApp, error) {
-	var r GitHubApp
-	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/github-apps/%d", id), input, &r); err != nil {
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/github-apps/%d", id), input, &raw); err != nil {
 		return nil, fmt.Errorf("updating github app %d: %w", id, err)
 	}
-	return &r, nil
+	app, err := decodeGitHubApp(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decoding github app %d update response: %w", id, err)
+	}
+	return app, nil
 }
 
 func (c *Client) DeleteGitHubApp(ctx context.Context, id int64) error {
@@ -95,17 +115,64 @@ func (c *Client) DeleteGitHubApp(ctx context.Context, id int64) error {
 }
 
 func (c *Client) ListGitHubAppRepositories(ctx context.Context, id int64) ([]GitHubRepository, error) {
-	var r []GitHubRepository
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/github-apps/%d/repositories", id), nil, &r); err != nil {
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/github-apps/%d/repositories", id), nil, &raw); err != nil {
 		return nil, fmt.Errorf("listing github app %d repositories: %w", id, err)
 	}
-	return r, nil
+	repos, err := decodeGitHubRepositories(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decoding github app %d repositories response: %w", id, err)
+	}
+	return repos, nil
 }
 
 func (c *Client) ListGitHubAppBranches(ctx context.Context, id int64, owner, repo string) ([]GitHubBranch, error) {
-	var r []GitHubBranch
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/github-apps/%d/repositories/%s/%s/branches", id, url.PathEscape(owner), url.PathEscape(repo)), nil, &r); err != nil {
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/github-apps/%d/repositories/%s/%s/branches", id, url.PathEscape(owner), url.PathEscape(repo)), nil, &raw); err != nil {
 		return nil, fmt.Errorf("listing github app %d branches for %s/%s: %w", id, owner, repo, err)
 	}
-	return r, nil
+	branches, err := decodeGitHubBranches(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decoding github app %d branches response for %s/%s: %w", id, owner, repo, err)
+	}
+	return branches, nil
+}
+
+func decodeGitHubApp(raw json.RawMessage) (*GitHubApp, error) {
+	var wrapped gitHubAppEnvelope
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Data != nil {
+		return wrapped.Data, nil
+	}
+
+	var app GitHubApp
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
+func decodeGitHubRepositories(raw json.RawMessage) ([]GitHubRepository, error) {
+	var repos []GitHubRepository
+	if err := json.Unmarshal(raw, &repos); err == nil {
+		return repos, nil
+	}
+
+	var wrapped gitHubRepositoriesEnvelope
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped.Repositories, nil
+}
+
+func decodeGitHubBranches(raw json.RawMessage) ([]GitHubBranch, error) {
+	var branches []GitHubBranch
+	if err := json.Unmarshal(raw, &branches); err == nil {
+		return branches, nil
+	}
+
+	var wrapped gitHubBranchesEnvelope
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped.Branches, nil
 }

--- a/internal/service/githubapp/data_source_acc_test.go
+++ b/internal/service/githubapp/data_source_acc_test.go
@@ -1,7 +1,6 @@
 package githubapp_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -14,12 +13,14 @@ func TestAccGitHubAppRepositoriesDataSource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
 	name := acctest.RandomWithPrefix("tf-acc-ghapp-repos")
+	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-repos-key")
+	privateKey := acctest.GenerateTestRSAKey(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccGitHubAppReposConfig(name),
+				Config:      testAccGitHubAppReposConfig(name, privateKeyName, privateKey),
 				ExpectError: regexp.MustCompile(`.+`),
 			},
 		},
@@ -31,50 +32,34 @@ func TestAccGitHubAppBranchesDataSource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
 	name := acctest.RandomWithPrefix("tf-acc-ghapp-br")
+	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-br-key")
+	privateKey := acctest.GenerateTestRSAKey(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccGitHubAppBranchesConfig(name),
+				Config:      testAccGitHubAppBranchesConfig(name, privateKeyName, privateKey),
 				ExpectError: regexp.MustCompile(`.+`),
 			},
 		},
 	})
 }
 
-func testAccGitHubAppReposConfig(name string) string {
-	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
-resource "coolify_github_app" "test" {
-  name            = %[1]q
-  app_id          = 12345
-  installation_id = 67890
-  client_id       = "Iv1.dummy"
-  client_secret   = "dummysecret"
-  private_key_uuid = "pk-uuid-dummy"
-}
-
+func testAccGitHubAppReposConfig(name, privateKeyName, privateKey string) string {
+	return testAccGitHubAppConfig(name, privateKeyName, privateKey) + `
 data "coolify_github_app_repositories" "test" {
   github_app_id = coolify_github_app.test.id
 }
-`, name)
+`
 }
 
-func testAccGitHubAppBranchesConfig(name string) string {
-	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
-resource "coolify_github_app" "test" {
-  name            = %[1]q
-  app_id          = 12345
-  installation_id = 67890
-  client_id       = "Iv1.dummy"
-  client_secret   = "dummysecret"
-  private_key_uuid = "pk-uuid-dummy"
-}
-
+func testAccGitHubAppBranchesConfig(name, privateKeyName, privateKey string) string {
+	return testAccGitHubAppConfig(name, privateKeyName, privateKey) + `
 data "coolify_github_app_branches" "test" {
   github_app_id = coolify_github_app.test.id
   owner         = "coollabsio"
   repo          = "coolify"
 }
-`, name)
+`
 }

--- a/internal/service/githubapp/resource.go
+++ b/internal/service/githubapp/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/client"
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/flex"
@@ -137,6 +138,8 @@ func (r *gitHubAppResource) Create(ctx context.Context, req resource.CreateReque
 
 	input := client.CreateGitHubAppIntegrationInput{
 		Name:           plan.Name.ValueString(),
+		APIURL:         "https://api.github.com",
+		HTMLURL:        "https://github.com",
 		AppID:          plan.AppID.ValueInt64(),
 		InstallationID: plan.InstallationID.ValueInt64(),
 		ClientID:       plan.ClientID.ValueString(),
@@ -144,7 +147,11 @@ func (r *gitHubAppResource) Create(ctx context.Context, req resource.CreateReque
 		PrivateKeyUUID: plan.PrivateKeyUUID.ValueString(),
 	}
 	flex.SetIfKnown(&input.OrganizationName, plan.OrganizationName)
-	flex.SetIfKnown(&input.WebhookSecret, plan.WebhookSecret)
+	if plan.WebhookSecret.IsNull() || plan.WebhookSecret.IsUnknown() {
+		input.WebhookSecret = defaultWebhookSecret(plan.Name.ValueString())
+	} else {
+		flex.SetIfKnown(&input.WebhookSecret, plan.WebhookSecret)
+	}
 
 	app, err := r.client.CreateGitHubApp(ctx, input)
 	if err != nil {
@@ -242,6 +249,9 @@ func (r *gitHubAppResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	flattenGitHubApp(app, &plan)
+	if plan.WebhookSecret.IsNull() || plan.WebhookSecret.IsUnknown() {
+		plan.WebhookSecret = state.WebhookSecret
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -303,5 +313,15 @@ func flattenGitHubApp(app *client.GitHubApp, model *gitHubAppResourceModel) {
 	model.AppID = types.Int64Value(app.AppID)
 	model.InstallationID = types.Int64Value(app.InstallationID)
 	model.ClientID = types.StringValue(app.ClientID)
-	model.WebhookSecret = flex.StringToFramework(app.WebhookSecret)
+	if app.WebhookSecret != "" {
+		model.WebhookSecret = types.StringValue(app.WebhookSecret)
+	}
+}
+
+func defaultWebhookSecret(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "terraform-provider-coolify"
+	}
+	return trimmed + "-webhook"
 }

--- a/internal/service/githubapp/resource_acc_test.go
+++ b/internal/service/githubapp/resource_acc_test.go
@@ -2,7 +2,6 @@ package githubapp_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,10 +14,9 @@ func TestAccGitHubAppResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	if os.Getenv("COOLIFY_GITHUB_APP_UUID") == "" {
-		t.Skip("COOLIFY_GITHUB_APP_UUID not set, skipping (real GitHub App credentials required)")
-	}
 	name := acctest.RandomWithPrefix("tf-acc-ghapp")
+	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-key")
+	privateKey := acctest.GenerateTestRSAKey(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
@@ -26,7 +24,7 @@ func TestAccGitHubAppResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: testAccGitHubAppConfig(name),
+				Config: testAccGitHubAppConfig(name, privateKeyName, privateKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_github_app.test", "id"),
 					resource.TestCheckResourceAttr("coolify_github_app.test", "name", name),
@@ -37,7 +35,7 @@ func TestAccGitHubAppResource_CRUD(t *testing.T) {
 			},
 			// Step 2: Update name
 			{
-				Config: testAccGitHubAppConfig(name + "-updated"),
+				Config: testAccGitHubAppConfig(name+"-updated", privateKeyName, privateKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_github_app.test", "name", name+"-updated"),
 					resource.TestCheckResourceAttr("coolify_github_app.test", "app_id", "12345"),
@@ -49,7 +47,7 @@ func TestAccGitHubAppResource_CRUD(t *testing.T) {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "id",
-				ImportStateVerifyIgnore:              []string{"client_secret", "private_key_uuid"},
+				ImportStateVerifyIgnore:              []string{"client_secret", "webhook_secret", "private_key_uuid"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["coolify_github_app.test"]
 					if !ok {
@@ -66,17 +64,16 @@ func TestAccGitHubAppDataSources(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	if os.Getenv("COOLIFY_GITHUB_APP_UUID") == "" {
-		t.Skip("COOLIFY_GITHUB_APP_UUID not set, skipping (real GitHub App credentials required)")
-	}
 	name := acctest.RandomWithPrefix("tf-acc-ghapp-ds")
+	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-ds-key")
+	privateKey := acctest.GenerateTestRSAKey(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_github_app", "/api/v1/github-apps/"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGitHubAppConfig(name) + `
+				Config: testAccGitHubAppConfig(name, privateKeyName, privateKey) + `
 data "coolify_github_apps" "all" {
   depends_on = [coolify_github_app.test]
 }
@@ -90,15 +87,21 @@ data "coolify_github_apps" "all" {
 	})
 }
 
-func testAccGitHubAppConfig(name string) string {
+func testAccGitHubAppConfig(name, privateKeyName, privateKey string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
-resource "coolify_github_app" "test" {
-  name            = %[1]q
-  app_id          = 12345
-  installation_id = 67890
-  client_id       = "Iv1.fake123456789"
-  client_secret   = "fake-client-secret-value"
-  private_key_uuid = "pk-uuid-acctest"
+resource "coolify_private_key" "test" {
+  name        = %[2]q
+  description = "acc test github app key"
+  private_key = %[3]q
 }
-`, name)
+
+resource "coolify_github_app" "test" {
+  name             = %[1]q
+  app_id           = 12345
+  installation_id  = 67890
+  client_id        = "Iv1.fake123456789"
+  client_secret    = "fake-client-secret-value"
+  private_key_uuid = coolify_private_key.test.uuid
+}
+`, name, privateKeyName, privateKey)
 }

--- a/internal/service/githubapp/resource_test.go
+++ b/internal/service/githubapp/resource_test.go
@@ -147,6 +147,8 @@ func newMockCoolifyServer(forceReadFailure *atomic.Bool, auditT ...testing.TB) (
 		var body struct {
 			Name             string `json:"name"`
 			OrganizationName string `json:"organization"`
+			APIURL           string `json:"api_url"`
+			HTMLURL          string `json:"html_url"`
 			AppID            int64  `json:"app_id"`
 			InstallationID   int64  `json:"installation_id"`
 			ClientID         string `json:"client_id"`
@@ -200,7 +202,7 @@ func newMockCoolifyServer(forceReadFailure *atomic.Bool, auditT ...testing.TB) (
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(app)
+		json.NewEncoder(w).Encode(map[string]any{"message": "GitHub app updated successfully", "data": app})
 	})
 
 	mux.HandleFunc("DELETE /api/v1/github-apps/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -226,10 +228,10 @@ func newMockCoolifyServer(forceReadFailure *atomic.Bool, auditT ...testing.TB) (
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]client.GitHubRepository{
+		json.NewEncoder(w).Encode(map[string]any{"repositories": []client.GitHubRepository{
 			{Name: "repo-1", FullName: "testowner/repo-1", Private: false},
 			{Name: "repo-2", FullName: "testowner/repo-2", Private: true},
-		})
+		}})
 	})
 
 	mux.HandleFunc("GET /api/v1/github-apps/{id}/repositories/{owner}/{repo}/branches", func(w http.ResponseWriter, r *http.Request) {
@@ -241,10 +243,10 @@ func newMockCoolifyServer(forceReadFailure *atomic.Bool, auditT ...testing.TB) (
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]client.GitHubBranch{
+		json.NewEncoder(w).Encode(map[string]any{"branches": []client.GitHubBranch{
 			{Name: "main"},
 			{Name: "develop"},
-		})
+		}})
 	})
 
 	handler := acctest.WithVersionEndpoint(mux)


### PR DESCRIPTION
## Summary
- align the GitHub App resource with stock Coolify create and refresh behavior
- decode wrapped GitHub App update, repository, and branch API responses
- make the acceptance fixtures self-bootstrap with a real private key and stable test inputs
- update the GitHub App docs and example to match the real contract

## Verification
- `PATH="$(go env GOPATH)/bin:${PATH}" make ci`
- `TF_ACC=1 COOLIFY_ENDPOINT="http://localhost:8000" COOLIFY_TOKEN="***" go test -race -count=1 -timeout=20m ./internal/service/githubapp/ -run 'TestAccGitHubApp(Resource_CRUD|DataSources|RepositoriesDataSource|BranchesDataSource)$'`\n\nRelated #180