### PR TITLE
Add per-plan list cache for env vars, storages, scheduled tasks

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -221,7 +221,7 @@ func (c *Client) doCachedList(ctx context.Context, path string, result interface
 	if err != nil {
 		return fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -24,6 +25,55 @@ type Client struct {
 	apiToken   string // unexported: prevents %+v leaking the token
 	HTTPClient *http.Client
 	UserAgent  string
+	listCache  listCache
+}
+
+// listCache is a short-lived, thread-safe cache for GET list responses.
+// It prevents redundant API calls when multiple resources with the same
+// parent are read during a single plan/apply cycle.
+type listCache struct {
+	mu      sync.Mutex
+	entries map[string]listCacheEntry
+}
+
+type listCacheEntry struct {
+	data    []byte
+	expires time.Time
+}
+
+const listCacheTTL = 5 * time.Second
+
+// getCached returns cached response bytes for the given path, or nil if
+// the cache is empty or expired.
+func (lc *listCache) get(path string) []byte {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	if lc.entries == nil {
+		return nil
+	}
+	e, ok := lc.entries[path]
+	if !ok || time.Now().After(e.expires) {
+		delete(lc.entries, path)
+		return nil
+	}
+	return e.data
+}
+
+// set stores response bytes in the cache with a TTL.
+func (lc *listCache) set(path string, data []byte) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	if lc.entries == nil {
+		lc.entries = make(map[string]listCacheEntry)
+	}
+	lc.entries[path] = listCacheEntry{data: data, expires: time.Now().Add(listCacheTTL)}
+}
+
+// invalidate removes a cache entry (called after mutating operations).
+func (lc *listCache) invalidate(path string) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.entries, path)
 }
 
 // RetryConfig holds user-configurable retry settings.
@@ -148,6 +198,48 @@ func IsNotFound(err error) bool {
 // do executes an API request, accepting any 2xx status.
 func (c *Client) do(ctx context.Context, method, path string, body interface{}, result interface{}) error {
 	return c.doWithStatus(ctx, method, path, body, result, 0)
+}
+
+// doCachedList performs a GET request with short-lived caching. Repeated
+// calls with the same path within the TTL window return cached data
+// without hitting the API. Use for List endpoints where multiple
+// Terraform resources share the same parent.
+func (c *Client) doCachedList(ctx context.Context, path string, result interface{}) error {
+	if cached := c.listCache.get(path); cached != nil {
+		return json.Unmarshal(cached, result)
+	}
+	// Make the real API call and capture raw bytes.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return &NotFoundError{Message: fmt.Sprintf("resource not found: %s", extractAPIMessage(respBody))}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, extractAPIMessage(respBody))
+	}
+
+	c.listCache.set(path, respBody)
+	if result != nil {
+		return json.Unmarshal(respBody, result)
+	}
+	return nil
 }
 
 // doWithStatus executes an API request. When expectedStatus is non-zero only

--- a/internal/client/environment_variables.go
+++ b/internal/client/environment_variables.go
@@ -35,85 +35,103 @@ type CreateEnvVarResponse struct {
 func (c *Client) CreateApplicationEnvVar(ctx context.Context, appUUID string, ev EnvironmentVariable, createIsBuild *bool) (*CreateEnvVarResponse, error) {
 	var r CreateEnvVarResponse
 	input := applicationEnvVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview, IsBuild: createIsBuild}
-	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID)), input, &r, http.StatusCreated); err != nil {
+	path := fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID))
+	if err := c.doWithStatus(ctx, http.MethodPost, path, input, &r, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating application env var %s: %w", appUUID, err)
 	}
+	c.listCache.invalidate(path)
 	return &r, nil
 }
 func (c *Client) ListApplicationEnvVars(ctx context.Context, appUUID string) ([]EnvironmentVariable, error) {
 	var v []EnvironmentVariable
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID)), nil, &v); err != nil {
+	path := fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID))
+	if err := c.doCachedList(ctx, path, &v); err != nil {
 		return nil, fmt.Errorf("listing application env vars %s: %w", appUUID, err)
 	}
 	return v, nil
 }
 func (c *Client) UpdateApplicationEnvVar(ctx context.Context, appUUID string, ev EnvironmentVariable) error {
 	input := applicationEnvVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview, IsBuild: &ev.IsBuild}
-	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID)), input, nil); err != nil {
+	listPath := fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID))
+	if err := c.do(ctx, http.MethodPatch, listPath, input, nil); err != nil {
 		return fmt.Errorf("updating application env var %s: %w", appUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return nil
 }
 func (c *Client) DeleteApplicationEnvVar(ctx context.Context, appUUID string, envUUID string) error {
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/applications/%s/envs/%s", url.PathEscape(appUUID), url.PathEscape(envUUID)), nil, nil); err != nil {
 		return fmt.Errorf("deleting application env var %s/%s: %w", appUUID, envUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID)))
 	return nil
 }
 func (c *Client) CreateServiceEnvVar(ctx context.Context, svcUUID string, ev EnvironmentVariable) (*CreateEnvVarResponse, error) {
 	var r CreateEnvVarResponse
 	input := envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
-	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID)), input, &r, http.StatusCreated); err != nil {
+	path := fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID))
+	if err := c.doWithStatus(ctx, http.MethodPost, path, input, &r, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating service env var %s: %w", svcUUID, err)
 	}
