### PR TITLE
Add redis_password field to Redis database resource

### DIFF
--- a/docs/resources/redis_database.md
+++ b/docs/resources/redis_database.md
@@ -13,11 +13,17 @@ Manages a Redis database resource on Coolify.
 ## Example Usage
 
 ```terraform
+variable "redis_password" {
+  type      = string
+  sensitive = true
+}
+
 resource "coolify_redis_database" "example" {
-  name         = "my-redis"
-  project_uuid = coolify_project.example.uuid
-  server_uuid  = coolify_server.example.uuid
-  image        = "redis:7"
+  name           = "my-redis"
+  project_uuid   = coolify_project.example.uuid
+  server_uuid    = coolify_server.example.uuid
+  image          = "redis:7"
+  redis_password = var.redis_password
 }
 ```
 
@@ -48,6 +54,7 @@ resource "coolify_redis_database" "example" {
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `redis_conf` (String) Custom Redis configuration (base64-encoded `redis.conf` content).
+- `redis_password` (String, Sensitive) The Redis authentication password. Stored as an encrypted environment variable in Coolify.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/examples/resources/coolify_redis_database/resource.tf
+++ b/examples/resources/coolify_redis_database/resource.tf
@@ -1,6 +1,12 @@
+variable "redis_password" {
+  type      = string
+  sensitive = true
+}
+
 resource "coolify_redis_database" "example" {
-  name         = "my-redis"
-  project_uuid = coolify_project.example.uuid
-  server_uuid  = coolify_server.example.uuid
-  image        = "redis:7"
+  name           = "my-redis"
+  project_uuid   = coolify_project.example.uuid
+  server_uuid    = coolify_server.example.uuid
+  image          = "redis:7"
+  redis_password = var.redis_password
 }

--- a/internal/client/databases.go
+++ b/internal/client/databases.go
@@ -57,6 +57,7 @@ type Database struct {
 	MariadbConf            string `json:"mariadb_conf,omitempty"`
 	MongoConf              string `json:"mongo_conf,omitempty"`
 	RedisConf              string `json:"redis_conf,omitempty"`
+	RedisPassword          string `json:"redis_password,omitempty"`
 	ClickhouseDB           string `json:"clickhouse_db,omitempty"`
 	KeydbConf              string `json:"keydb_conf,omitempty"`
 	KeydbPassword          string `json:"keydb_password,omitempty"`
@@ -114,6 +115,7 @@ type CreateRedisInput struct {
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
 	Image           string `json:"image,omitempty"`
+	RedisPassword   string `json:"redis_password,omitempty"`
 	IsPublic        *bool  `json:"is_public,omitempty"`
 	PublicPort      *int64 `json:"public_port,omitempty"`
 }
@@ -211,6 +213,7 @@ type UpdateDatabaseInput struct {
 	MariadbConf            *string `json:"mariadb_conf,omitempty"`
 	MongoConf              *string `json:"mongo_conf,omitempty"`
 	RedisConf              *string `json:"redis_conf,omitempty"`
+	RedisPassword          *string `json:"redis_password,omitempty"`
 	ClickhouseDB           *string `json:"clickhouse_db,omitempty"`
 	KeydbConf              *string `json:"keydb_conf,omitempty"`
 	KeydbPassword          *string `json:"keydb_password,omitempty"`

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -24,7 +24,8 @@ type res struct{ client *client.Client }
 type model struct {
 	pg.CommonModel
 	// Type-specific
-	RedisConf types.String `tfsdk:"redis_conf"`
+	RedisPassword types.String `tfsdk:"redis_password"`
+	RedisConf     types.String `tfsdk:"redis_conf"`
 }
 
 func NewResource() resource.Resource { return &res{} }
@@ -33,7 +34,8 @@ func (r *res) Metadata(_ context.Context, req resource.MetadataRequest, resp *re
 }
 func (r *res) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{MarkdownDescription: "Manages a Redis database resource on Coolify.", Attributes: pg.CommonDatabaseAttrs(ctx, map[string]schema.Attribute{
-		"redis_conf": schema.StringAttribute{MarkdownDescription: "Custom Redis configuration (base64-encoded `redis.conf` content).", Optional: true},
+		"redis_password": schema.StringAttribute{MarkdownDescription: "The Redis authentication password. Stored as an encrypted environment variable in Coolify.", Optional: true, Computed: true, Sensitive: true},
+		"redis_conf":     schema.StringAttribute{MarkdownDescription: "Custom Redis configuration (base64-encoded `redis.conf` content).", Optional: true},
 	})}
 }
 func (r *res) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -58,6 +60,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)
+	flex.SetIfKnown(&in.RedisPassword, p.RedisPassword)
 	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
 	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
 	c, err := r.client.CreateDatabase(ctx, "redis", in)
@@ -69,6 +72,7 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 
 	p.UUID = types.StringValue(c.UUID)
 	pg.NormalizeCommonCreateState(&p.CommonModel)
+	pg.NormalizeUnknownString(&p.RedisPassword)
 	pg.NormalizeUnknownString(&p.RedisConf)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
 	if resp.Diagnostics.HasError() {
@@ -129,12 +133,13 @@ func (r *res) Update(ctx context.Context, req resource.UpdateRequest, resp *reso
 	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_redis_database", "uuid": s.UUID.ValueString()})
 
 	u := client.UpdateDatabaseInput{
-		Name:        flex.StringIfChanged(p.Name, s.Name),
-		Description: flex.StringIfChanged(p.Description, s.Description),
-		Image:       flex.StringIfChanged(p.Image, s.Image),
-		IsPublic:    flex.BoolIfChanged(p.IsPublic, s.IsPublic),
-		PublicPort:  flex.Int64IfChanged(p.PublicPort, s.PublicPort),
-		RedisConf:   flex.StringIfChanged(p.RedisConf, s.RedisConf),
+		Name:          flex.StringIfChanged(p.Name, s.Name),
+		Description:   flex.StringIfChanged(p.Description, s.Description),
+		Image:         flex.StringIfChanged(p.Image, s.Image),
+		IsPublic:      flex.BoolIfChanged(p.IsPublic, s.IsPublic),
+		PublicPort:    flex.Int64IfChanged(p.PublicPort, s.PublicPort),
+		RedisPassword: flex.StringIfChanged(p.RedisPassword, s.RedisPassword),
+		RedisConf:     flex.StringIfChanged(p.RedisConf, s.RedisConf),
 	}
 	pg.SetUpdateExtendedDiff(&u, p.ExtFields(), s.ExtFields())
 	db, err := pg.UpdateDatabase(ctx, r.client, s.UUID.ValueString(), u)
@@ -164,5 +169,8 @@ func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, 
 func flattenDatabase(db *client.Database, m *model) {
 	pg.FlattenDatabaseCommon(db, m.CommonPtrs())
 	pg.FlattenDatabaseExtended(db, m.ExtFields())
+	if db.RedisPassword != "" {
+		m.RedisPassword = types.StringValue(db.RedisPassword)
+	}
 	flex.SetStringIfConfigured(&m.RedisConf, db.RedisConf)
 }

--- a/internal/service/database/redis/resource_test.go
+++ b/internal/service/database/redis/resource_test.go
@@ -16,19 +16,21 @@ import (
 )
 
 type mockRedisState struct {
-	mu          sync.Mutex
-	uuid        string
-	name        string
-	description string
-	image       string
-	deleted     bool
+	mu            sync.Mutex
+	uuid          string
+	name          string
+	description   string
+	image         string
+	redisPassword string
+	deleted       bool
 }
 
 func newMockRedisServer() (*httptest.Server, *mockRedisState) {
 	state := &mockRedisState{
-		uuid:  "aaaa0001-0001-4000-8000-000000000001",
-		name:  "redis-test-db",
-		image: "redis:7",
+		uuid:          "aaaa0001-0001-4000-8000-000000000001",
+		name:          "redis-test-db",
+		image:         "redis:7",
+		redisPassword: "default-redis-pass",
 	}
 
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,6 +58,7 @@ func newMockRedisServer() (*httptest.Server, *mockRedisState) {
 				"image":                     state.image,
 				"is_public":                 false,
 				"public_port":               nil,
+				"redis_password":            state.redisPassword,
 				"limits_memory":             "0",
 				"limits_memory_swap":        "0",
 				"limits_memory_swappiness":  60,
@@ -73,6 +76,9 @@ func newMockRedisServer() (*httptest.Server, *mockRedisState) {
 			}
 			if v, ok := body["description"].(string); ok {
 				state.description = v
+			}
+			if v, ok := body["redis_password"].(string); ok {
+				state.redisPassword = v
 			}
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]string{"message": "updated"})
@@ -185,6 +191,7 @@ func TestRedisDatabaseResource_CreateReadBackFailurePreservesState(t *testing.T)
 				"environment_name":          "production",
 				"image":                     "redis:7",
 				"is_public":                 false,
+				"redis_password":            "default-redis-pass",
 				"limits_memory":             "0",
 				"limits_memory_swap":        "0",
 				"limits_memory_swappiness":  60,
@@ -251,6 +258,7 @@ func TestRedisDatabaseResource_Disappears(t *testing.T) {
 				"environment_name":          "production",
 				"image":                     "redis:7",
 				"is_public":                 false,
+				"redis_password":            "default-redis-pass",
 				"limits_memory":             "0",
 				"limits_memory_swap":        "0",
 				"limits_memory_swappiness":  60,


### PR DESCRIPTION
## Summary

Add the `redis_password` attribute to `coolify_redis_database`, completing full API parity across all 8 database types.

## Changes

- **Client**: Add `RedisPassword` to `Database`, `CreateRedisInput`, and `UpdateDatabaseInput` structs
- **Resource**: Add `redis_password` schema attribute (Sensitive, Optional, Computed), wire through Create, Update, Read, and flatten
- **Tests**: Update all 3 mock servers to include `redis_password` in GET responses and PATCH handling
- **Example**: Add `redis_password` with variable to example HCL
- **Docs**: Regenerated

## Context

Coolify stores Redis passwords as encrypted environment variables via an Eloquent accessor on the `StandaloneRedis` model. The API accepts `redis_password` in both create and update `allowedFields`. This was the last missing database-specific field; all other types (PostgreSQL, MySQL, MariaDB, MongoDB, ClickHouse, KeyDB, Dragonfly) already had full field coverage.