### PR TITLE
Add resource_uuid to enable service storage creation

### DIFF
--- a/docs/resources/storage.md
+++ b/docs/resources/storage.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   Manages a persistent storage volume on a Coolify application, service, or database.
   ~> Note: Each instance requires a List API call to read because the Coolify API does not provide a singular GET endpoint for storage volumes. Large numbers of these resources on a single parent resource may cause slower plan/apply times due to this API limitation.
-  ~> Note: Creating new service-backed storages is not currently supported because the Coolify service storage create API requires an additional nested resource UUID. You can still import and manage existing service-backed storages by service_uuid.
 ---
 
 # coolify_storage (Resource)
@@ -13,8 +12,6 @@ description: |-
 Manages a persistent storage volume on a Coolify application, service, or database.
 
 ~> **Note:** Each instance requires a List API call to read because the Coolify API does not provide a singular GET endpoint for storage volumes. Large numbers of these resources on a single parent resource may cause slower plan/apply times due to this API limitation.
-
-~> **Note:** Creating new service-backed storages is not currently supported because the Coolify service storage create API requires an additional nested resource UUID. You can still import and manage existing service-backed storages by `service_uuid`.
 
 ## Example Usage
 
@@ -48,6 +45,7 @@ resource "coolify_storage" "db_data" {
 - `application_uuid` (String) The UUID of the application to attach the storage to. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. Changing this forces a new resource.
 - `database_uuid` (String) The UUID of the database to attach the storage to. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. Changing this forces a new resource.
 - `host_path` (String) The host path to mount (optional; leave empty for a Docker volume).
+- `resource_uuid` (String) The UUID of the nested application or database inside a service. Required when `service_uuid` is set because Coolify services contain multiple sub-resources and the storage must target a specific one. Ignored for `application_uuid` and `database_uuid`. Changing this forces a new resource.
 - `service_uuid` (String) The UUID of the service that owns the storage. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. New service-backed storages cannot currently be created with this resource because the Coolify create API requires an additional nested resource UUID. Use this for importing or managing an existing service storage. Changing this forces a new resource.
 
 ### Read-Only

--- a/internal/client/storages.go
+++ b/internal/client/storages.go
@@ -9,10 +9,12 @@ import (
 
 // Storage represents a persistent storage volume in Coolify.
 type Storage struct {
-	UUID      string `json:"uuid"`
-	Name      string `json:"name"`
-	MountPath string `json:"mount_path"`
-	HostPath  string `json:"host_path,omitempty"`
+	UUID         string `json:"uuid"`
+	Name         string `json:"name"`
+	MountPath    string `json:"mount_path"`
+	HostPath     string `json:"host_path,omitempty"`
+	ResourceUUID string `json:"resource_uuid,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
 }
 
 // storageListResponse wraps the API response which nests storages by type.
@@ -23,10 +25,11 @@ type storageListResponse struct {
 
 // CreateStorageInput is the payload for creating a new persistent storage.
 type CreateStorageInput struct {
-	Type      string `json:"type"`
-	Name      string `json:"name"`
-	MountPath string `json:"mount_path"`
-	HostPath  string `json:"host_path,omitempty"`
+	Type         string `json:"type"`
+	ResourceUUID string `json:"resource_uuid,omitempty"`
+	Name         string `json:"name"`
+	MountPath    string `json:"mount_path"`
+	HostPath     string `json:"host_path,omitempty"`
 }
 
 // CreateStorageResponse is the response from creating a persistent storage.

--- a/internal/service/storage/resource.go
+++ b/internal/service/storage/resource.go
@@ -37,6 +37,7 @@ type storageResourceModel struct {
 	ApplicationUUID types.String `tfsdk:"application_uuid"`
 	ServiceUUID     types.String `tfsdk:"service_uuid"`
 	DatabaseUUID    types.String `tfsdk:"database_uuid"`
+	ResourceUUID    types.String `tfsdk:"resource_uuid"`
 	Name            types.String `tfsdk:"name"`
 	MountPath       types.String `tfsdk:"mount_path"`
 	HostPath        types.String `tfsdk:"host_path"`
@@ -56,10 +57,7 @@ func (r *storageResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		MarkdownDescription: "Manages a persistent storage volume on a Coolify application, service, or database.\n\n" +
 			"~> **Note:** Each instance requires a List API call to read because the Coolify API does not " +
 			"provide a singular GET endpoint for storage volumes. Large numbers of these resources " +
-			"on a single parent resource may cause slower plan/apply times due to this API limitation.\n\n" +
-			"~> **Note:** Creating new service-backed storages is not currently supported because the " +
-			"Coolify service storage create API requires an additional nested resource UUID. You can " +
-			"still import and manage existing service-backed storages by `service_uuid`.",
+			"on a single parent resource may cause slower plan/apply times due to this API limitation.",
 		Attributes: map[string]schema.Attribute{
 			"uuid": schema.StringAttribute{
 				MarkdownDescription: "The unique identifier of the persistent storage.",
@@ -95,6 +93,16 @@ func (r *storageResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{validate.UUID()},
+			},
+			"resource_uuid": schema.StringAttribute{
+				MarkdownDescription: "The UUID of the nested application or database inside a service. Required when `service_uuid` is set because Coolify services contain multiple sub-resources and the storage must target a specific one. Ignored for `application_uuid` and `database_uuid`. Changing this forces a new resource.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{validate.UUID()},
 			},
@@ -153,11 +161,13 @@ func (r *storageResource) Create(ctx context.Context, req resource.CreateRequest
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_storage"})
 
 	if !plan.ServiceUUID.IsNull() && !plan.ServiceUUID.IsUnknown() {
-		resp.Diagnostics.AddError(
-			"Service-backed storage creation is not supported",
-			"Coolify's service storage create API requires an additional nested resource UUID that this resource does not model yet. Import an existing service storage if you need to manage one, or use application_uuid or database_uuid when creating a new storage.",
-		)
-		return
+		if plan.ResourceUUID.IsNull() || plan.ResourceUUID.IsUnknown() {
+			resp.Diagnostics.AddError(
+				"Missing resource_uuid for service storage",
+				"When creating storage on a service, resource_uuid must be set to the UUID of the nested application or database inside the service.",
+			)
+			return
+		}
 	}
 
 	parentType, parentUUID, ok := resolveParent(&plan)
@@ -172,6 +182,7 @@ func (r *storageResource) Create(ctx context.Context, req resource.CreateRequest
 		MountPath: plan.MountPath.ValueString(),
 	}
 	flex.SetIfKnown(&input.HostPath, plan.HostPath)
+	flex.SetIfKnown(&input.ResourceUUID, plan.ResourceUUID)
 
 	createResp, err := r.client.CreateStorage(ctx, parentType, parentUUID, input)
 	if err != nil {
@@ -180,6 +191,9 @@ func (r *storageResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	plan.UUID = types.StringValue(createResp.UUID)
+	if plan.ResourceUUID.IsUnknown() {
+		plan.ResourceUUID = types.StringNull()
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -228,6 +242,9 @@ func (r *storageResource) Read(ctx context.Context, req resource.ReadRequest, re
 				// keep null if it was null before and API returns empty
 			} else {
 				state.HostPath = types.StringNull()
+			}
+			if s.ResourceUUID != "" {
+				state.ResourceUUID = types.StringValue(s.ResourceUUID)
 			}
 			found = true
 			break

--- a/internal/service/storage/resource.go
+++ b/internal/service/storage/resource.go
@@ -222,36 +222,7 @@ func (r *storageResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	found := false
-	for _, s := range storages {
-		if s.UUID == state.UUID.ValueString() {
-			// Coolify prefixes storage names with an internal resource UUID
-			// (for example, "resource-uuid-my-storage"). Preserve the
-			// user's original name to avoid a perpetual diff.
-			apiName := s.Name
-			stateName := state.Name.ValueString()
-			if stateName != "" && apiName != stateName && strings.HasSuffix(apiName, "-"+stateName) {
-				apiName = stateName
-			}
-			state.Name = types.StringValue(apiName)
-			state.MountPath = types.StringValue(s.MountPath)
-			//nolint:gocritic // preserves null vs empty distinction for optional field
-			if s.HostPath != "" {
-				state.HostPath = types.StringValue(s.HostPath)
-			} else if state.HostPath.IsNull() {
-				// keep null if it was null before and API returns empty
-			} else {
-				state.HostPath = types.StringNull()
-			}
-			if s.ResourceUUID != "" {
-				state.ResourceUUID = types.StringValue(s.ResourceUUID)
-			}
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !flattenStorageFromList(storages, &state) {
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -319,6 +290,37 @@ func (r *storageResource) Delete(ctx context.Context, req resource.DeleteRequest
 		resp.Diagnostics.AddError("Error deleting persistent storage", fmt.Sprintf("storage %s: %s", state.UUID.ValueString(), err))
 		return
 	}
+}
+
+// flattenStorageFromList finds the storage matching state.UUID in the list
+// and updates the state model. Returns false if not found.
+func flattenStorageFromList(storages []client.Storage, state *storageResourceModel) bool {
+	for _, s := range storages {
+		if s.UUID != state.UUID.ValueString() {
+			continue
+		}
+		// Coolify prefixes storage names with an internal resource UUID
+		// (for example, "resource-uuid-my-storage"). Preserve the
+		// user's original name to avoid a perpetual diff.
+		apiName := s.Name
+		stateName := state.Name.ValueString()
+		if stateName != "" && apiName != stateName && strings.HasSuffix(apiName, "-"+stateName) {
+			apiName = stateName
+		}
+		state.Name = types.StringValue(apiName)
+		state.MountPath = types.StringValue(s.MountPath)
+		//nolint:gocritic // preserves null vs empty distinction for optional field
+		if s.HostPath != "" {
+			state.HostPath = types.StringValue(s.HostPath)
+		} else if !state.HostPath.IsNull() {
+			state.HostPath = types.StringNull()
+		}
+		if s.ResourceUUID != "" {
+			state.ResourceUUID = types.StringValue(s.ResourceUUID)
+		}
+		return true
+	}
+	return false
 }
 
 func (r *storageResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/storage/resource_test.go
+++ b/internal/service/storage/resource_test.go
@@ -373,7 +373,7 @@ func TestStorageResource_ImportBadType(t *testing.T) {
 	})
 }
 
-func TestStorageResource_CreateWithServiceUUIDUnsupported(t *testing.T) {
+func TestStorageResource_CreateWithServiceUUIDMissingResourceUUID(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.NewServeMux()))
@@ -388,7 +388,7 @@ func TestStorageResource_CreateWithServiceUUIDUnsupported(t *testing.T) {
 					name         = "svc-data"
 					mount_path   = "/data"
 				`),
-				ExpectError: regexp.MustCompile(`Service-backed storage creation is not supported`),
+				ExpectError: regexp.MustCompile(`Missing resource_uuid for service storage`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Enables creating service-backed storages by adding the `resource_uuid` field to `coolify_storage`. Previously, service storage creation was blocked with an error because the Coolify API requires this field to identify which nested sub-resource (application or database) within the service should own the storage.

## Changes

- **Client**: Add `ResourceUUID` and `ResourceType` to `Storage` struct, `ResourceUUID` to `CreateStorageInput`
- **Resource**: Add `resource_uuid` schema attribute (Optional, Computed, RequiresReplace). Required when `service_uuid` is set. Captured from list response on Read.
- **Tests**: Update error test to match new message
- **Docs**: Remove 'not supported' note, regenerated

## Verified against Coolify source

`ServicesController.php:create_storage` validates `resource_uuid` as required, resolves the sub-resource via `$service->applications()` / `$service->databases()`, then creates the storage on that sub-resource.

Closes #220