### PR TITLE
Fix Validate job on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,18 +209,18 @@ jobs:
         run: make counts-check
       - name: Install actionlint
         if: ${{ !cancelled() && (needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-        run: GOBIN="$(pwd)/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        run: |
+          GOBIN="$(pwd)/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       - name: Lint GitHub Actions workflows
         if: ${{ !cancelled() && (needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
         run: make actionlint-check
-      - name: Set up Python
-        if: ${{ !cancelled() && (needs.changes.outputs.scripts == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.9"
       - name: Run Python script tests
         if: ${{ !cancelled() && (needs.changes.outputs.scripts == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-        run: make python-test
+        run: |
+          command -v python3.9 >/dev/null 2>&1 || { echo "::error::python3.9 is required on self-hosted runners"; exit 1; }
+          python3.9 --version
+          make python-test PYTHON=python3.9
       - name: Configure Docker for CI
         if: ${{ !cancelled() }}
         run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,7 @@
 GOLANGCI_LINT_VERSION := 2.12.2
 GORELEASER_MAJOR := 2
 ACTIONLINT_VERSION := 1.7.12
+PYTHON ?= python3
 BIN_DIR := $(CURDIR)/bin
 
 export PATH := $(BIN_DIR):$(PATH)
@@ -63,7 +64,7 @@ validate: ## Check HCL formatting in examples/
 	terraform fmt -check -recursive examples/
 
 python-test: check-python3 ## Run Python unit tests for scripts/
-	python3 -m unittest discover -s scripts -p '*test*.py' -v
+	$(PYTHON) -m unittest discover -s scripts -p '*test*.py' -v
 
 install: ## Install provider to local Go bin
 	go install .
@@ -162,10 +163,10 @@ check-goreleaser-version: ## Verify goreleaser major version matches CI
 	fi
 
 check-python3: ## Verify Python 3 is installed for Python-backed tooling
-	@command -v python3 >/dev/null 2>&1 || (echo "ERROR: python3 is required for Python-backed Make targets in this repo. Install Python 3.9+ and re-run."; exit 1)
+	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "ERROR: $(PYTHON) is required for Python-backed Make targets in this repo. Install Python 3.9+ and re-run."; exit 1)
 
 check-actionlint-version: ## Verify actionlint version matches CI
-	@version="$$(actionlint --version 2>/dev/null | awk 'NR == 1 {print $$1}')"; \
+	@version="$$(actionlint --version 2>/dev/null | awk 'NR == 1 {print $$1}' | sed 's/^v//')"; \
 	if [ "$$version" != "$(ACTIONLINT_VERSION)" ]; then \
 		echo "ERROR: actionlint $(ACTIONLINT_VERSION) required to match CI. Install with: make tools"; \
 		if [ -n "$$version" ]; then echo "Installed: $$version"; else echo "Installed: not found"; fi; \


### PR DESCRIPTION
## Summary
- accept the `v` prefix in `actionlint --version` output and keep the installed binary on PATH in CI
- stop using `actions/setup-python` in the self-hosted Validate job and run script tests with the preinstalled `python3.9` instead
- preserve the existing local gate behavior while making the self-hosted Validate job match the runner reality

## Testing
- make actionlint-check
- make python-test PYTHON=python3.9
- actionlint
- make ci

Refs #383
Refs #384