### PR TITLE
Align GitHub App application acceptance and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ export COOLIFY_ENDPOINT="http://localhost:8000"
 export COOLIFY_TOKEN="your-api-token"
 # Also required for cloud token and Hetzner-related acceptance tests.
 export COOLIFY_HETZNER_TOKEN="your-real-hetzner-api-token"
+# Optional extra COOLIFY_GITHUB_APP_* fixture variables for the
+# GitHub App application acceptance test are documented in TESTING.md.
 make testacc
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Cloud token and Hetzner-related acceptance tests need a real
 `COOLIFY_TOKEN` setup, because Coolify validates the token against Hetzner on
 create.
 
+GitHub App application acceptance additionally needs the optional
+`COOLIFY_GITHUB_APP_*` fixture variables documented in [TESTING.md](TESTING.md),
+because Coolify verifies repository access during application creation.
+
 For local provider testing with `dev_overrides`, acceptance test setup, and
 project structure details, see [CONTRIBUTING.md](CONTRIBUTING.md) and
 [TESTING.md](TESTING.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -99,6 +99,16 @@ export COOLIFY_SERVER_UUID="<server-uuid>"
 
 # Required for cloud token and Hetzner-related acceptance tests
 export COOLIFY_HETZNER_TOKEN="<real-hetzner-api-token>"
+
+# Optional: enable GitHub App application acceptance with a live fixture.
+export COOLIFY_GITHUB_APP_APP_ID="123456"
+export COOLIFY_GITHUB_APP_INSTALLATION_ID="7890123"
+export COOLIFY_GITHUB_APP_CLIENT_ID="Iv1.abc123def456"
+export COOLIFY_GITHUB_APP_CLIENT_SECRET="<github-app-client-secret>"
+export COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE="$HOME/.config/coolify/github-app.pem"
+export COOLIFY_GITHUB_APP_REPOSITORY="owner/repo"
+# Optional, defaults to main.
+export COOLIFY_GITHUB_APP_BRANCH="main"
 ```
 
 #### Server validation for application tests
@@ -116,6 +126,11 @@ Cloud token and Hetzner-related acceptance tests require a real
 provided token against Hetzner, so placeholder values will be rejected. The
 main affected packages today are `internal/service/cloudtoken` and
 `internal/service/hetzner`.
+
+GitHub App application acceptance requires live `COOLIFY_GITHUB_APP_*`
+fixture variables because Coolify verifies repository access during
+`POST /applications/private-github-app`. The main affected test today is
+`internal/service/application.TestAccGitHubAppApplicationResource_CRUD`.
 
 **Important**: Running all tests in parallel can overwhelm the Coolify API
 and cause false timeout failures. Use `-p 1` to run packages sequentially:
@@ -277,8 +292,8 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 | `coolify_mysql_database` | Yes | Yes | Yes | Yes | Second DB type for coverage |
 | `coolify_application` | Yes | Yes | Yes | Yes | Public git with coollabsio/coolify-examples |
 | `coolify_private_git_application` | Yes | Yes | Yes | Yes | SSH URL, dummy key |
-| `coolify_github_app_application` | N/A | | | | Tested via `coolify_application` variants |
-| `coolify_github_app` | Yes | Yes | N/A | Yes | Dummy credentials (metadata only) |
+| `coolify_github_app_application` | Yes | Yes | Yes | Yes | Requires live `COOLIFY_GITHUB_APP_*` fixture env vars with repository access |
+| `coolify_github_app` | Yes | Yes | N/A | Yes | Uses a Terraform-managed private key fixture; create/update work without repository access |
 | `coolify_server` | Yes | Yes | Yes | Yes | RFC 5737 IP (192.0.2.1), not reachable |
 | `coolify_clickhouse_database` | Yes | Yes | Yes | Yes | |
 | `coolify_mariadb_database` | Yes | Yes | Yes | Yes | |
@@ -329,8 +344,8 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 | `coolify_backup_executions` | Yes | May return empty list |
 | `coolify_github_app` | Yes | Singular lookup by numeric ID |
 | `coolify_github_apps` | Yes | Paired with github_app resource |
-| `coolify_github_app_repositories` | Yes | ExpectError with dummy credentials |
-| `coolify_github_app_branches` | Yes | ExpectError with dummy credentials |
+| `coolify_github_app_repositories` | Yes | ExpectError without live repository-access fixture credentials |
+| `coolify_github_app_branches` | Yes | ExpectError without live repository-access fixture credentials |
 | `coolify_hetzner_images` | Yes | Needs Hetzner token in Coolify |
 | `coolify_hetzner_locations` | Yes | Needs Hetzner token in Coolify |
 | `coolify_hetzner_server_types` | Yes | Needs Hetzner token in Coolify |
@@ -347,8 +362,8 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 | Category | Strategy |
 |----------|----------|
 | **Server registration** | Uses RFC 5737 documentation IP (192.0.2.1); server registers but is not reachable |
-| **GitHub App** | Uses dummy credentials (app_id=12345, fake secret/key); CRUD works, API calls to GitHub fail gracefully |
-| **GitHub App repos/branches** | Uses `ExpectError` since dummy credentials can't query GitHub |
+| **GitHub App** | Uses a Terraform-managed private key fixture plus placeholder OAuth fields; create and update work without repository access |
+| **GitHub App repos/branches** | Uses `ExpectError` because the acceptance fixture does not include a live GitHub App installation token |
 | **Private Git application** | Uses SSH URL with dummy key; registers metadata without cloning |
 | **Hetzner data sources** | Zero-input parameterless calls; pass when Hetzner is configured in Coolify |
 | **Runtime data** | application_logs, backup_executions, task_executions may return empty lists; test verifies the list attribute exists |

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -86,6 +86,7 @@ must be set in your `.tf` configuration before running `terraform plan`:
 |---|---|
 | All databases | `project_uuid`, `server_uuid`, `environment_name` |
 | All applications | `project_uuid`, `server_uuid`, `environment_name` |
+| `coolify_github_app_application` | `github_app_uuid` (Coolify stores the linked GitHub App as `source_id`/`source_type`, so import cannot recover the original UUID) |
 | `coolify_service` | `project_uuid`, `server_uuid`, `environment_name`, `type` |
 | `coolify_environment` | `description` (stored in Terraform state only; not returned by the API) |
 | `coolify_github_app` | `client_secret`, `private_key_uuid` (write-only, never returned by the API) |
@@ -96,6 +97,10 @@ must be set in your `.tf` configuration before running `terraform plan`:
 If these fields are missing, `terraform plan` will either show a diff
 or propose replacing the resource. Set them in your config to match
 your actual Coolify setup.
+
+For `coolify_github_app_application`, import also cannot reconstruct
+`github_app_uuid` from the API. Keep that field in your configuration
+before the first `terraform plan`, or expect a post-import diff.
 
 Additionally, Coolify normalizes some input values:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ automatically, but they are worth knowing:
 | **Base64 encoding required** | `coolify_dockerfile_application` | `dockerfile_location` must be base64-encoded despite the field name; use `base64encode()` |
 | **Server must be reachable** | All applications | Terraform fails with `Application created but not persisted` if Coolify cannot read the app back after creation |
 | **Cloud token validation** | `coolify_cloud_token` | Coolify validates the token against the cloud provider's API on creation (cannot use placeholder values) |
+| **GitHub App repository validation** | `coolify_github_app_application` | Coolify verifies repository access during create, so end-to-end tests need a live GitHub App installation with repository access |
 | **Async deletion** | `coolify_project` | Child resources are deleted asynchronously; project delete retries automatically |
 
 The provider preserves your configured values for all normalized fields.

--- a/docs/resources/github_app.md
+++ b/docs/resources/github_app.md
@@ -18,6 +18,8 @@ variable "github_app_client_secret" {
   sensitive = true
 }
 
+# Requires a coolify_private_key resource created from the GitHub App
+# private key PEM before creating the integration.
 resource "coolify_github_app" "example" {
   name             = "my-github-app"
   app_id           = 12345

--- a/docs/resources/github_app_application.md
+++ b/docs/resources/github_app_application.md
@@ -3,22 +3,24 @@
 page_title: "coolify_github_app_application Resource - coolify"
 subcategory: ""
 description: |-
-  Manages a Coolify application deployed via a GitHub App integration.
+  Manages a Coolify application deployed via a GitHub App integration. Coolify verifies repository access during create, so the referenced GitHub App must have installation access to the target repository.
 ---
 
 # coolify_github_app_application (Resource)
 
-Manages a Coolify application deployed via a GitHub App integration.
+Manages a Coolify application deployed via a GitHub App integration. Coolify verifies repository access during create, so the referenced GitHub App must have installation access to the target repository.
 
 ## Example Usage
 
 ```terraform
+# Requires an existing coolify_github_app backed by a live GitHub App
+# installation that can access the target repository.
 resource "coolify_github_app_application" "app" {
   name            = "my-github-app"
   project_uuid    = coolify_project.example.uuid
   server_uuid     = coolify_server.example.uuid
   github_app_uuid = coolify_github_app.example.uuid
-  git_repository  = "github.com/myorg/myrepo"
+  git_repository  = "https://github.com/myorg/myrepo"
   git_branch      = "main"
   build_pack      = "nixpacks"
   ports_exposes   = "3000"
@@ -32,8 +34,8 @@ resource "coolify_github_app_application" "app" {
 ### Required
 
 - `build_pack` (String) The build pack type. Valid values: `nixpacks`, `dockerfile`, `dockercompose`, `static`.
-- `git_repository` (String) The Git repository URL (e.g. `github.com/org/repo`).
-- `github_app_uuid` (String) The UUID of the GitHub App used for repository access.
+- `git_repository` (String) The Git repository URL (for example `https://github.com/org/repo` or `org/repo`). Coolify checks repository access during create.
+- `github_app_uuid` (String) The UUID of the GitHub App used for repository access. The app installation must be able to read the repository configured in `git_repository`.
 - `ports_exposes` (String) The ports to expose, as a comma-separated list (e.g. `3000` or `3000,8080`).
 - `project_uuid` (String) The UUID of the project this application belongs to. Changing this forces a new resource.
 - `server_uuid` (String) The UUID of the server to deploy the application on. Changing this forces a new resource.

--- a/examples/resources/coolify_github_app/resource.tf
+++ b/examples/resources/coolify_github_app/resource.tf
@@ -3,6 +3,8 @@ variable "github_app_client_secret" {
   sensitive = true
 }
 
+# Requires a coolify_private_key resource created from the GitHub App
+# private key PEM before creating the integration.
 resource "coolify_github_app" "example" {
   name             = "my-github-app"
   app_id           = 12345

--- a/examples/resources/coolify_github_app_application/resource.tf
+++ b/examples/resources/coolify_github_app_application/resource.tf
@@ -1,9 +1,11 @@
+# Requires an existing coolify_github_app backed by a live GitHub App
+# installation that can access the target repository.
 resource "coolify_github_app_application" "app" {
   name            = "my-github-app"
   project_uuid    = coolify_project.example.uuid
   server_uuid     = coolify_server.example.uuid
   github_app_uuid = coolify_github_app.example.uuid
-  git_repository  = "github.com/myorg/myrepo"
+  git_repository  = "https://github.com/myorg/myrepo"
   git_branch      = "main"
   build_pack      = "nixpacks"
   ports_exposes   = "3000"

--- a/examples/scenarios/acme-integrations/README.md
+++ b/examples/scenarios/acme-integrations/README.md
@@ -1,23 +1,24 @@
 # ACME Corp External Integrations
 
-This scenario tests external integration resources: GitHub App registration
-(with dummy credentials) and Coolify managed services from the service catalog.
+This scenario tests external integration resources through a managed service
+from the Coolify catalog. GitHub App registration is documented separately
+because application creation requires a live GitHub App installation.
 
 ## Resources Tested
 
 | Resource | Purpose |
 |---|---|
-| `coolify_github_app` | GitHub App with dummy credentials (metadata only) |
 | `coolify_service` | Managed service from Coolify catalog (uptime-kuma) |
 
 ## How It Works
 
-The GitHub App uses dummy values (app_id=12345, fake client_secret). Coolify
-stores the metadata without verifying OAuth connectivity, so CRUD operations
-work without a real GitHub App configured.
-
 The managed service uses the `uptime-kuma` type from Coolify's built-in
 service catalog. Coolify creates the Docker containers for the service.
+
+GitHub App-backed applications are intentionally not part of this scenario.
+Coolify verifies repository access during `POST /applications/private-github-app`,
+so a realistic end-to-end example needs a live GitHub App installation with
+repository access.
 
 ## Running
 

--- a/examples/scenarios/acme-integrations/acme-integrations.tftest.hcl
+++ b/examples/scenarios/acme-integrations/acme-integrations.tftest.hcl
@@ -1,6 +1,6 @@
 # Acceptance test for ACME Corp external integrations.
 #
-# Tests: github_app (with dummy credentials), service (from catalog).
+# Tests: managed service from the Coolify catalog.
 #
 # Required variables via TF_VAR_*:
 #   TF_VAR_coolify_endpoint, TF_VAR_coolify_token, TF_VAR_server_uuid

--- a/examples/scenarios/acme-integrations/main.tf
+++ b/examples/scenarios/acme-integrations/main.tf
@@ -1,7 +1,7 @@
 # ACME Corp External Integrations
 #
-# Tests external integration resources: GitHub App registration and
-# Coolify managed services (from the service catalog).
+# Tests external integration resources via Coolify managed services
+# from the built-in service catalog.
 
 terraform {
   required_providers {
@@ -22,12 +22,6 @@ resource "coolify_project" "integrations" {
   name        = "acme-integrations"
   description = "ACME Corp external service integrations"
 }
-
-# --- GitHub App ---
-# Temporarily removed: Coolify validates GitHub App credentials on creation
-# (returns 422 with dummy values). Unlike what acceptance tests suggest,
-# real Coolify requires valid GitHub App OAuth credentials.
-# See issue #44 for tracking.
 
 # --- Managed Service (from Coolify service catalog) ---
 

--- a/internal/service/application/resource_github_app.go
+++ b/internal/service/application/resource_github_app.go
@@ -50,15 +50,15 @@ func (r *gitHubAppApplicationResource) Metadata(_ context.Context, req resource.
 
 func (r *gitHubAppApplicationResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Coolify application deployed via a GitHub App integration.",
+		MarkdownDescription: "Manages a Coolify application deployed via a GitHub App integration. Coolify verifies repository access during create, so the referenced GitHub App must have installation access to the target repository.",
 		Attributes: CommonAppAttrs(ctx, map[string]schema.Attribute{
 			"github_app_uuid": schema.StringAttribute{
-				MarkdownDescription: "The UUID of the GitHub App used for repository access.",
+				MarkdownDescription: "The UUID of the GitHub App used for repository access. The app installation must be able to read the repository configured in `git_repository`.",
 				Required:            true,
 				Validators:          []validator.String{validate.UUID()},
 			},
 			"git_repository": schema.StringAttribute{
-				MarkdownDescription: "The Git repository URL (e.g. `github.com/org/repo`).",
+				MarkdownDescription: "The Git repository URL (for example `https://github.com/org/repo` or `org/repo`). Coolify checks repository access during create.",
 				Required:            true,
 			},
 			"git_branch": schema.StringAttribute{

--- a/internal/service/application/resource_github_app_acc_test.go
+++ b/internal/service/application/resource_github_app_acc_test.go
@@ -3,6 +3,8 @@ package application_test
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -13,11 +15,10 @@ func TestAccGitHubAppApplicationResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	if os.Getenv("COOLIFY_GITHUB_APP_UUID") == "" {
-		t.Skip("COOLIFY_GITHUB_APP_UUID not set, skipping (real GitHub App credentials required)")
-	}
+	fixture := accTestGitHubAppApplicationFixture(t)
 	serverUUID := acctest.AccTestServerUUID(t)
 	name := acctest.RandomWithPrefix("tf-acc-ghapp-app")
+	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-app-key")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
@@ -25,7 +26,7 @@ func TestAccGitHubAppApplicationResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: testAccGitHubAppApplicationConfig(name, serverUUID, ""),
+				Config: testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName, fixture, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_github_app_application.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_github_app_application.test", "build_pack", "nixpacks"),
@@ -34,45 +35,132 @@ func TestAccGitHubAppApplicationResource_CRUD(t *testing.T) {
 			},
 			// Step 2: Update description
 			{
-				Config: testAccGitHubAppApplicationConfig(name, serverUUID, `description = "Updated github app application"`),
+				Config: testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName, fixture, `description = "Updated github app application"`),
 				Check:  resource.TestCheckResourceAttr("coolify_github_app_application.test", "description", "Updated github app application"),
 			},
-			// Step 3: Import by UUID
+			// Step 3: Idempotency check
+			{
+				Config:             testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName, fixture, `description = "Updated github app application"`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 4: Import by UUID
 			{
 				ResourceName:                         "coolify_github_app_application.test",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "uuid",
 				ImportStateIdFunc:                    acctest.ImportStateIDFunc("coolify_github_app_application.test", "uuid"),
-				ImportStateVerifyIgnore:              []string{"environment_name", "github_app_uuid", "project_uuid", "server_uuid"},
+				ImportStateVerifyIgnore:              []string{"environment_name", "github_app_uuid", "project_uuid", "server_uuid"}, // github_app_uuid is not returned by the API after import
 			},
 		},
 	})
 }
 
-func testAccGitHubAppApplicationConfig(name, serverUUID, extra string) string {
+type gitHubAppApplicationFixture struct {
+	AppID          int64
+	InstallationID int64
+	ClientID       string
+	ClientSecret   string
+	PrivateKey     string
+	GitRepository  string
+	GitBranch      string
+}
+
+func accTestGitHubAppApplicationFixture(t *testing.T) gitHubAppApplicationFixture {
+	t.Helper()
+
+	required := []string{
+		"COOLIFY_GITHUB_APP_APP_ID",
+		"COOLIFY_GITHUB_APP_INSTALLATION_ID",
+		"COOLIFY_GITHUB_APP_CLIENT_ID",
+		"COOLIFY_GITHUB_APP_CLIENT_SECRET",
+		"COOLIFY_GITHUB_APP_REPOSITORY",
+	}
+	missing := make([]string, 0, len(required)+1)
+	values := make(map[string]string, len(required))
+	for _, key := range required {
+		value := strings.TrimSpace(os.Getenv(key))
+		if value == "" {
+			missing = append(missing, key)
+			continue
+		}
+		values[key] = value
+	}
+
+	privateKey := os.Getenv("COOLIFY_GITHUB_APP_PRIVATE_KEY")
+	if privateKey == "" {
+		privateKeyFile := strings.TrimSpace(os.Getenv("COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE"))
+		if privateKeyFile == "" {
+			missing = append(missing, "COOLIFY_GITHUB_APP_PRIVATE_KEY or COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE")
+		} else {
+			keyBytes, err := os.ReadFile(privateKeyFile)
+			if err != nil {
+				t.Fatalf("reading COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE %q: %s", privateKeyFile, err)
+			}
+			privateKey = string(keyBytes)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Skipf("GitHub App application acceptance requires live GitHub App credentials and repository access; missing %s", strings.Join(missing, ", "))
+	}
+
+	appID, err := strconv.ParseInt(values["COOLIFY_GITHUB_APP_APP_ID"], 10, 64)
+	if err != nil {
+		t.Fatalf("parsing COOLIFY_GITHUB_APP_APP_ID: %s", err)
+	}
+	installationID, err := strconv.ParseInt(values["COOLIFY_GITHUB_APP_INSTALLATION_ID"], 10, 64)
+	if err != nil {
+		t.Fatalf("parsing COOLIFY_GITHUB_APP_INSTALLATION_ID: %s", err)
+	}
+
+	branch := strings.TrimSpace(os.Getenv("COOLIFY_GITHUB_APP_BRANCH"))
+	if branch == "" {
+		branch = "main"
+	}
+
+	return gitHubAppApplicationFixture{
+		AppID:          appID,
+		InstallationID: installationID,
+		ClientID:       values["COOLIFY_GITHUB_APP_CLIENT_ID"],
+		ClientSecret:   values["COOLIFY_GITHUB_APP_CLIENT_SECRET"],
+		PrivateKey:     privateKey,
+		GitRepository:  values["COOLIFY_GITHUB_APP_REPOSITORY"],
+		GitBranch:      branch,
+	}
+}
+
+func testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName string, fixture gitHubAppApplicationFixture, extra string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {
   name = %[1]q
 }
 
+resource "coolify_private_key" "test" {
+  name        = %[3]q
+  description = "acc test github app application key"
+  private_key = %[4]q
+}
+
 resource "coolify_github_app" "test" {
   name             = "%[1]s-ghapp"
-  app_id           = 12345
-  installation_id  = 67890
-  client_id        = "Iv1.fake123456789"
-  client_secret    = "fake-client-secret-value"
-  private_key_uuid = "pk-uuid-acctest"
+  app_id           = %[5]d
+  installation_id  = %[6]d
+  client_id        = %[7]q
+  client_secret    = %[8]q
+  private_key_uuid = coolify_private_key.test.uuid
 }
 
 resource "coolify_github_app_application" "test" {
   project_uuid    = coolify_project.test.uuid
   server_uuid     = %[2]q
   github_app_uuid = coolify_github_app.test.uuid
-  git_repository  = "coollabsio/coolify-examples"
+  git_repository  = %[9]q
+  git_branch      = %[10]q
   build_pack      = "nixpacks"
   ports_exposes   = "3000"
-  %[3]s
+  %[11]s
 }
-`, name, serverUUID, extra)
+`, name, serverUUID, privateKeyName, fixture.PrivateKey, fixture.AppID, fixture.InstallationID, fixture.ClientID, fixture.ClientSecret, fixture.GitRepository, fixture.GitBranch, extra)
 }

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -86,6 +86,7 @@ must be set in your `.tf` configuration before running `terraform plan`:
 |---|---|
 | All databases | `project_uuid`, `server_uuid`, `environment_name` |
 | All applications | `project_uuid`, `server_uuid`, `environment_name` |
+| `coolify_github_app_application` | `github_app_uuid` (Coolify stores the linked GitHub App as `source_id`/`source_type`, so import cannot recover the original UUID) |
 | `coolify_service` | `project_uuid`, `server_uuid`, `environment_name`, `type` |
 | `coolify_environment` | `description` (stored in Terraform state only; not returned by the API) |
 | `coolify_github_app` | `client_secret`, `private_key_uuid` (write-only, never returned by the API) |
@@ -96,6 +97,10 @@ must be set in your `.tf` configuration before running `terraform plan`:
 If these fields are missing, `terraform plan` will either show a diff
 or propose replacing the resource. Set them in your config to match
 your actual Coolify setup.
+
+For `coolify_github_app_application`, import also cannot reconstruct
+`github_app_uuid` from the API. Keep that field in your configuration
+before the first `terraform plan`, or expect a post-import diff.
 
 Additionally, Coolify normalizes some input values:
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -73,6 +73,7 @@ automatically, but they are worth knowing:
 | **Base64 encoding required** | `coolify_dockerfile_application` | `dockerfile_location` must be base64-encoded despite the field name; use `base64encode()` |
 | **Server must be reachable** | All applications | Terraform fails with `Application created but not persisted` if Coolify cannot read the app back after creation |
 | **Cloud token validation** | `coolify_cloud_token` | Coolify validates the token against the cloud provider's API on creation (cannot use placeholder values) |
+| **GitHub App repository validation** | `coolify_github_app_application` | Coolify verifies repository access during create, so end-to-end tests need a live GitHub App installation with repository access |
 | **Async deletion** | `coolify_project` | Child resources are deleted asynchronously; project delete retries automatically |
 
 The provider preserves your configured values for all normalized fields.


### PR DESCRIPTION
## Summary
- replace the stale GitHub App application acceptance gate with live COOLIFY_GITHUB_APP_* fixture requirements
- align GitHub App application docs, examples, and import guidance with Coolify's real repository-access validation
- remove the old dummy-credential story from the ACME integrations scenario and document the real prerequisites

## Verification
- make ci
- TF_ACC=1 go test -race -count=1 -timeout=20m ./internal/service/githubapp -v against local Coolify with a temporary API token
- TF_ACC=1 go test -race -count=1 -timeout=20m ./internal/service/application -run TestAccGitHubAppApplicationResource_CRUD -v against local Coolify with a temporary API token, which now skips cleanly without GitHub fixture env vars

Closes #180
