### PR TITLE
Improve delete warnings and validate workflow checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,17 @@ jobs:
       - name: Verify AGENTS.md counts
         if: ${{ !cancelled() }}
         run: make counts-check
+      - name: Install actionlint
+        if: ${{ !cancelled() && (needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        run: GOBIN="$(pwd)/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Lint GitHub Actions workflows
+        if: ${{ !cancelled() && (needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        run: make actionlint-check
+      - name: Set up Python
+        if: ${{ !cancelled() && (needs.changes.outputs.scripts == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.9"
       - name: Run Python script tests
         if: ${{ !cancelled() && (needs.changes.outputs.scripts == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         run: make python-test
@@ -429,9 +440,11 @@ jobs:
         run: |
           rm -f /tmp/scenario-deploy-key /tmp/scenario-deploy-key.pub
           ssh-keygen -t rsa -b 2048 -f /tmp/scenario-deploy-key -N "" -q
-          echo "TF_VAR_deploy_key<<EOFKEY" >> "$GITHUB_ENV"
-          cat /tmp/scenario-deploy-key >> "$GITHUB_ENV"
-          echo "EOFKEY" >> "$GITHUB_ENV"
+          {
+            echo "TF_VAR_deploy_key<<EOFKEY"
+            cat /tmp/scenario-deploy-key
+            echo "EOFKEY"
+          } >> "$GITHUB_ENV"
       - name: Run scenario tests
         if: steps.secrets.outputs.configured == 'true' && steps.health.outputs.healthy == 'true'
         env:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 GOLANGCI_LINT_VERSION := 2.12.2
 GORELEASER_MAJOR := 2
+ACTIONLINT_VERSION := 1.7.12
 BIN_DIR := $(CURDIR)/bin
 
 export PATH := $(BIN_DIR):$(PATH)
@@ -99,7 +100,7 @@ test-import-gen: ## Test terraform plan -generate-config-out compatibility (need
 scaffold: ## Scaffold a new resource (usage: make scaffold NAME=webhook)
 	@./scripts/new-resource.sh $(NAME)
 
-ci: build lint test validate python-test docs-check api-coverage-check counts-check vulncheck goreleaser-check modverify ## Run all checks (CI also runs trivy + gitleaks security scans)
+ci: build lint test validate actionlint-check python-test docs-check api-coverage-check counts-check vulncheck goreleaser-check modverify ## Run all checks (CI also runs trivy + gitleaks security scans)
 
 modverify: ## Verify module cache integrity against go.sum
 	go mod verify
@@ -163,6 +164,17 @@ check-goreleaser-version: ## Verify goreleaser major version matches CI
 check-python3: ## Verify Python 3 is installed for Python-backed tooling
 	@command -v python3 >/dev/null 2>&1 || (echo "ERROR: python3 is required for Python-backed Make targets in this repo. Install Python 3.9+ and re-run."; exit 1)
 
+check-actionlint-version: ## Verify actionlint version matches CI
+	@version="$$(actionlint --version 2>/dev/null | awk 'NR == 1 {print $$1}')"; \
+	if [ "$$version" != "$(ACTIONLINT_VERSION)" ]; then \
+		echo "ERROR: actionlint $(ACTIONLINT_VERSION) required to match CI. Install with: make tools"; \
+		if [ -n "$$version" ]; then echo "Installed: $$version"; else echo "Installed: not found"; fi; \
+		exit 1; \
+	fi
+
+actionlint-check: check-actionlint-version ## Lint GitHub Actions workflows
+	actionlint
+
 check-tfplugindocs: ## Verify tfplugindocs is installed for docs generation
 	@command -v tfplugindocs >/dev/null 2>&1 || (echo "ERROR: tfplugindocs is required for docs generation. Install with: make tools"; exit 1)
 
@@ -178,6 +190,8 @@ tools: ## Install all required development tools
 	@GOBIN="$(BIN_DIR)" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 	@echo "Installing goreleaser to $(BIN_DIR)..."
 	@GOBIN="$(BIN_DIR)" go install github.com/goreleaser/goreleaser/v$(GORELEASER_MAJOR)@latest
+	@echo "Installing actionlint $(ACTIONLINT_VERSION) to $(BIN_DIR)..."
+	@GOBIN="$(BIN_DIR)" go install github.com/rhysd/actionlint/cmd/actionlint@v$(ACTIONLINT_VERSION)
 	@echo "Installing tfplugindocs to $(BIN_DIR)..."
 	@cd tools && GOBIN="$(BIN_DIR)" go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	@echo "All tools installed to $(BIN_DIR)."
@@ -185,4 +199,4 @@ tools: ## Install all required development tools
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test testacc acc-bootstrap acc-preflight check-pkg test-pkg testacc-pkg lint fmt docs docs-check api-coverage-check counts-check validate python-test install spec-update spec-check spec-generate api-coverage contract-extract contract-check contract-matrix vulncheck check-golangci-lint-version check-goreleaser-version check-python3 check-tfplugindocs goreleaser-check modverify ci scaffold test-import-gen tools help
+.PHONY: build test testacc acc-bootstrap acc-preflight check-pkg test-pkg testacc-pkg lint fmt docs docs-check api-coverage-check counts-check validate python-test install spec-update spec-check spec-generate api-coverage contract-extract contract-check contract-matrix vulncheck check-golangci-lint-version check-goreleaser-version check-python3 check-actionlint-version check-tfplugindocs actionlint-check goreleaser-check modverify ci scaffold test-import-gen tools help

--- a/internal/service/application/common_crud.go
+++ b/internal/service/application/common_crud.go
@@ -44,6 +44,7 @@ func setImportDefaults(ctx context.Context, resp *resource.ImportStateResponse) 
 }
 
 const applicationCreateReadBackFailedSummary = "Application created but refresh failed"
+const deletePollingTimeoutWarningSummary = "Delete is still finishing in Coolify"
 
 func addApplicationCreateReadBackDiagnostic(resp *resource.CreateResponse, detail string) {
 	resp.Diagnostics.AddError(applicationCreateReadBackFailedSummary, detail)
@@ -165,6 +166,17 @@ func readApplication(
 // asynchronously via DeleteResourceJob; without polling, downstream
 // resources (e.g. project) fail to delete because the app still exists.
 // A 404 is treated as already-deleted and does not produce an error.
+func addDeletePollingTimeoutWarning(resp *resource.DeleteResponse, resourceType, uuid string) {
+	resp.Diagnostics.AddWarning(
+		deletePollingTimeoutWarningSummary,
+		fmt.Sprintf(
+			"Coolify accepted deletion of %s %s, but the resource was still returned by the API when the provider stopped polling. Terraform removed it from state, but the remote resource may still exist temporarily. Wait a moment before retrying dependent operations if they still report it.",
+			resourceType,
+			uuid,
+		),
+	)
+}
+
 func deleteApplication(
 	ctx context.Context,
 	c *client.Client,
@@ -182,6 +194,7 @@ func deleteApplication(
 	}
 	if !client.PollUntilDeleted(ctx, func() error { _, err := c.GetApplication(ctx, uuid); return err }) {
 		tflog.Warn(ctx, "resource may still exist after polling timeout", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
+		addDeletePollingTimeoutWarning(resp, resourceType, uuid)
 	}
 	tflog.Debug(ctx, "deleted resource", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
 }

--- a/internal/service/application/common_test.go
+++ b/internal/service/application/common_test.go
@@ -1,9 +1,16 @@
 package application
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -206,5 +213,50 @@ func TestHasNonDefaultAppExtendedFields_DefaultValues(t *testing.T) {
 				t.Errorf("expected false when %s is set to its default", tt.name)
 			}
 		})
+	}
+}
+
+func TestDeleteApplication_AddsWarningWhenPollingTimesOut(t *testing.T) {
+	t.Parallel()
+
+	const uuid = "app-delete-timeout-uuid"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/applications/%s", uuid):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/applications/%s", uuid):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"uuid":"` + uuid + `"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"test"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	resp := &resource.DeleteResponse{}
+
+	deleteApplication(ctx, c, "coolify_application", uuid, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+	}
+	if resp.Diagnostics.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning, got %d", resp.Diagnostics.WarningsCount())
+	}
+	warning := resp.Diagnostics.Warnings()[0]
+	if warning.Summary() != deletePollingTimeoutWarningSummary {
+		t.Fatalf("warning summary = %q, want %q", warning.Summary(), deletePollingTimeoutWarningSummary)
+	}
+	if !strings.Contains(warning.Detail(), uuid) {
+		t.Fatalf("warning detail %q does not mention uuid %s", warning.Detail(), uuid)
+	}
+	if !strings.Contains(warning.Detail(), "may still exist temporarily") {
+		t.Fatalf("warning detail %q does not explain the temporary remote state", warning.Detail())
 	}
 }

--- a/internal/service/database/common.go
+++ b/internal/service/database/common.go
@@ -229,7 +229,20 @@ func UpdateDatabase(ctx context.Context, c *client.Client, uuid string, input cl
 
 // DeleteDatabase removes a database by UUID, silently succeeding if already
 // gone.
-func DeleteDatabase(ctx context.Context, c *client.Client, resourceType, uuid string) error {
+const deletePollingTimeoutWarningSummary = "Delete is still finishing in Coolify"
+
+func addDeletePollingTimeoutWarning(resp *resource.DeleteResponse, resourceType, uuid string) {
+	resp.Diagnostics.AddWarning(
+		deletePollingTimeoutWarningSummary,
+		fmt.Sprintf(
+			"Coolify accepted deletion of %s %s, but the resource was still returned by the API when the provider stopped polling. Terraform removed it from state, but the remote resource may still exist temporarily. Wait a moment before retrying dependent operations if they still report it.",
+			resourceType,
+			uuid,
+		),
+	)
+}
+
+func DeleteDatabase(ctx context.Context, c *client.Client, resourceType, uuid string, resp *resource.DeleteResponse) error {
 	if err := c.DeleteDatabase(ctx, uuid); err != nil {
 		if client.IsNotFound(err) {
 			return nil
@@ -238,6 +251,7 @@ func DeleteDatabase(ctx context.Context, c *client.Client, resourceType, uuid st
 	}
 	if !client.PollUntilDeleted(ctx, func() error { _, err := c.GetDatabase(ctx, uuid); return err }) {
 		tflog.Warn(ctx, "resource may still exist after polling timeout", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
+		addDeletePollingTimeoutWarning(resp, resourceType, uuid)
 	}
 	tflog.Debug(ctx, "deleted resource", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
 	return nil
@@ -276,7 +290,7 @@ func DeleteDatabaseState(
 	resp *resource.DeleteResponse,
 ) {
 	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
-	if err := DeleteDatabase(ctx, c, resourceType, uuid); err != nil {
+	if err := DeleteDatabase(ctx, c, resourceType, uuid, resp); err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Error deleting %s", resourceType), fmt.Sprintf("%s %s: %s", resourceType, uuid, err))
 	}
 }

--- a/internal/service/database/common_test.go
+++ b/internal/service/database/common_test.go
@@ -1,8 +1,16 @@
 package database
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -78,5 +86,52 @@ func TestHasExtendedFields_DefaultValues(t *testing.T) {
 				t.Errorf("expected false when %s is set to its default", tt.name)
 			}
 		})
+	}
+}
+
+func TestDeleteDatabase_AddsWarningWhenPollingTimesOut(t *testing.T) {
+	t.Parallel()
+
+	const uuid = "db-delete-timeout-uuid"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", uuid):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/databases/%s", uuid):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"uuid":"` + uuid + `"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"test"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	resp := &resource.DeleteResponse{}
+
+	err := DeleteDatabase(ctx, c, "coolify_database_postgresql", uuid, resp)
+	if err != nil {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+	}
+	if resp.Diagnostics.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning, got %d", resp.Diagnostics.WarningsCount())
+	}
+	warning := resp.Diagnostics.Warnings()[0]
+	if warning.Summary() != deletePollingTimeoutWarningSummary {
+		t.Fatalf("warning summary = %q, want %q", warning.Summary(), deletePollingTimeoutWarningSummary)
+	}
+	if !strings.Contains(warning.Detail(), uuid) {
+		t.Fatalf("warning detail %q does not mention uuid %s", warning.Detail(), uuid)
+	}
+	if !strings.Contains(warning.Detail(), "may still exist temporarily") {
+		t.Fatalf("warning detail %q does not explain the temporary remote state", warning.Detail())
 	}
 }

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -291,6 +291,36 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
+const deletePollingTimeoutWarningSummary = "Delete is still finishing in Coolify"
+
+func addDeletePollingTimeoutWarning(resp *resource.DeleteResponse, resourceType, uuid string) {
+	resp.Diagnostics.AddWarning(
+		deletePollingTimeoutWarningSummary,
+		fmt.Sprintf(
+			"Coolify accepted deletion of %s %s, but the resource was still returned by the API when the provider stopped polling. Terraform removed it from state, but the remote resource may still exist temporarily. Wait a moment before retrying dependent operations if they still report it.",
+			resourceType,
+			uuid,
+		),
+	)
+}
+
+func deleteService(ctx context.Context, c *client.Client, resourceType, uuid string, resp *resource.DeleteResponse) {
+	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
+
+	if err := c.DeleteService(ctx, uuid); err != nil {
+		if client.IsNotFound(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Error deleting service", fmt.Sprintf("service %s: %s", uuid, err))
+		return
+	}
+	if !client.PollUntilDeleted(ctx, func() error { _, err := c.GetService(ctx, uuid); return err }) {
+		tflog.Warn(ctx, "resource may still exist after polling timeout", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
+		addDeletePollingTimeoutWarning(resp, resourceType, uuid)
+	}
+	tflog.Debug(ctx, "deleted resource", map[string]interface{}{"resource_type": resourceType, "uuid": uuid})
+}
+
 func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state serviceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -298,20 +328,7 @@ func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	uuid := state.UUID.ValueString()
-	tflog.Debug(ctx, "deleting resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
-
-	if err := r.client.DeleteService(ctx, uuid); err != nil {
-		if client.IsNotFound(err) {
-			return
-		}
-		resp.Diagnostics.AddError("Error deleting service", fmt.Sprintf("service %s: %s", uuid, err))
-		return
-	}
-	if !client.PollUntilDeleted(ctx, func() error { _, err := r.client.GetService(ctx, uuid); return err }) {
-		tflog.Warn(ctx, "resource may still exist after polling timeout", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
-	}
-	tflog.Debug(ctx, "deleted resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
+	deleteService(ctx, r.client, "coolify_service", state.UUID.ValueString(), resp)
 }
 
 func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,9 +13,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	servicepkg "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -250,6 +258,106 @@ func TestServiceResource_CreateReadBackFailurePreservesState(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestDeleteService_AddsWarningWhenPollingTimesOut(t *testing.T) {
+	t.Parallel()
+
+	const uuid = "svc-delete-timeout-uuid"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", uuid):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", uuid):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"uuid":"` + uuid + `"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"test"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	res := servicepkg.NewResource()
+	cfgRes, ok := res.(fwresource.ResourceWithConfigure)
+	if !ok {
+		t.Fatal("service resource does not implement ResourceWithConfigure")
+	}
+	var cfgResp fwresource.ConfigureResponse
+	cfgRes.Configure(ctx, fwresource.ConfigureRequest{ProviderData: c}, &cfgResp)
+	if cfgResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected configure errors: %v", cfgResp.Diagnostics.Errors())
+	}
+
+	var schemaResp fwresource.SchemaResponse
+	res.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema errors: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	setDiags := state.Set(ctx, struct {
+		Timeouts                      timeouts.Value `tfsdk:"timeouts"`
+		UUID                          types.String   `tfsdk:"uuid"`
+		Name                          types.String   `tfsdk:"name"`
+		Description                   types.String   `tfsdk:"description"`
+		ProjectUUID                   types.String   `tfsdk:"project_uuid"`
+		ServerUUID                    types.String   `tfsdk:"server_uuid"`
+		EnvironmentName               types.String   `tfsdk:"environment_name"`
+		Type                          types.String   `tfsdk:"type"`
+		Status                        types.String   `tfsdk:"status"`
+		DockerCompose                 types.String   `tfsdk:"docker_compose"`
+		DockerComposeRaw              types.String   `tfsdk:"docker_compose_raw"`
+		ConnectToNetwork              types.Bool     `tfsdk:"connect_to_docker_network"`
+		IsContainerLabelEscapeEnabled types.Bool     `tfsdk:"is_container_label_escape_enabled"`
+		ConfigHash                    types.String   `tfsdk:"config_hash"`
+		InstantDeploy                 types.Bool     `tfsdk:"instant_deploy"`
+	}{
+		Timeouts:                      timeouts.Value{Object: types.ObjectNull(map[string]attr.Type{"create": types.StringType})},
+		UUID:                          types.StringValue(uuid),
+		Name:                          types.StringNull(),
+		Description:                   types.StringNull(),
+		ProjectUUID:                   types.StringNull(),
+		ServerUUID:                    types.StringNull(),
+		EnvironmentName:               types.StringNull(),
+		Type:                          types.StringNull(),
+		Status:                        types.StringNull(),
+		DockerCompose:                 types.StringNull(),
+		DockerComposeRaw:              types.StringNull(),
+		ConnectToNetwork:              types.BoolNull(),
+		IsContainerLabelEscapeEnabled: types.BoolNull(),
+		ConfigHash:                    types.StringNull(),
+		InstantDeploy:                 types.BoolNull(),
+	})
+	if setDiags.HasError() {
+		t.Fatalf("unexpected state set errors: %v", setDiags.Errors())
+	}
+
+	resp := &fwresource.DeleteResponse{State: state}
+	res.Delete(ctx, fwresource.DeleteRequest{State: state}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+	}
+	if resp.Diagnostics.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning, got %d", resp.Diagnostics.WarningsCount())
+	}
+	warning := resp.Diagnostics.Warnings()[0]
+	if warning.Summary() != "Delete is still finishing in Coolify" {
+		t.Fatalf("warning summary = %q, want %q", warning.Summary(), "Delete is still finishing in Coolify")
+	}
+	if !strings.Contains(warning.Detail(), uuid) {
+		t.Fatalf("warning detail %q does not mention uuid %s", warning.Detail(), uuid)
+	}
+	if !strings.Contains(warning.Detail(), "may still exist temporarily") {
+		t.Fatalf("warning detail %q does not explain the temporary remote state", warning.Detail())
+	}
 }
 
 func TestServiceResource_Disappears(t *testing.T) {


### PR DESCRIPTION
## Summary
- add user-visible Terraform warnings when Coolify async delete polling times out for applications, databases, and services
- cover the warning path with regression tests in the touched service packages
- add actionlint to local and CI validation, pin Python 3.9 in the Validate job, and clean the multiline GITHUB_ENV write for workflow linting

## Testing
- go test ./internal/service/application ./internal/service/database ./internal/service/service
- actionlint
- make python-test
- make ci

Refs #383
Refs #384
Refs #385