### PR TITLE
Serialize golangci-lint on shared runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 
 run:
   timeout: 5m
+  # Shared self-hosted runners should wait for the golangci-lint lock instead of failing.
+  allow-serial-runners: true
 
 linters:
   enable:


### PR DESCRIPTION
## Summary
- configure golangci-lint to wait on the file lock instead of failing on the shared self-hosted runner pool
- keep the existing lint checks unchanged while removing flaky lock-contention failures on parallel CI runs

## Verification
- golangci-lint run ./...
- make ci

