### PR TITLE
Add CreateReadBackFailure resilience tests for application types

### DIFF
--- a/internal/service/application/resource_docker_test.go
+++ b/internal/service/application/resource_docker_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -497,6 +498,69 @@ func TestDockerImageApplicationResource_InvalidFQDN(t *testing.T) {
 				ExpectError: regexp.MustCompile(`must be a valid URL starting with http:// or https://`),
 			},
 		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestDockerImageApplicationResource_CreateReadBackFailurePreservesState
+// ---------------------------------------------------------------------------
+
+func TestDockerImageApplicationResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+
+	const appUUID = "docker-readback-fail-uuid"
+
+	var forceReadFailure atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/dockerimage", func(w http.ResponseWriter, r *http.Request) {
+		forceReadFailure.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": appUUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		if forceReadFailure.Load() {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(client.Application{
+			UUID:                    appUUID,
+			Name:                    "docker-readback",
+			DockerRegistryImageName: "nginx:latest",
+			PortsExposes:            "80",
+			ProjectUUID:             "aaaa0002-0002-4000-8000-000000000002",
+			ServerUUID:              "bbbb0002-0002-4000-8000-000000000002",
+			EnvironmentName:         "production",
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testDockerImageResourceConfig(srv.URL, `
+				project_uuid  = "aaaa0002-0002-4000-8000-000000000002"
+				server_uuid   = "bbbb0002-0002-4000-8000-000000000002"
+				docker_image  = "nginx:latest"
+				ports_exposes = "80"
+			`),
+			ExpectError: regexp.MustCompile(`(?s)Application created but refresh failed.*Could not read application.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/application/resource_github_app_test.go
+++ b/internal/service/application/resource_github_app_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -385,6 +387,74 @@ func TestGitHubAppApplicationResource_Disappears(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestGitHubAppApplicationResource_CreateReadBackFailurePreservesState
+// ---------------------------------------------------------------------------
+
+func TestGitHubAppApplicationResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+
+	const appUUID = "ghapp-readback-fail-uuid"
+
+	var forceReadFailure atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/private-github-app", func(w http.ResponseWriter, r *http.Request) {
+		forceReadFailure.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": appUUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		if forceReadFailure.Load() {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(client.Application{
+			UUID:            appUUID,
+			Name:            "ghapp-readback",
+			GitRepository:   "github.com/org/repo",
+			GitBranch:       "main",
+			BuildPack:       "nixpacks",
+			PortsExposes:    "3000",
+			ProjectUUID:     "aaaa0001-0001-4000-8000-000000000001",
+			ServerUUID:      "bbbb0001-0001-4000-8000-000000000001",
+			EnvironmentName: "production",
+			GitHubAppUUID:   "cccc0001-0001-4000-8000-000000000001",
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testGitHubAppResourceConfig(srv.URL, `
+				project_uuid    = "aaaa0001-0001-4000-8000-000000000001"
+				server_uuid     = "bbbb0001-0001-4000-8000-000000000001"
+				github_app_uuid = "cccc0001-0001-4000-8000-000000000001"
+				git_repository  = "github.com/org/repo"
+				build_pack      = "nixpacks"
+				ports_exposes   = "3000"
+			`),
+			ExpectError: regexp.MustCompile(`(?s)Application created but refresh failed.*Could not read application.*partial Terraform state was saved`),
+		}},
 	})
 }
 

--- a/internal/service/application/resource_private_git_test.go
+++ b/internal/service/application/resource_private_git_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SebTardifLabs/terraform-provider-coolify/internal/acctest"
@@ -499,6 +500,74 @@ func TestPrivateGitApplicationResource_InvalidBuildPack(t *testing.T) {
 				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestPrivateGitApplicationResource_CreateReadBackFailurePreservesState
+// ---------------------------------------------------------------------------
+
+func TestPrivateGitApplicationResource_CreateReadBackFailurePreservesState(t *testing.T) {
+	t.Parallel()
+
+	const appUUID = "pgit-readback-fail-uuid"
+
+	var forceReadFailure atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/private-deploy-key", func(w http.ResponseWriter, r *http.Request) {
+		forceReadFailure.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": appUUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		if forceReadFailure.Load() {
+			http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(client.Application{
+			UUID:            appUUID,
+			Name:            "pgit-readback",
+			GitRepository:   "git@github.com:org/repo.git",
+			GitBranch:       "main",
+			BuildPack:       "nixpacks",
+			PortsExposes:    "3000",
+			ProjectUUID:     "aaaa0002-0002-4000-8000-000000000002",
+			ServerUUID:      "bbbb0002-0002-4000-8000-000000000002",
+			EnvironmentName: "production",
+			PrivateKeyUUID:  "dddd0001-0001-4000-8000-000000000001",
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testPrivateGitResourceConfig(srv.URL, `
+				project_uuid     = "aaaa0002-0002-4000-8000-000000000002"
+				server_uuid      = "bbbb0002-0002-4000-8000-000000000002"
+				git_repository   = "git@github.com:org/repo.git"
+				private_key_uuid = "dddd0001-0001-4000-8000-000000000001"
+				build_pack       = "nixpacks"
+				ports_exposes    = "3000"
+			`),
+			ExpectError: regexp.MustCompile(`(?s)Application created but refresh failed.*Could not read application.*partial Terraform state was saved`),
+		}},
 	})
 }
 


### PR DESCRIPTION
## Summary

Add `CreateReadBackFailurePreservesState` tests for the 3 application resource types that were missing them: docker_image, github_app, and private_git.

## What these tests verify

When the Coolify API's POST (create) succeeds but the follow-up GET (read-back) returns 500, the provider must:
1. Save partial state (so the resource is tracked)
2. Report an actionable error (`Application created but refresh failed...partial Terraform state was saved`)
3. Allow the user to recover with `terraform refresh` or `terraform import`

## Packages audited but skipped

4 other resources were audited and correctly found to not need this test:
- **environment_variable**: Sets state directly from plan values (no read-back GET)
- **github_app** (config resource): POST returns the created object; no separate GET
- **scheduled_task**: Sets state directly from create response
- **storage**: Sets state directly from create response

## Test count

574 -> 577 tests