+	c.listCache.invalidate(path)
 	return &r, nil
 }
 func (c *Client) ListServiceEnvVars(ctx context.Context, svcUUID string) ([]EnvironmentVariable, error) {
 	var v []EnvironmentVariable
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID)), nil, &v); err != nil {
+	path := fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID))
+	if err := c.doCachedList(ctx, path, &v); err != nil {
 		return nil, fmt.Errorf("listing service env vars %s: %w", svcUUID, err)
 	}
 	return v, nil
 }
 func (c *Client) UpdateServiceEnvVar(ctx context.Context, svcUUID string, ev EnvironmentVariable) error {
 	input := envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
-	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID)), input, nil); err != nil {
+	listPath := fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID))
+	if err := c.do(ctx, http.MethodPatch, listPath, input, nil); err != nil {
 		return fmt.Errorf("updating service env var %s: %w", svcUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return nil
 }
 func (c *Client) DeleteServiceEnvVar(ctx context.Context, svcUUID string, envUUID string) error {
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/services/%s/envs/%s", url.PathEscape(svcUUID), url.PathEscape(envUUID)), nil, nil); err != nil {
 		return fmt.Errorf("deleting service env var %s/%s: %w", svcUUID, envUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID)))
 	return nil
 }
 func (c *Client) CreateDatabaseEnvVar(ctx context.Context, dbUUID string, ev EnvironmentVariable) (*CreateEnvVarResponse, error) {
 	var r CreateEnvVarResponse
 	input := envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
-	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID)), input, &r, http.StatusCreated); err != nil {
+	path := fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID))
+	if err := c.doWithStatus(ctx, http.MethodPost, path, input, &r, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating database env var %s: %w", dbUUID, err)
 	}
+	c.listCache.invalidate(path)
 	return &r, nil
 }
 func (c *Client) ListDatabaseEnvVars(ctx context.Context, dbUUID string) ([]EnvironmentVariable, error) {
 	var v []EnvironmentVariable
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID)), nil, &v); err != nil {
+	path := fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID))
+	if err := c.doCachedList(ctx, path, &v); err != nil {
 		return nil, fmt.Errorf("listing database env vars %s: %w", dbUUID, err)
 	}
 	return v, nil
 }
 func (c *Client) UpdateDatabaseEnvVar(ctx context.Context, dbUUID string, ev EnvironmentVariable) error {
 	input := envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
-	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID)), input, nil); err != nil {
+	listPath := fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID))
+	if err := c.do(ctx, http.MethodPatch, listPath, input, nil); err != nil {
 		return fmt.Errorf("updating database env var %s: %w", dbUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return nil
 }
 func (c *Client) DeleteDatabaseEnvVar(ctx context.Context, dbUUID string, envUUID string) error {
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/databases/%s/envs/%s", url.PathEscape(dbUUID), url.PathEscape(envUUID)), nil, nil); err != nil {
 		return fmt.Errorf("deleting database env var %s/%s: %w", dbUUID, envUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID)))
 	return nil
 }
 
@@ -136,6 +154,7 @@ func (c *Client) BulkUpdateAppEnvVars(ctx context.Context, appUUID string, input
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/applications/%s/envs/bulk", url.PathEscape(appUUID)), input, nil); err != nil {
 		return fmt.Errorf("bulk updating application env vars %s: %w", appUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/applications/%s/envs", url.PathEscape(appUUID)))
 	return nil
 }
 
@@ -144,6 +163,7 @@ func (c *Client) BulkUpdateDatabaseEnvVars(ctx context.Context, dbUUID string, i
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/databases/%s/envs/bulk", url.PathEscape(dbUUID)), input, nil); err != nil {
 		return fmt.Errorf("bulk updating database env vars %s: %w", dbUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/databases/%s/envs", url.PathEscape(dbUUID)))
 	return nil
 }
 
@@ -152,5 +172,6 @@ func (c *Client) BulkUpdateServiceEnvVars(ctx context.Context, svcUUID string, i
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/services/%s/envs/bulk", url.PathEscape(svcUUID)), input, nil); err != nil {
 		return fmt.Errorf("bulk updating service env vars %s: %w", svcUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/services/%s/envs", url.PathEscape(svcUUID)))
 	return nil
 }

--- a/internal/client/scheduled_tasks.go
+++ b/internal/client/scheduled_tasks.go
@@ -43,7 +43,8 @@ func (c *Client) ListScheduledTasks(ctx context.Context, parentType, parentUUID 
 		return nil, err
 	}
 	var tasks []ScheduledTask
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID)), nil, &tasks); err != nil {
+	path := fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID))
+	if err := c.doCachedList(ctx, path, &tasks); err != nil {
 		return nil, fmt.Errorf("listing scheduled tasks for %s %s: %w", parentType, parentUUID, err)
 	}
 	return tasks, nil
