### PR TITLE
fix: add empty UUID guards to application creates + test coverage improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Read these skills when working in this repo:
 
 Terraform provider for [Coolify](https://coolify.io/), the open-source self-hosted PaaS.
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
-26 resources, 44 data sources, 660+ tests (unit + acceptance), 8 CI jobs.
+26 resources, 44 data sources, 690+ tests (unit + acceptance), 8 CI jobs.
 9 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -161,7 +161,7 @@ mismatches, and zero validation rules when we compared it against the source.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 660+ tests (unit + acceptance)
+- 690+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, python-test, docs-check, api-coverage-check, counts-check, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Input validators: `build_pack` OneOf, FQDN format, cron syntax, port range (1-65535), UUID format, environment variable name format
 - Configurable `timeouts` block on all application resources
 - Graceful handling of out-of-band resource deletion (404 in Read removes from state)
-- 640+ unit tests with race detection across 34 packages
+- 690+ unit tests with race detection across 34 packages
 - CI pipeline: 8 jobs (detect changes, test, lint, validate, scenario tests, acceptance tests, spec freshness, CI gate)
 - GoReleaser config for GPG-signed releases
 - Computed `status` field on all application resources

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ full local setup. Run `make help` to list the supported local targets from
 
 ```bash
 make build       # Compile the provider
-make test        # Run unit tests (660+ tests, race detector enabled)
+make test        # Run unit tests (690+ tests, race detector enabled)
 make testacc     # Run acceptance tests (needs running Coolify instance)
 make lint        # Run golangci-lint
 make fmt         # Format code (gofmt + go mod tidy)

--- a/internal/client/applications.go
+++ b/internal/client/applications.go
@@ -237,6 +237,9 @@ func (c *Client) CreatePublicApplication(ctx context.Context, input CreatePublic
 	if err := c.doWithStatus(ctx, http.MethodPost, "/api/v1/applications/public", input, &a, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating public application: %w", err)
 	}
+	if a.UUID == "" {
+		return nil, fmt.Errorf("creating public application: API returned empty UUID")
+	}
 	return &a, nil
 }
 func (c *Client) UpdateApplication(ctx context.Context, uuid string, input UpdateApplicationInput) (*Application, error) {
@@ -291,6 +294,9 @@ func (c *Client) CreatePrivateGitApplication(ctx context.Context, input CreatePr
 	if err := c.doWithStatus(ctx, http.MethodPost, "/api/v1/applications/private-deploy-key", input, &a, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating private git application: %w", err)
 	}
+	if a.UUID == "" {
+		return nil, fmt.Errorf("creating private git application: API returned empty UUID")
+	}
 	return &a, nil
 }
 
@@ -312,6 +318,9 @@ func (c *Client) CreateDockerImageApplication(ctx context.Context, input CreateD
 	var a Application
 	if err := c.doWithStatus(ctx, http.MethodPost, "/api/v1/applications/dockerimage", input, &a, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating docker image application: %w", err)
+	}
+	if a.UUID == "" {
+		return nil, fmt.Errorf("creating docker image application: API returned empty UUID")
 	}
 	return &a, nil
 }
@@ -335,6 +344,9 @@ func (c *Client) CreateDockerfileApplication(ctx context.Context, input CreateDo
 	var a Application
 	if err := c.doWithStatus(ctx, http.MethodPost, "/api/v1/applications/dockerfile", input, &a, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating dockerfile application: %w", err)
+	}
+	if a.UUID == "" {
+		return nil, fmt.Errorf("creating dockerfile application: API returned empty UUID")
 	}
 	return &a, nil
 }
@@ -362,6 +374,9 @@ func (c *Client) CreateGitHubAppApplication(ctx context.Context, input CreateGit
 	var a Application
 	if err := c.doWithStatus(ctx, http.MethodPost, "/api/v1/applications/private-github-app", input, &a, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating github app application: %w", err)
+	}
+	if a.UUID == "" {
+		return nil, fmt.Errorf("creating github app application: API returned empty UUID")
 	}
 	return &a, nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4514,6 +4514,71 @@ func TestClient_CreateService_EmptyUUID(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty UUID")
 }
 
+func TestClient_CreatePublicApplication_EmptyUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Application{UUID: "", Name: "broken"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreatePublicApplication(context.Background(), CreatePublicAppInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty UUID")
+}
+
+func TestClient_CreatePrivateGitApplication_EmptyUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Application{UUID: "", Name: "broken"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreatePrivateGitApplication(context.Background(), CreatePrivateGitAppInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty UUID")
+}
+
+func TestClient_CreateDockerImageApplication_EmptyUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Application{UUID: "", Name: "broken"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreateDockerImageApplication(context.Background(), CreateDockerImageAppInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty UUID")
+}
+
+func TestClient_CreateDockerfileApplication_EmptyUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Application{UUID: "", Name: "broken"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreateDockerfileApplication(context.Background(), CreateDockerfileAppInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty UUID")
+}
+
+func TestClient_CreateGitHubAppApplication_EmptyUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Application{UUID: "", Name: "broken"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreateGitHubAppApplication(context.Background(), CreateGitHubAppInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty UUID")
+}
+
 // --- Hetzner List Endpoints ---
 
 func TestClient_ListHetznerImages(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4513,3 +4513,87 @@ func TestClient_CreateService_EmptyUUID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty UUID")
 }
+
+// --- Hetzner List Endpoints ---
+
+func TestClient_ListHetznerImages(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/hetzner/images", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]HetznerImage{
+			{ID: 1, Name: "ubuntu-22.04", Description: "Ubuntu 22.04"},
+			{ID: 2, Name: "debian-12", Description: "Debian 12"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	images, err := c.ListHetznerImages(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, images, 2)
+	assert.Equal(t, int64(1), images[0].ID)
+	assert.Equal(t, "ubuntu-22.04", images[0].Name)
+}
+
+func TestClient_ListHetznerLocations(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/hetzner/locations", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]HetznerLocation{
+			{ID: 1, Name: "fsn1", Description: "Falkenstein DC Park 1", City: "Falkenstein", Country: "DE"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	locations, err := c.ListHetznerLocations(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, locations, 1)
+	assert.Equal(t, "fsn1", locations[0].Name)
+	assert.Equal(t, "DE", locations[0].Country)
+}
+
+func TestClient_ListHetznerServerTypes(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/hetzner/server-types", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]HetznerServerType{
+			{ID: 1, Name: "cx22", Description: "CX22", Cores: 2, Memory: 4, Disk: 40},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	types, err := c.ListHetznerServerTypes(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, types, 1)
+	assert.Equal(t, "cx22", types[0].Name)
+	assert.Equal(t, int64(2), types[0].Cores)
+	assert.Equal(t, int64(4), types[0].Memory)
+}
+
+func TestClient_ListHetznerSSHKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/hetzner/ssh-keys", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]HetznerSSHKey{
+			{ID: 1, Name: "deploy-key", Fingerprint: "aa:bb:cc:dd"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	keys, err := c.ListHetznerSSHKeys(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "deploy-key", keys[0].Name)
+	assert.Equal(t, "aa:bb:cc:dd", keys[0].Fingerprint)
+}


### PR DESCRIPTION
Multi-perspective improvement cycle: 14 perspectives reviewed, 3 actionable findings fixed.

## Changes

### Bug fix: empty UUID guard on application creates
All 5 application Create client methods (public, private git, docker image, dockerfile, github app) were missing the empty UUID validation that databases and services already had. If the Coolify API returned a 201 with an empty UUID field, the resource would be saved to Terraform state with an empty ID, making it unmanageable.

Added `if a.UUID == "" { return nil, fmt.Errorf(...) }` to all 5 methods, matching the existing pattern in `CreateDatabase` and `CreateService`. Added 5 corresponding tests.

### Test coverage: Hetzner list client methods
`ListHetznerImages`, `ListHetznerLocations`, `ListHetznerServerTypes`, and `ListHetznerSSHKeys` were the only client methods without direct unit tests. Added tests that validate HTTP method, URL path, query parameter passing, and response deserialization.

### Documentation: test count update
Updated AGENTS.md, README.md, and CHANGELOG.md from '660+' to '690+' (actual count: 697).

## Perspectives reviewed (no-op)
Developer, End User, Maintainer, Ops/SRE, Security, Product Manager, Spec/Contract, Performance, Backward Compat, Architecture, New Contributor, Observability: all clean.