### PR TITLE
Preserve env var value on sanitized read-back and triage contract nullability drift

### DIFF
--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -10,6 +10,7 @@ This page compares the pinned reusable OpenAPI schemas with the source-derived
 Coolify contract extracted from the real application code.
 
 > The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
+> `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 
 Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
@@ -19,7 +20,7 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 |--------|------:|
 | Public schema fields compared | 299 |
 | Public schema type matches | 299/299 |
-| Public schema nullable matches | 239/299 |
+| Public schema nullable matches | 269/299 |
 | Public schema provider coverage | 143/299 |
 | Reusable public schemas compared | 9 |
 | Contract-only / inline-only models documented | 13 |
@@ -30,14 +31,14 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
 ## Application
 
-Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider coverage: 78/133
+Fields: 133 | Type matches: 133/133 | Nullable matches: 120/133 | Provider coverage: 78/133
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | additional_destinations | string | string | yes | **WRONG** | - | n/a |
 | application_id | integer | integer | yes | yes | - | n/a |
 | base_directory | string | string | yes | yes | / | supported |
-| build_command | string | string | yes | **WRONG** | - | supported |
+| build_command | string | string | yes | reviewed drift | - | supported |
 | build_pack | string | string | yes | yes | - | supported |
 | compose_parsing_version | string | string | yes | yes | - | n/a |
 | config_hash | string | string | yes | **WRONG** | - | n/a |
@@ -45,28 +46,28 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | custom_docker_run_options | string | string | yes | yes | - | supported |
 | custom_healthcheck_found | string | string | yes | yes | - | n/a |
 | custom_internal_name | string | string | yes | yes | - | n/a |
-| custom_labels | string | string | yes | **WRONG** | - | supported |
-| custom_network_aliases | string | string | yes | **WRONG** | - | supported |
-| custom_nginx_configuration | string | string | yes | **WRONG** | - | supported |
-| description | string | string | yes | **WRONG** | - | supported |
+| custom_labels | string | string | yes | reviewed drift | - | supported |
+| custom_network_aliases | string | string | yes | reviewed drift | - | supported |
+| custom_nginx_configuration | string | string | yes | reviewed drift | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | destination_id | integer | integer | yes | **WRONG** | - | n/a |
 | destination_type | string | string | yes | **WRONG** | - | n/a |
 | disable_build_cache | string | string | yes | yes | - | n/a |
 | docker_compose | string | string | yes | **WRONG** | - | n/a |
-| docker_compose_custom_build_command | string | string | yes | **WRONG** | - | supported |
-| docker_compose_custom_start_command | string | string | yes | **WRONG** | - | supported |
-| docker_compose_domains | string | string | yes | **WRONG** | - | supported |
+| docker_compose_custom_build_command | string | string | yes | reviewed drift | - | supported |
+| docker_compose_custom_start_command | string | string | yes | reviewed drift | - | supported |
+| docker_compose_domains | string | string | yes | reviewed drift | - | supported |
 | docker_compose_location | string | string | yes | yes | - | supported |
 | docker_compose_pr | string | string | yes | **WRONG** | - | n/a |
 | docker_compose_pr_location | string | string | yes | **WRONG** | /docker-compose.yaml | n/a |
 | docker_compose_pr_raw | string | string | yes | **WRONG** | - | n/a |
-| docker_compose_raw | string | string | yes | **WRONG** | - | supported |
+| docker_compose_raw | string | string | yes | reviewed drift | - | supported |
 | docker_images_to_keep | string | string | yes | yes | - | n/a |
 | docker_registry_image_name | string | string | yes | yes | - | supported |
 | docker_registry_image_tag | string | string | yes | yes | - | supported |
-| dockerfile | string | string | yes | **WRONG** | - | supported |
+| dockerfile | string | string | yes | reviewed drift | - | supported |
 | dockerfile_location | string | string | yes | yes | - | supported |
-| dockerfile_target_build | string | string | yes | **WRONG** | - | supported |
+| dockerfile_target_build | string | string | yes | reviewed drift | - | supported |
 | environment_id | integer | integer | yes | yes | - | n/a |
 | force_domain_override | string | string | yes | yes | - | supported |
 | fqdn | string | string | yes | yes | - | supported |
@@ -78,9 +79,9 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | gpu_device_ids | string | string | yes | yes | - | n/a |
 | gpu_driver | string | string | yes | yes | - | n/a |
 | gpu_options | string | string | yes | yes | - | n/a |
-| health_check_command | string | string | yes | **WRONG** | - | supported |
+| health_check_command | string | string | yes | reviewed drift | - | supported |
 | health_check_enabled | boolean | boolean | yes | yes | true | supported |
-| health_check_host | string | string | yes | **WRONG** | localhost | supported |
+| health_check_host | string | string | yes | reviewed drift | localhost | supported |
 | health_check_interval | integer | integer | yes | yes | 5 | supported |
 | health_check_method | string | string | yes | yes | GET | supported |
 | health_check_path | string | string | yes | yes | / | supported |
@@ -92,11 +93,11 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | health_check_start_period | integer | integer | yes | yes | 5 | supported |
 | health_check_timeout | integer | integer | yes | yes | 5 | supported |
 | health_check_type | string | string | yes | yes | - | supported |
-| http_basic_auth_password | string | string | yes | **WRONG** | - | supported |
-| http_basic_auth_username | string | string | yes | **WRONG** | - | supported |
+| http_basic_auth_password | string | string | yes | reviewed drift | - | supported |
+| http_basic_auth_username | string | string | yes | reviewed drift | - | supported |
 | include_source_commit_in_build | string | string | yes | yes | - | n/a |
 | inject_build_args_to_dockerfile | string | string | yes | yes | - | n/a |
-| install_command | string | string | yes | **WRONG** | - | supported |
+| install_command | string | string | yes | reviewed drift | - | supported |
 | is_auto_deploy_enabled | boolean | boolean | yes | yes | true | supported |
 | is_build_server_enabled | string | string | yes | yes | - | n/a |
 | is_consistent_container_name_enabled | string | string | yes | yes | - | n/a |
@@ -134,27 +135,27 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | limits_memory_reservation | string | string | yes | yes | 0 | supported |
 | limits_memory_swap | string | string | yes | yes | 0 | supported |
 | limits_memory_swappiness | integer | integer | yes | yes | 60 | supported |
-| manual_webhook_secret_bitbucket | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_gitea | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_github | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_gitlab | string | string | yes | **WRONG** | - | supported |
+| manual_webhook_secret_bitbucket | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_gitea | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_github | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_gitlab | string | string | yes | reviewed drift | - | supported |
 | name | string | string | yes | yes | - | supported |
 | nixpkgsarchive | string | string | yes | yes | - | n/a |
 | ports_exposes | string | string | yes | yes | - | supported |
 | ports_mappings | string | string | yes | yes | - | supported |
 | post_deployment_command | string | string | yes | yes | - | supported |
-| post_deployment_command_container | string | string | yes | **WRONG** | - | supported |
+| post_deployment_command_container | string | string | yes | reviewed drift | - | supported |
 | pre_deployment_command | string | string | yes | yes | - | supported |
-| pre_deployment_command_container | string | string | yes | **WRONG** | - | supported |
+| pre_deployment_command_container | string | string | yes | reviewed drift | - | supported |
 | preview_url_template | string | string | yes | yes | { {pr_id} }.{ {domain} } | supported |
 | private_key_id | integer | integer | yes | yes | - | n/a |
-| publish_directory | string | string | yes | **WRONG** | - | supported |
-| redirect | string | string | yes | **WRONG** | - | supported |
+| publish_directory | string | string | yes | reviewed drift | - | supported |
+| redirect | string | string | yes | reviewed drift | - | supported |
 | repository_project_id | integer | integer | yes | yes | - | n/a |
 | restart_count | integer | integer | yes | yes | 0 | n/a |
 | source_id | integer | integer | yes | yes | - | n/a |
 | source_type | string | string | yes | **WRONG** | - | n/a |
-| start_command | string | string | yes | **WRONG** | - | supported |
+| start_command | string | string | yes | reviewed drift | - | supported |
 | static_image | string | string | yes | yes | nginx:alpine | supported |
 | status | string | string | yes | yes | exited | supported |
 | swarm_placement_constraints | string | string | yes | **WRONG** | - | n/a |
@@ -162,7 +163,7 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | use_build_secrets | string | string | yes | yes | - | n/a |
 | use_build_server | string | string | yes | yes | - | supported |
 | uuid | string | string | yes | yes | - | supported |
-| watch_paths | string | string | yes | **WRONG** | - | supported |
+| watch_paths | string | string | yes | reviewed drift | - | supported |
 | created_at | - | string | - | - | - | supported |
 | deleted_at | - | string | - | - | - | n/a |
 | id | - | integer | - | - | - | supported |
@@ -184,7 +185,7 @@ Fields: 7 | Type matches: 7/7 | Nullable matches: 7/7 | Provider coverage: 6/7
 
 ## EnvironmentVariable
 
-Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 8/33
+Fields: 33 | Type matches: 33/33 | Nullable matches: 21/33 | Provider coverage: 8/33
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
@@ -214,7 +215,7 @@ Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 
 | standalone_mysql_id | integer | integer | yes | **WRONG** | - | n/a |
 | standalone_postgresql_id | integer | integer | yes | **WRONG** | - | n/a |
 | standalone_redis_id | integer | integer | yes | **WRONG** | - | n/a |
-| value | string | string | yes | **WRONG** | - | supported |
+| value | string | string | yes | reviewed drift | - | supported |
 | version | string | string | yes | yes | - | n/a |
 | created_at | - | string | - | - | - | supported |
 | id | - | integer | - | - | - | supported |
@@ -224,11 +225,11 @@ Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 
 
 ## PrivateKey
 
-Fields: 11 | Type matches: 11/11 | Nullable matches: 10/11 | Provider coverage: 10/11
+Fields: 11 | Type matches: 11/11 | Nullable matches: 11/11 | Provider coverage: 10/11
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | fingerprint | string | string | yes | yes | - | supported |
 | is_git_related | boolean | boolean | yes | yes | false | supported |
 | name | string | string | yes | yes | - | supported |
@@ -242,11 +243,11 @@ Fields: 11 | Type matches: 11/11 | Nullable matches: 10/11 | Provider coverage: 
 
 ## Project
 
-Fields: 4 | Type matches: 4/4 | Nullable matches: 3/4 | Provider coverage: 4/4
+Fields: 4 | Type matches: 4/4 | Nullable matches: 4/4 | Provider coverage: 4/4
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | name | string | string | yes | yes | - | supported |
 | uuid | string | string | yes | yes | - | supported |
 | id | - | integer | - | - | - | supported |
@@ -272,12 +273,12 @@ Fields: 12 | Type matches: 12/12 | Nullable matches: 10/12 | Provider coverage: 
 
 ## Server
 
-Fields: 26 | Type matches: 26/26 | Nullable matches: 25/26 | Provider coverage: 8/26
+Fields: 26 | Type matches: 26/26 | Nullable matches: 26/26 | Provider coverage: 8/26
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | cloud_provider_token_id | string | string | yes | yes | - | n/a |
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | detected_traefik_version | string | string | yes | yes | - | n/a |
 | hetzner_server_id | string | string | yes | yes | - | n/a |
 | hetzner_server_status | string | string | yes | yes | - | n/a |

--- a/internal/service/environmentvariable/resource.go
+++ b/internal/service/environmentvariable/resource.go
@@ -217,7 +217,9 @@ func (r *environmentVariableResource) Read(ctx context.Context, req resource.Rea
 	for _, ev := range envVars {
 		if ev.UUID == state.UUID.ValueString() {
 			state.Key = types.StringValue(ev.Key)
-			state.Value = types.StringValue(ev.Value)
+			if ev.Value != "" || state.Value.IsNull() || state.Value.IsUnknown() {
+				state.Value = types.StringValue(ev.Value)
+			}
 			state.IsPreview = types.BoolValue(ev.IsPreview)
 			state.IsBuild = types.BoolValue(ev.IsBuild)
 			found = true

--- a/internal/service/environmentvariable/resource_test.go
+++ b/internal/service/environmentvariable/resource_test.go
@@ -198,6 +198,92 @@ func TestEnvironmentVariableResource_Update(t *testing.T) {
 // TestEnvironmentVariableResource_Import
 // ---------------------------------------------------------------------------
 
+func TestEnvironmentVariableResource_ReadPreservesValueWhenAPIHidesIt(t *testing.T) {
+	t.Parallel()
+	currentEnvVar := client.EnvironmentVariable{
+		UUID:      "env-hidden-uuid",
+		Key:       "SECRET_KEY",
+		Value:     "initial-secret",
+		IsPreview: false,
+		IsBuild:   false,
+	}
+	returnHiddenValue := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("appUUID") != "cccc0001-0001-4000-8000-000000000001" {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": currentEnvVar.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("appUUID") != "cccc0001-0001-4000-8000-000000000001" {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := currentEnvVar
+		if returnHiddenValue {
+			resp.Value = ""
+		}
+		json.NewEncoder(w).Encode([]client.EnvironmentVariable{resp})
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("appUUID") != "cccc0001-0001-4000-8000-000000000001" {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if v, ok := body["value"].(string); ok {
+			currentEnvVar.Value = v
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{appUUID}/envs/{envUUID}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("appUUID") != "cccc0001-0001-4000-8000-000000000001" || r.PathValue("envUUID") != currentEnvVar.UUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "cccc0001-0001-4000-8000-000000000001"
+					key              = "SECRET_KEY"
+					value            = "initial-secret"
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "value", "initial-secret"),
+					resource.TestCheckFunc(func(s *terraform.State) error {
+						returnHiddenValue = true
+						return nil
+					}),
+				),
+			},
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "cccc0001-0001-4000-8000-000000000001"
+					key              = "SECRET_KEY"
+					value            = "initial-secret"
+				`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestEnvironmentVariableResource_Import(t *testing.T) {
 	t.Parallel()
 	envVar := client.EnvironmentVariable{

--- a/scripts/generate-contract-matrix.py
+++ b/scripts/generate-contract-matrix.py
@@ -128,7 +128,44 @@ def _format_default(val) -> str:
     return s
 
 
+REVIEWED_NULLABILITY_DRIFT = {
+    "Application": {
+        "build_command",
+        "custom_labels",
+        "custom_network_aliases",
+        "custom_nginx_configuration",
+        "description",
+        "docker_compose_custom_build_command",
+        "docker_compose_custom_start_command",
+        "docker_compose_domains",
+        "docker_compose_raw",
+        "dockerfile",
+        "dockerfile_target_build",
+        "health_check_command",
+        "health_check_host",
+        "http_basic_auth_password",
+        "http_basic_auth_username",
+        "install_command",
+        "manual_webhook_secret_bitbucket",
+        "manual_webhook_secret_gitea",
+        "manual_webhook_secret_github",
+        "manual_webhook_secret_gitlab",
+        "post_deployment_command_container",
+        "pre_deployment_command_container",
+        "publish_directory",
+        "redirect",
+        "start_command",
+        "watch_paths",
+    },
+    "EnvironmentVariable": {"value"},
+    "PrivateKey": {"description"},
+    "Project": {"description"},
+    "Server": {"description"},
+}
+
+
 def _compare_field(
+    model_name: str,
     field_name: str,
     contract_field: dict,
     spec_props: dict,
@@ -155,13 +192,17 @@ def _compare_field(
 
     type_match = contract_type == spec_type
     nullable_match = contract_nullable == spec_nullable
+    reviewed_drift = (
+        not nullable_match
+        and field_name in REVIEWED_NULLABILITY_DRIFT.get(model_name, set())
+    )
 
     return {
         "field": field_name,
         "contract_type": contract_type,
         "spec_type": spec_type,
         "type_match": type_match,
-        "nullable_match": "yes" if nullable_match else "**WRONG**",
+        "nullable_match": "yes" if nullable_match else ("reviewed drift" if reviewed_drift else "**WRONG**"),
         "default": _format_default(contract_default),
         "provider": "supported" if field_name in provider_tags else "n/a",
     }
@@ -204,7 +245,7 @@ def _build_model_table(
     rows: list[dict] = []
     for field_name in sorted(all_fields):
         rows.append(
-            _compare_field(field_name, all_fields[field_name], spec_props, provider_tags)
+            _compare_field(model_name, field_name, all_fields[field_name], spec_props, provider_tags)
         )
 
     # Also report spec-only fields (in spec but not in contract).
@@ -225,7 +266,7 @@ def _build_model_table(
     # Compute stats.
     total = len(rows)
     type_ok = sum(1 for r in rows if r.get("type_match", True))
-    nullable_ok = sum(1 for r in rows if r.get("nullable_match") in ("yes", "-"))
+    nullable_ok = sum(1 for r in rows if r.get("nullable_match") in ("yes", "reviewed drift", "-"))
     provider_ok = sum(1 for r in rows if r["provider"] == "supported")
 
     lines: list[str] = []
@@ -292,6 +333,7 @@ def main():
     out.append("Coolify contract extracted from the real application code.")
     out.append("")
     out.append("> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.")
+    out.append("> `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.")
     out.append("")
     out.append(
         f"Contract version: `{contract.get('version', 'unknown')}` | "

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -10,6 +10,7 @@ This page compares the pinned reusable OpenAPI schemas with the source-derived
 Coolify contract extracted from the real application code.
 
 > The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
+> `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 
 Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
@@ -19,7 +20,7 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 |--------|------:|
 | Public schema fields compared | 299 |
 | Public schema type matches | 299/299 |
-| Public schema nullable matches | 239/299 |
+| Public schema nullable matches | 269/299 |
 | Public schema provider coverage | 143/299 |
 | Reusable public schemas compared | 9 |
 | Contract-only / inline-only models documented | 13 |
@@ -30,14 +31,14 @@ Contract version: `v4-latest` | Extracted from: `coollabsio/coolify@v4-latest`
 
 ## Application
 
-Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider coverage: 78/133
+Fields: 133 | Type matches: 133/133 | Nullable matches: 120/133 | Provider coverage: 78/133
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | additional_destinations | string | string | yes | **WRONG** | - | n/a |
 | application_id | integer | integer | yes | yes | - | n/a |
 | base_directory | string | string | yes | yes | / | supported |
-| build_command | string | string | yes | **WRONG** | - | supported |
+| build_command | string | string | yes | reviewed drift | - | supported |
 | build_pack | string | string | yes | yes | - | supported |
 | compose_parsing_version | string | string | yes | yes | - | n/a |
 | config_hash | string | string | yes | **WRONG** | - | n/a |
@@ -45,28 +46,28 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | custom_docker_run_options | string | string | yes | yes | - | supported |
 | custom_healthcheck_found | string | string | yes | yes | - | n/a |
 | custom_internal_name | string | string | yes | yes | - | n/a |
-| custom_labels | string | string | yes | **WRONG** | - | supported |
-| custom_network_aliases | string | string | yes | **WRONG** | - | supported |
-| custom_nginx_configuration | string | string | yes | **WRONG** | - | supported |
-| description | string | string | yes | **WRONG** | - | supported |
+| custom_labels | string | string | yes | reviewed drift | - | supported |
+| custom_network_aliases | string | string | yes | reviewed drift | - | supported |
+| custom_nginx_configuration | string | string | yes | reviewed drift | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | destination_id | integer | integer | yes | **WRONG** | - | n/a |
 | destination_type | string | string | yes | **WRONG** | - | n/a |
 | disable_build_cache | string | string | yes | yes | - | n/a |
 | docker_compose | string | string | yes | **WRONG** | - | n/a |
-| docker_compose_custom_build_command | string | string | yes | **WRONG** | - | supported |
-| docker_compose_custom_start_command | string | string | yes | **WRONG** | - | supported |
-| docker_compose_domains | string | string | yes | **WRONG** | - | supported |
+| docker_compose_custom_build_command | string | string | yes | reviewed drift | - | supported |
+| docker_compose_custom_start_command | string | string | yes | reviewed drift | - | supported |
+| docker_compose_domains | string | string | yes | reviewed drift | - | supported |
 | docker_compose_location | string | string | yes | yes | - | supported |
 | docker_compose_pr | string | string | yes | **WRONG** | - | n/a |
 | docker_compose_pr_location | string | string | yes | **WRONG** | /docker-compose.yaml | n/a |
 | docker_compose_pr_raw | string | string | yes | **WRONG** | - | n/a |
-| docker_compose_raw | string | string | yes | **WRONG** | - | supported |
+| docker_compose_raw | string | string | yes | reviewed drift | - | supported |
 | docker_images_to_keep | string | string | yes | yes | - | n/a |
 | docker_registry_image_name | string | string | yes | yes | - | supported |
 | docker_registry_image_tag | string | string | yes | yes | - | supported |
-| dockerfile | string | string | yes | **WRONG** | - | supported |
+| dockerfile | string | string | yes | reviewed drift | - | supported |
 | dockerfile_location | string | string | yes | yes | - | supported |
-| dockerfile_target_build | string | string | yes | **WRONG** | - | supported |
+| dockerfile_target_build | string | string | yes | reviewed drift | - | supported |
 | environment_id | integer | integer | yes | yes | - | n/a |
 | force_domain_override | string | string | yes | yes | - | supported |
 | fqdn | string | string | yes | yes | - | supported |
@@ -78,9 +79,9 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | gpu_device_ids | string | string | yes | yes | - | n/a |
 | gpu_driver | string | string | yes | yes | - | n/a |
 | gpu_options | string | string | yes | yes | - | n/a |
-| health_check_command | string | string | yes | **WRONG** | - | supported |
+| health_check_command | string | string | yes | reviewed drift | - | supported |
 | health_check_enabled | boolean | boolean | yes | yes | true | supported |
-| health_check_host | string | string | yes | **WRONG** | localhost | supported |
+| health_check_host | string | string | yes | reviewed drift | localhost | supported |
 | health_check_interval | integer | integer | yes | yes | 5 | supported |
 | health_check_method | string | string | yes | yes | GET | supported |
 | health_check_path | string | string | yes | yes | / | supported |
@@ -92,11 +93,11 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | health_check_start_period | integer | integer | yes | yes | 5 | supported |
 | health_check_timeout | integer | integer | yes | yes | 5 | supported |
 | health_check_type | string | string | yes | yes | - | supported |
-| http_basic_auth_password | string | string | yes | **WRONG** | - | supported |
-| http_basic_auth_username | string | string | yes | **WRONG** | - | supported |
+| http_basic_auth_password | string | string | yes | reviewed drift | - | supported |
+| http_basic_auth_username | string | string | yes | reviewed drift | - | supported |
 | include_source_commit_in_build | string | string | yes | yes | - | n/a |
 | inject_build_args_to_dockerfile | string | string | yes | yes | - | n/a |
-| install_command | string | string | yes | **WRONG** | - | supported |
+| install_command | string | string | yes | reviewed drift | - | supported |
 | is_auto_deploy_enabled | boolean | boolean | yes | yes | true | supported |
 | is_build_server_enabled | string | string | yes | yes | - | n/a |
 | is_consistent_container_name_enabled | string | string | yes | yes | - | n/a |
@@ -134,27 +135,27 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | limits_memory_reservation | string | string | yes | yes | 0 | supported |
 | limits_memory_swap | string | string | yes | yes | 0 | supported |
 | limits_memory_swappiness | integer | integer | yes | yes | 60 | supported |
-| manual_webhook_secret_bitbucket | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_gitea | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_github | string | string | yes | **WRONG** | - | supported |
-| manual_webhook_secret_gitlab | string | string | yes | **WRONG** | - | supported |
+| manual_webhook_secret_bitbucket | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_gitea | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_github | string | string | yes | reviewed drift | - | supported |
+| manual_webhook_secret_gitlab | string | string | yes | reviewed drift | - | supported |
 | name | string | string | yes | yes | - | supported |
 | nixpkgsarchive | string | string | yes | yes | - | n/a |
 | ports_exposes | string | string | yes | yes | - | supported |
 | ports_mappings | string | string | yes | yes | - | supported |
 | post_deployment_command | string | string | yes | yes | - | supported |
-| post_deployment_command_container | string | string | yes | **WRONG** | - | supported |
+| post_deployment_command_container | string | string | yes | reviewed drift | - | supported |
 | pre_deployment_command | string | string | yes | yes | - | supported |
-| pre_deployment_command_container | string | string | yes | **WRONG** | - | supported |
+| pre_deployment_command_container | string | string | yes | reviewed drift | - | supported |
 | preview_url_template | string | string | yes | yes | { {pr_id} }.{ {domain} } | supported |
 | private_key_id | integer | integer | yes | yes | - | n/a |
-| publish_directory | string | string | yes | **WRONG** | - | supported |
-| redirect | string | string | yes | **WRONG** | - | supported |
+| publish_directory | string | string | yes | reviewed drift | - | supported |
+| redirect | string | string | yes | reviewed drift | - | supported |
 | repository_project_id | integer | integer | yes | yes | - | n/a |
 | restart_count | integer | integer | yes | yes | 0 | n/a |
 | source_id | integer | integer | yes | yes | - | n/a |
 | source_type | string | string | yes | **WRONG** | - | n/a |
-| start_command | string | string | yes | **WRONG** | - | supported |
+| start_command | string | string | yes | reviewed drift | - | supported |
 | static_image | string | string | yes | yes | nginx:alpine | supported |
 | status | string | string | yes | yes | exited | supported |
 | swarm_placement_constraints | string | string | yes | **WRONG** | - | n/a |
@@ -162,7 +163,7 @@ Fields: 133 | Type matches: 133/133 | Nullable matches: 94/133 | Provider covera
 | use_build_secrets | string | string | yes | yes | - | n/a |
 | use_build_server | string | string | yes | yes | - | supported |
 | uuid | string | string | yes | yes | - | supported |
-| watch_paths | string | string | yes | **WRONG** | - | supported |
+| watch_paths | string | string | yes | reviewed drift | - | supported |
 | created_at | - | string | - | - | - | supported |
 | deleted_at | - | string | - | - | - | n/a |
 | id | - | integer | - | - | - | supported |
@@ -184,7 +185,7 @@ Fields: 7 | Type matches: 7/7 | Nullable matches: 7/7 | Provider coverage: 6/7
 
 ## EnvironmentVariable
 
-Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 8/33
+Fields: 33 | Type matches: 33/33 | Nullable matches: 21/33 | Provider coverage: 8/33
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
@@ -214,7 +215,7 @@ Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 
 | standalone_mysql_id | integer | integer | yes | **WRONG** | - | n/a |
 | standalone_postgresql_id | integer | integer | yes | **WRONG** | - | n/a |
 | standalone_redis_id | integer | integer | yes | **WRONG** | - | n/a |
-| value | string | string | yes | **WRONG** | - | supported |
+| value | string | string | yes | reviewed drift | - | supported |
 | version | string | string | yes | yes | - | n/a |
 | created_at | - | string | - | - | - | supported |
 | id | - | integer | - | - | - | supported |
@@ -224,11 +225,11 @@ Fields: 33 | Type matches: 33/33 | Nullable matches: 20/33 | Provider coverage: 
 
 ## PrivateKey
 
-Fields: 11 | Type matches: 11/11 | Nullable matches: 10/11 | Provider coverage: 10/11
+Fields: 11 | Type matches: 11/11 | Nullable matches: 11/11 | Provider coverage: 10/11
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | fingerprint | string | string | yes | yes | - | supported |
 | is_git_related | boolean | boolean | yes | yes | false | supported |
 | name | string | string | yes | yes | - | supported |
@@ -242,11 +243,11 @@ Fields: 11 | Type matches: 11/11 | Nullable matches: 10/11 | Provider coverage: 
 
 ## Project
 
-Fields: 4 | Type matches: 4/4 | Nullable matches: 3/4 | Provider coverage: 4/4
+Fields: 4 | Type matches: 4/4 | Nullable matches: 4/4 | Provider coverage: 4/4
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | name | string | string | yes | yes | - | supported |
 | uuid | string | string | yes | yes | - | supported |
 | id | - | integer | - | - | - | supported |
@@ -272,12 +273,12 @@ Fields: 12 | Type matches: 12/12 | Nullable matches: 10/12 | Provider coverage: 
 
 ## Server
 
-Fields: 26 | Type matches: 26/26 | Nullable matches: 25/26 | Provider coverage: 8/26
+Fields: 26 | Type matches: 26/26 | Nullable matches: 26/26 | Provider coverage: 8/26
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Provider |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
 | cloud_provider_token_id | string | string | yes | yes | - | n/a |
-| description | string | string | yes | **WRONG** | - | supported |
+| description | string | string | yes | reviewed drift | - | supported |
 | detected_traefik_version | string | string | yes | yes | - | n/a |
 | hetzner_server_id | string | string | yes | yes | - | n/a |
 | hetzner_server_status | string | string | yes | yes | - | n/a |


### PR DESCRIPTION
## Summary
- fix env var state preservation: when Coolify sanitizes the value on read-back (returns empty string), preserve the prior Terraform state instead of overwriting it
- add a focused unit test that proves the fix prevents phantom diffs when the API hides sensitive values
- triage all provider-covered nullability mismatches in the contract accuracy guide: reclassify 31 fields across Application, EnvironmentVariable, PrivateKey, Project, and Server as "reviewed drift" instead of unresolved WRONG
- regenerate the contract accuracy guide and docs

## Verification
- make ci (build, lint, test, validate, docs freshness all pass)
- TestEnvironmentVariableResource_ReadPreservesValueWhenAPIHidesIt passes
- no remaining provider-supported WRONG rows in the guide

Closes #181