@@ -56,9 +57,11 @@ func (c *Client) CreateScheduledTask(ctx context.Context, parentType, parentUUID
 		return "", err
 	}
 	var resp createScheduledTaskResponse
-	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID)), input, &resp, http.StatusCreated); err != nil {
+	listPath := fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID))
+	if err := c.doWithStatus(ctx, http.MethodPost, listPath, input, &resp, http.StatusCreated); err != nil {
 		return "", fmt.Errorf("creating scheduled task for %s %s: %w", parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return resp.UUID, nil
 }
 
@@ -71,6 +74,7 @@ func (c *Client) UpdateScheduledTask(ctx context.Context, parentType, parentUUID
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks/%s", parentType, url.PathEscape(parentUUID), url.PathEscape(taskUUID)), input, nil); err != nil {
 		return fmt.Errorf("updating scheduled task %s for %s %s: %w", taskUUID, parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID)))
 	return nil
 }
 
@@ -83,6 +87,7 @@ func (c *Client) DeleteScheduledTask(ctx context.Context, parentType, parentUUID
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks/%s", parentType, url.PathEscape(parentUUID), url.PathEscape(taskUUID)), nil, nil); err != nil {
 		return fmt.Errorf("deleting scheduled task %s for %s %s: %w", taskUUID, parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/%s/%s/scheduled-tasks", parentType, url.PathEscape(parentUUID)))
 	return nil
 }
 

--- a/internal/client/storages.go
+++ b/internal/client/storages.go
@@ -54,7 +54,8 @@ func (c *Client) ListStorages(ctx context.Context, parentType, parentUUID string
 		return nil, err
 	}
 	var v storageListResponse
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID)), nil, &v); err != nil {
+	path := fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID))
+	if err := c.doCachedList(ctx, path, &v); err != nil {
 		return nil, fmt.Errorf("listing storages for %s %s: %w", parentType, parentUUID, err)
 	}
 	return append(v.PersistentStorages, v.FileStorages...), nil
@@ -67,9 +68,11 @@ func (c *Client) CreateStorage(ctx context.Context, parentType, parentUUID strin
 		return nil, err
 	}
 	var r CreateStorageResponse
-	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID)), input, &r, http.StatusCreated); err != nil {
+	listPath := fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID))
+	if err := c.doWithStatus(ctx, http.MethodPost, listPath, input, &r, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating storage for %s %s: %w", parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return &r, nil
 }
 
@@ -79,9 +82,11 @@ func (c *Client) UpdateStorage(ctx context.Context, parentType, parentUUID strin
 	if err := validateParentType(parentType); err != nil {
 		return err
 	}
-	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID)), input, nil); err != nil {
+	listPath := fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID))
+	if err := c.do(ctx, http.MethodPatch, listPath, input, nil); err != nil {
 		return fmt.Errorf("updating storage for %s %s: %w", parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(listPath)
 	return nil
 }
 
@@ -93,5 +98,6 @@ func (c *Client) DeleteStorage(ctx context.Context, parentType, parentUUID, stor
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/%s/%s/storages/%s", parentType, url.PathEscape(parentUUID), url.PathEscape(storageUUID)), nil, nil); err != nil {
 		return fmt.Errorf("deleting storage %s for %s %s: %w", storageUUID, parentType, parentUUID, err)
 	}
+	c.listCache.invalidate(fmt.Sprintf("/api/v1/%s/%s/storages", parentType, url.PathEscape(parentUUID)))
 	return nil
 }


### PR DESCRIPTION
## Summary

Add a short-lived (5s TTL), thread-safe cache to the API client for GET list responses. This eliminates redundant API calls when multiple Terraform resources share the same parent.

## Problem

Each `coolify_environment_variable`, `coolify_storage`, and `coolify_scheduled_task` calls the List API on every Read. With N resources on one parent, `terraform plan` makes N identical List calls, each returning all N items. With 10 env vars on one application, that's 10 identical API calls.

## Solution

A `listCache` on the `Client` struct stores raw JSON bytes keyed by GET path with a 5-second TTL. The first Read hits the API; subsequent reads within the window return cached data. Cache entries are invalidated after any Create, Update, Delete, or BulkUpdate on the same parent.

## Changes

- **`internal/client/client.go`**: Add `listCache` type with get/set/invalidate, add `doCachedList` method
- **`internal/client/environment_variables.go`**: Switch 3 List methods to `doCachedList`, add invalidation to 9 mutating methods
- **`internal/client/storages.go`**: Switch ListStorages to `doCachedList`, add invalidation to 3 mutating methods
- **`internal/client/scheduled_tasks.go`**: Switch ListScheduledTasks to `doCachedList`, add invalidation to 3 mutating methods

Closes #232