### PR TITLE
Clarify spec and contract audit boundaries

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -3,7 +3,8 @@
 <!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->
 <!-- Run: make api-coverage -->
 
-**Spec**: Coolify v4 (pinned in `testdata/specs/coolify-v4.json`)  
+**Route inventory**: pinned OpenAPI spec in `testdata/specs/coolify-v4.json`  
+**Field source of truth**: source-derived contract in `testdata/contracts/coolify-v4.json`  
 **Coverage**: 134 / 135 endpoints (99.3%)  
 **Planned**: 0 | **Skipped**: 1
 

--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -6,8 +6,10 @@ description: "Comparison of Coolify OpenAPI spec vs real source code contract."
 
 # API Contract Accuracy
 
-This page shows the accuracy of the Coolify OpenAPI specification compared
-to the real API behavior extracted from the Coolify source code.
+This page compares the pinned reusable OpenAPI schemas with the source-derived
+Coolify contract extracted from the real application code.
+
+> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
 
 Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
@@ -15,14 +17,16 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
 | Metric | Count |
 |--------|------:|
-| Total fields | 611 |
-| Type matches | 611/611 |
-| Nullable matches | 239/611 |
-| Provider coverage | 337/611 |
-| Models in contract | 22 |
-| Models in spec | 13 |
+| Public schema fields compared | 299 |
+| Public schema type matches | 299/299 |
+| Public schema nullable matches | 239/299 |
+| Public schema provider coverage | 143/299 |
+| Reusable public schemas compared | 9 |
+| Contract-only / inline-only models documented | 13 |
 
 ---
+
+## Reusable Public Schemas
 
 ## Application
 
@@ -386,7 +390,44 @@ Fields: 19 | Type matches: 19/19 | Nullable matches: 17/19 | Provider coverage: 
 | is_container_label_readonly_enabled | - | boolean | - | - | - | n/a |
 | updated_at | - | string | - | - | - | supported |
 
+## Contract-Only or Inline-Only Models
+
+These sections document source-derived models that do not map cleanly to reusable public OpenAPI component schemas.
+
+## ScheduledDatabaseBackup
+
+This section compares the internal source-derived backup model against the public backup request bodies in the pinned spec.
+Coolify stores the relation as `s3_storage_id` internally, while the public API accepts `s3_storage_uuid` on request bodies.
+That identifier translation is expected and does not imply a missing top-level S3 CRUD API.
+
+Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 15/19
+
+| Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
+|-------|:---:|:---:|:---:|:---:|---------|:---:|
+| database_backup_retention_amount_locally | integer | - | - | - | 0 | supported |
+| database_backup_retention_amount_s3 | string | - | - | - | - | supported |
+| database_backup_retention_days_locally | string | - | - | - | - | supported |
+| database_backup_retention_days_s3 | string | - | - | - | - | supported |
+| database_backup_retention_max_storage_locally | string | - | - | - | - | supported |
+| database_backup_retention_max_storage_s3 | string | - | - | - | - | supported |
+| database_id | integer | - | - | - | - | n/a |
+| database_type | string | - | - | - | - | supported |
+| databases_to_backup | string | - | - | - | - | supported |
+| description | string | - | - | - | - | supported |
+| disable_local_backup | string | - | - | - | - | n/a |
+| dump_all | string | - | - | - | - | supported |
+| enabled | boolean | - | - | - | true | supported |
+| frequency | string | - | - | - | - | supported |
+| number_of_backups_locally | integer | - | - | - | 7 | n/a |
+| s3_storage_id | integer | - | - | - | - | n/a |
+| save_s3 | boolean | - | - | - | true | supported |
+| timeout | integer | - | - | - | 3600 | supported |
+| uuid | string | - | - | - | - | supported |
+
 ## CloudProviderToken
+
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
 
 Fields: 3 | Type matches: 3/3 | Nullable matches: 3/3 | Provider coverage: 3/3
 
@@ -398,19 +439,22 @@ Fields: 3 | Type matches: 3/3 | Nullable matches: 3/3 | Provider coverage: 3/3
 
 ## GithubApp
 
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 9/19
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
+
+Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 11/19
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | administration | string | - | - | - | - | n/a |
-| api_url | string | - | - | - | - | n/a |
+| api_url | string | - | - | - | - | supported |
 | app_id | integer | - | - | - | - | supported |
 | client_id | string | - | - | - | - | supported |
 | client_secret | string | - | - | - | - | supported |
 | contents | string | - | - | - | - | n/a |
 | custom_port | integer | - | - | - | 22 | n/a |
 | custom_user | string | - | - | - | git | n/a |
-| html_url | string | - | - | - | - | n/a |
+| html_url | string | - | - | - | - | supported |
 | installation_id | integer | - | - | - | - | supported |
 | is_public | boolean | - | - | - | false | supported |
 | is_system_wide | boolean | - | - | - | false | n/a |
@@ -439,6 +483,9 @@ Fields: 8 | Type matches: 8/8 | Nullable matches: 8/8 | Provider coverage: 3/8
 
 ## S3Storage
 
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
+
 Fields: 10 | Type matches: 10/10 | Nullable matches: 10/10 | Provider coverage: 0/10
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
@@ -453,32 +500,6 @@ Fields: 10 | Type matches: 10/10 | Nullable matches: 10/10 | Provider coverage: 
 | secret | string | - | - | - | - | n/a |
 | unusable_email_sent | string | - | - | - | - | n/a |
 | uuid | string | - | - | - | - | n/a |
-
-## ScheduledDatabaseBackup
-
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 15/19
-
-| Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
-|-------|:---:|:---:|:---:|:---:|---------|:---:|
-| database_backup_retention_amount_locally | integer | - | - | - | 0 | supported |
-| database_backup_retention_amount_s3 | string | - | - | - | - | supported |
-| database_backup_retention_days_locally | string | - | - | - | - | supported |
-| database_backup_retention_days_s3 | string | - | - | - | - | supported |
-| database_backup_retention_max_storage_locally | string | - | - | - | - | supported |
-| database_backup_retention_max_storage_s3 | string | - | - | - | - | supported |
-| database_id | integer | - | - | - | - | n/a |
-| database_type | string | - | - | - | - | supported |
-| databases_to_backup | string | - | - | - | - | supported |
-| description | string | - | - | - | - | supported |
-| disable_local_backup | string | - | - | - | - | n/a |
-| dump_all | string | - | - | - | - | supported |
-| enabled | boolean | - | - | - | true | supported |
-| frequency | string | - | - | - | - | supported |
-| number_of_backups_locally | integer | - | - | - | 7 | n/a |
-| s3_storage_id | integer | - | - | - | - | n/a |
-| save_s3 | boolean | - | - | - | true | supported |
-| timeout | integer | - | - | - | 3600 | supported |
-| uuid | string | - | - | - | - | supported |
 
 ## StandaloneClickhouse
 

--- a/internal/spectest/client_spec_test.go
+++ b/internal/spectest/client_spec_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // TestClientEndpoints_SpecCompliance validates that every API endpoint
-// our client uses matches the OpenAPI spec. This catches wrong methods,
-// wrong paths, wrong request bodies, and wrong response shapes.
+// our client uses stays compatible with the pinned OpenAPI route spec.
+// This is a route and payload-shape audit only. The source-derived contract
+// remains the field-level source of truth for provider behavior.
 func TestClientEndpoints_SpecCompliance(t *testing.T) {
 	t.Parallel()
 
@@ -271,13 +272,13 @@ func TestClientEndpoints_SpecCompliance(t *testing.T) {
 		{"ListCloudTokens", "GET", "/api/v1/cloud-tokens",
 			nil, 200, []map[string]interface{}{{"id": 1, "name": "my-token"}}},
 		{"CreateCloudToken", "POST", "/api/v1/cloud-tokens",
-			map[string]interface{}{"name": "my-token"},
-			201, map[string]interface{}{"id": 1, "name": "my-token"}},
+			map[string]interface{}{"name": "my-token", "provider": "hetzner", "token": "secret-token"},
+			201, map[string]interface{}{"uuid": "ct-1"}},
 		{"GetCloudToken", "GET", "/api/v1/cloud-tokens/ct-1",
-			nil, 200, map[string]interface{}{"id": 1, "name": "my-token"}},
+			nil, 200, map[string]interface{}{"uuid": "ct-1", "name": "my-token", "provider": "hetzner"}},
 		{"UpdateCloudToken", "PATCH", "/api/v1/cloud-tokens/ct-1",
 			map[string]interface{}{"name": "updated-token"},
-			200, map[string]interface{}{"id": 1, "name": "updated-token"}},
+			200, map[string]interface{}{"uuid": "ct-1"}},
 		{"DeleteCloudToken", "DELETE", "/api/v1/cloud-tokens/ct-1",
 			nil, 200, map[string]string{"message": "deleted"}},
 		{"ValidateCloudToken", "POST", "/api/v1/cloud-tokens/ct-1/validate",
@@ -285,13 +286,17 @@ func TestClientEndpoints_SpecCompliance(t *testing.T) {
 
 		// GitHub Apps
 		{"ListGitHubApps", "GET", "/api/v1/github-apps",
-			nil, 200, []map[string]interface{}{{"id": 1, "name": "my-gh-app"}}},
+			nil, 200, []map[string]interface{}{{"id": 1, "uuid": "gh-1", "name": "my-gh-app", "api_url": "https://api.github.com", "html_url": "https://github.com", "app_id": 12345, "installation_id": 67890, "client_id": "Iv1.abc123", "private_key_id": 1, "is_system_wide": false, "team_id": 1}}},
 		{"CreateGitHubApp", "POST", "/api/v1/github-apps",
-			map[string]interface{}{"name": "my-gh-app"},
-			201, map[string]interface{}{"id": 1, "uuid": "gh-1"}},
+			map[string]interface{}{
+				"name": "my-gh-app", "api_url": "https://api.github.com", "html_url": "https://github.com",
+				"app_id": 12345, "installation_id": 67890, "client_id": "Iv1.abc123",
+				"client_secret": "secret", "private_key_uuid": "pk-1",
+			},
+			201, map[string]interface{}{"id": 1, "uuid": "gh-1", "name": "my-gh-app"}},
 		{"UpdateGitHubApp", "PATCH", "/api/v1/github-apps/1",
-			map[string]interface{}{"name": "updated-gh-app"},
-			200, map[string]interface{}{"id": 1, "name": "updated-gh-app"}},
+			map[string]interface{}{"name": "updated-gh-app", "client_secret": "updated-secret"},
+			200, map[string]interface{}{"message": "GitHub app updated successfully", "data": map[string]interface{}{"id": 1, "name": "updated-gh-app"}}},
 		{"DeleteGitHubApp", "DELETE", "/api/v1/github-apps/1",
 			nil, 200, map[string]string{"message": "deleted"}},
 		{"ListRepos", "GET", "/api/v1/github-apps/1/repositories",

--- a/internal/spectest/coverage_test.go
+++ b/internal/spectest/coverage_test.go
@@ -20,11 +20,12 @@ type coverageStatus struct {
 	notes    string // human-readable context
 }
 
-// coveredEndpoints returns the full API endpoint registry.
-// This is the single source of truth for API coverage. The
-// TestSpecCoverage_Completeness test fails if the OpenAPI spec has
-// endpoints not listed here. The TestSpecCoverage_GenerateDoc test
-// generates API_COVERAGE.md from this data.
+// coveredEndpoints returns the provider's route coverage registry.
+// The pinned OpenAPI spec is the route inventory for completeness checks.
+// The source-derived contract remains the field-level source of truth.
+// TestSpecCoverage_Completeness fails if the pinned route inventory and
+// this registry drift. TestSpecCoverage_GenerateDoc generates API_COVERAGE.md
+// from this data.
 func coveredEndpoints() map[string]coverageStatus {
 	covered := func(resource, since string) coverageStatus {
 		return coverageStatus{category: "covered", resource: resource, since: since}
@@ -314,7 +315,8 @@ func TestSpecCoverage_GenerateDoc(t *testing.T) {
 	b.WriteString("# API Coverage\n\n")
 	b.WriteString("<!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->\n")
 	b.WriteString("<!-- Run: make api-coverage -->\n\n")
-	b.WriteString("**Spec**: Coolify v4 (pinned in `testdata/specs/coolify-v4.json`)  \n")
+	b.WriteString("**Route inventory**: pinned OpenAPI spec in `testdata/specs/coolify-v4.json`  \n")
+	b.WriteString("**Field source of truth**: source-derived contract in `testdata/contracts/coolify-v4.json`  \n")
 	fmt.Fprintf(&b, "**Coverage**: %d / %d endpoints (%.1f%%)  \n", len(coveredList), total, pct)
 	fmt.Fprintf(&b, "**Planned**: %d | **Skipped**: %d\n", len(plannedList), len(skippedList))
 

--- a/scripts/generate-contract-matrix.py
+++ b/scripts/generate-contract-matrix.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Generate a contract accuracy matrix comparing source-code contract vs OpenAPI spec.
+"""Generate the API contract accuracy guide.
 
-Reads the extracted contract JSON and the (patched) OpenAPI spec, then
-produces a Markdown guide template showing field-by-field accuracy for
-each model that exists in both files.
+Reads the source-derived contract JSON and pinned OpenAPI spec, then
+produces the Markdown guide template used for the API contract accuracy
+documentation. Reusable public schemas are compared field-by-field, and
+contract-only or inline-only models are documented separately.
 
 Usage:
     python3 scripts/generate-contract-matrix.py
@@ -20,7 +21,7 @@ SPEC_PATH = ROOT / "testdata" / "specs" / "coolify-v4.json"
 OUTPUT_PATH = ROOT / "templates" / "guides" / "api-contract-accuracy.md.tmpl"
 CLIENT_DIR = ROOT / "internal" / "client"
 
-# Maps contract model names to OpenAPI schema names (only models in both).
+# Preferred documentation order, with the reusable OpenAPI schema name to compare when present.
 MODEL_TO_SCHEMA = {
     "Application": "Application",
     "Server": "Server",
@@ -31,11 +32,20 @@ MODEL_TO_SCHEMA = {
     "EnvironmentVariable": "EnvironmentVariable",
     "PrivateKey": "PrivateKey",
     "ScheduledTask": "ScheduledTask",
+    "ScheduledDatabaseBackup": "ScheduledDatabaseBackup",
 }
 
 # Contract models that intentionally have no public provider surface.
 PROVIDER_TAG_OVERRIDES = {
     "S3Storage": set(),
+}
+
+# Models we keep in the contract-only / inline-only section even though the
+# pinned route spec may mention them elsewhere.
+CONTRACT_ONLY_MODELS = {
+    "CloudProviderToken",
+    "GithubApp",
+    "S3Storage",
 }
 
 # Map contract field types to a normalised display type.
@@ -157,6 +167,23 @@ def _compare_field(
     }
 
 
+def _model_intro(model_name: str, spec_schema: dict | None) -> list[str]:
+    if model_name == "ScheduledDatabaseBackup":
+        return [
+            "This section compares the internal source-derived backup model against the public backup request bodies in the pinned spec.",
+            "Coolify stores the relation as `s3_storage_id` internally, while the public API accepts `s3_storage_uuid` on request bodies.",
+            "That identifier translation is expected and does not imply a missing top-level S3 CRUD API.",
+            "",
+        ]
+    if spec_schema is None and model_name in CONTRACT_ONLY_MODELS:
+        return [
+            "This model exists in the extracted source contract but not as a reusable public OpenAPI schema.",
+            "Treat it as implementation detail coverage, not proof of a standalone public API surface.",
+            "",
+        ]
+    return []
+
+
 def _build_model_table(
     model_name: str,
     contract_model: dict,
@@ -204,6 +231,7 @@ def _build_model_table(
     lines: list[str] = []
     lines.append(f"## {model_name}")
     lines.append("")
+    lines.extend(_model_intro(model_name, spec_schema))
     lines.append(
         f"Fields: {total} | Type matches: {type_ok}/{total} "
         f"| Nullable matches: {nullable_ok}/{total} "
@@ -259,9 +287,11 @@ def main():
     out.append("# API Contract Accuracy")
     out.append("")
     out.append(
-        "This page shows the accuracy of the Coolify OpenAPI specification compared"
+        "This page compares the pinned reusable OpenAPI schemas with the source-derived"
     )
-    out.append("to the real API behavior extracted from the Coolify source code.")
+    out.append("Coolify contract extracted from the real application code.")
+    out.append("")
+    out.append("> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.")
     out.append("")
     out.append(
         f"Contract version: `{contract.get('version', 'unknown')}` | "
@@ -269,83 +299,94 @@ def main():
     )
     out.append("")
 
-    # Summary counts.
-    total_fields = 0
-    total_type_ok = 0
-    total_nullable_ok = 0
-    total_provider = 0
+    def accumulate(section: list[str], stats: dict[str, int]):
+        for line in section:
+            if not line.startswith("Fields:"):
+                continue
+            parts = line.split("|")
+            for p in parts:
+                p = p.strip()
+                if p.startswith("Fields:"):
+                    stats["total_fields"] += int(p.split(":")[1].strip())
+                elif p.startswith("Type matches:"):
+                    n, _ = p.split(":")[1].strip().split("/")
+                    stats["total_type_ok"] += int(n)
+                elif p.startswith("Nullable matches:"):
+                    n, _ = p.split(":")[1].strip().split("/")
+                    stats["total_nullable_ok"] += int(n)
+                elif p.startswith("Provider coverage:"):
+                    n, _ = p.split(":")[1].strip().split("/")
+                    stats["total_provider"] += int(n)
 
-    model_sections: list[list[str]] = []
+    public_stats = {
+        "total_fields": 0,
+        "total_type_ok": 0,
+        "total_nullable_ok": 0,
+        "total_provider": 0,
+    }
+    contract_only_stats = {
+        "total_fields": 0,
+        "total_type_ok": 0,
+        "total_nullable_ok": 0,
+        "total_provider": 0,
+    }
+
+    public_sections: list[list[str]] = []
+    contract_only_sections: list[list[str]] = []
+
     for model_name, schema_name in sorted(MODEL_TO_SCHEMA.items()):
         contract_model = contract.get("models", {}).get(model_name)
         if contract_model is None:
             continue
         spec_schema = schemas.get(schema_name)
         section = _build_model_table(model_name, contract_model, spec_schema, provider_tags)
-        model_sections.append(section)
+        if spec_schema is None:
+            contract_only_sections.append(section)
+            accumulate(section, contract_only_stats)
+        else:
+            public_sections.append(section)
+            accumulate(section, public_stats)
 
-        # Parse stats from the summary line.
-        for line in section:
-            if line.startswith("Fields:"):
-                parts = line.split("|")
-                for p in parts:
-                    p = p.strip()
-                    if p.startswith("Fields:"):
-                        total_fields += int(p.split(":")[1].strip())
-                    elif p.startswith("Type matches:"):
-                        n, d = p.split(":")[1].strip().split("/")
-                        total_type_ok += int(n)
-                    elif p.startswith("Nullable matches:"):
-                        n, d = p.split(":")[1].strip().split("/")
-                        total_nullable_ok += int(n)
-                    elif p.startswith("Provider coverage:"):
-                        n, d = p.split(":")[1].strip().split("/")
-                        total_provider += int(n)
-
-    # Also generate sections for contract models NOT in the spec.
     for model_name in sorted(contract.get("models", {})):
         if model_name in MODEL_TO_SCHEMA:
             continue
         contract_model = contract["models"][model_name]
         section = _build_model_table(model_name, contract_model, None, provider_tags)
-        model_sections.append(section)
-
-        for line in section:
-            if line.startswith("Fields:"):
-                parts = line.split("|")
-                for p in parts:
-                    p = p.strip()
-                    if p.startswith("Fields:"):
-                        total_fields += int(p.split(":")[1].strip())
-                    elif p.startswith("Type matches:"):
-                        n, d = p.split(":")[1].strip().split("/")
-                        total_type_ok += int(n)
-                    elif p.startswith("Provider coverage:"):
-                        n, d = p.split(":")[1].strip().split("/")
-                        total_provider += int(n)
+        contract_only_sections.append(section)
+        accumulate(section, contract_only_stats)
 
     out.append("## Summary")
     out.append("")
     out.append(f"| Metric | Count |")
     out.append(f"|--------|------:|")
-    out.append(f"| Total fields | {total_fields} |")
-    out.append(f"| Type matches | {total_type_ok}/{total_fields} |")
-    out.append(f"| Nullable matches | {total_nullable_ok}/{total_fields} |")
-    out.append(f"| Provider coverage | {total_provider}/{total_fields} |")
-    out.append(f"| Models in contract | {len(contract.get('models', {}))} |")
-    out.append(
-        f"| Models in spec | {len(schemas)} |"
-    )
+    out.append(f"| Public schema fields compared | {public_stats['total_fields']} |")
+    out.append(f"| Public schema type matches | {public_stats['total_type_ok']}/{public_stats['total_fields']} |")
+    out.append(f"| Public schema nullable matches | {public_stats['total_nullable_ok']}/{public_stats['total_fields']} |")
+    out.append(f"| Public schema provider coverage | {public_stats['total_provider']}/{public_stats['total_fields']} |")
+    out.append(f"| Reusable public schemas compared | {len(public_sections)} |")
+    out.append(f"| Contract-only / inline-only models documented | {len(contract_only_sections)} |")
     out.append("")
     out.append("---")
     out.append("")
+    out.append("## Reusable Public Schemas")
+    out.append("")
 
-    for section in model_sections:
+    for section in public_sections:
         out.extend(section)
+
+    if contract_only_sections:
+        out.append("## Contract-Only or Inline-Only Models")
+        out.append("")
+        out.append("These sections document source-derived models that do not map cleanly to reusable public OpenAPI component schemas.")
+        out.append("")
+        for section in contract_only_sections:
+            out.extend(section)
 
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT_PATH.write_text("\n".join(out) + "\n")
-    print(f"Generated {OUTPUT_PATH} ({total_fields} fields across {len(model_sections)} models)", file=sys.stderr)
+    total_fields = public_stats["total_fields"] + contract_only_stats["total_fields"]
+    total_models = len(public_sections) + len(contract_only_sections)
+    print(f"Generated {OUTPUT_PATH} ({total_fields} fields across {total_models} models)", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -6,8 +6,10 @@ description: "Comparison of Coolify OpenAPI spec vs real source code contract."
 
 # API Contract Accuracy
 
-This page shows the accuracy of the Coolify OpenAPI specification compared
-to the real API behavior extracted from the Coolify source code.
+This page compares the pinned reusable OpenAPI schemas with the source-derived
+Coolify contract extracted from the real application code.
+
+> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
 
 Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
@@ -15,14 +17,16 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
 | Metric | Count |
 |--------|------:|
-| Total fields | 611 |
-| Type matches | 611/611 |
-| Nullable matches | 239/611 |
-| Provider coverage | 337/611 |
-| Models in contract | 22 |
-| Models in spec | 13 |
+| Public schema fields compared | 299 |
+| Public schema type matches | 299/299 |
+| Public schema nullable matches | 239/299 |
+| Public schema provider coverage | 143/299 |
+| Reusable public schemas compared | 9 |
+| Contract-only / inline-only models documented | 13 |
 
 ---
+
+## Reusable Public Schemas
 
 ## Application
 
@@ -386,7 +390,44 @@ Fields: 19 | Type matches: 19/19 | Nullable matches: 17/19 | Provider coverage: 
 | is_container_label_readonly_enabled | - | boolean | - | - | - | n/a |
 | updated_at | - | string | - | - | - | supported |
 
+## Contract-Only or Inline-Only Models
+
+These sections document source-derived models that do not map cleanly to reusable public OpenAPI component schemas.
+
+## ScheduledDatabaseBackup
+
+This section compares the internal source-derived backup model against the public backup request bodies in the pinned spec.
+Coolify stores the relation as `s3_storage_id` internally, while the public API accepts `s3_storage_uuid` on request bodies.
+That identifier translation is expected and does not imply a missing top-level S3 CRUD API.
+
+Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 15/19
+
+| Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
+|-------|:---:|:---:|:---:|:---:|---------|:---:|
+| database_backup_retention_amount_locally | integer | - | - | - | 0 | supported |
+| database_backup_retention_amount_s3 | string | - | - | - | - | supported |
+| database_backup_retention_days_locally | string | - | - | - | - | supported |
+| database_backup_retention_days_s3 | string | - | - | - | - | supported |
+| database_backup_retention_max_storage_locally | string | - | - | - | - | supported |
+| database_backup_retention_max_storage_s3 | string | - | - | - | - | supported |
+| database_id | integer | - | - | - | - | n/a |
+| database_type | string | - | - | - | - | supported |
+| databases_to_backup | string | - | - | - | - | supported |
+| description | string | - | - | - | - | supported |
+| disable_local_backup | string | - | - | - | - | n/a |
+| dump_all | string | - | - | - | - | supported |
+| enabled | boolean | - | - | - | true | supported |
+| frequency | string | - | - | - | - | supported |
+| number_of_backups_locally | integer | - | - | - | 7 | n/a |
+| s3_storage_id | integer | - | - | - | - | n/a |
+| save_s3 | boolean | - | - | - | true | supported |
+| timeout | integer | - | - | - | 3600 | supported |
+| uuid | string | - | - | - | - | supported |
+
 ## CloudProviderToken
+
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
 
 Fields: 3 | Type matches: 3/3 | Nullable matches: 3/3 | Provider coverage: 3/3
 
@@ -398,19 +439,22 @@ Fields: 3 | Type matches: 3/3 | Nullable matches: 3/3 | Provider coverage: 3/3
 
 ## GithubApp
 
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 9/19
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
+
+Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 11/19
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | administration | string | - | - | - | - | n/a |
-| api_url | string | - | - | - | - | n/a |
+| api_url | string | - | - | - | - | supported |
 | app_id | integer | - | - | - | - | supported |
 | client_id | string | - | - | - | - | supported |
 | client_secret | string | - | - | - | - | supported |
 | contents | string | - | - | - | - | n/a |
 | custom_port | integer | - | - | - | 22 | n/a |
 | custom_user | string | - | - | - | git | n/a |
-| html_url | string | - | - | - | - | n/a |
+| html_url | string | - | - | - | - | supported |
 | installation_id | integer | - | - | - | - | supported |
 | is_public | boolean | - | - | - | false | supported |
 | is_system_wide | boolean | - | - | - | false | n/a |
@@ -439,6 +483,9 @@ Fields: 8 | Type matches: 8/8 | Nullable matches: 8/8 | Provider coverage: 3/8
 
 ## S3Storage
 
+This model exists in the extracted source contract but not as a reusable public OpenAPI schema.
+Treat it as implementation detail coverage, not proof of a standalone public API surface.
+
 Fields: 10 | Type matches: 10/10 | Nullable matches: 10/10 | Provider coverage: 0/10
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
@@ -453,32 +500,6 @@ Fields: 10 | Type matches: 10/10 | Nullable matches: 10/10 | Provider coverage: 
 | secret | string | - | - | - | - | n/a |
 | unusable_email_sent | string | - | - | - | - | n/a |
 | uuid | string | - | - | - | - | n/a |
-
-## ScheduledDatabaseBackup
-
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Provider coverage: 15/19
-
-| Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
-|-------|:---:|:---:|:---:|:---:|---------|:---:|
-| database_backup_retention_amount_locally | integer | - | - | - | 0 | supported |
-| database_backup_retention_amount_s3 | string | - | - | - | - | supported |
-| database_backup_retention_days_locally | string | - | - | - | - | supported |
-| database_backup_retention_days_s3 | string | - | - | - | - | supported |
-| database_backup_retention_max_storage_locally | string | - | - | - | - | supported |
-| database_backup_retention_max_storage_s3 | string | - | - | - | - | supported |
-| database_id | integer | - | - | - | - | n/a |
-| database_type | string | - | - | - | - | supported |
-| databases_to_backup | string | - | - | - | - | supported |
-| description | string | - | - | - | - | supported |
-| disable_local_backup | string | - | - | - | - | n/a |
-| dump_all | string | - | - | - | - | supported |
-| enabled | boolean | - | - | - | true | supported |
-| frequency | string | - | - | - | - | supported |
-| number_of_backups_locally | integer | - | - | - | 7 | n/a |
-| s3_storage_id | integer | - | - | - | - | n/a |
-| save_s3 | boolean | - | - | - | true | supported |
-| timeout | integer | - | - | - | 3600 | supported |
-| uuid | string | - | - | - | - | supported |
 
 ## StandaloneClickhouse
 


### PR DESCRIPTION
## Summary
- clarify that the pinned OpenAPI file is route inventory plus reusable public schema reference, while the source-derived contract remains the field-level source of truth
- split the API contract accuracy guide into reusable public schemas versus contract-only or inline-only models
- align cloud token and GitHub App spec-audit fixtures with the current client contracts and document the ScheduledDatabaseBackup `s3_storage_uuid` versus `s3_storage_id` boundary

## Verification
- make ci
- python3 scripts/generate-contract-matrix.py
- go test -race -count=1 ./internal/spectest -run 'TestClientEndpoints_SpecCompliance|TestSpecCoverage_Completeness' -v

Closes #182
