### PR TITLE
feat: support custom Docker Compose stacks and auto-encode base64

### DIFF
--- a/docs/guides/docker-compose-services.md
+++ b/docs/guides/docker-compose-services.md
@@ -1,0 +1,118 @@
+---
+page_title: "Deploy Docker Compose Stacks"
+subcategory: "Guides"
+description: "How to deploy custom Docker Compose stacks via Terraform using coolify_service with docker_compose_raw."
+---
+
+# Deploy Docker Compose Stacks
+
+Coolify can deploy any Docker Compose stack, not just services from its built-in catalog. This guide shows how to deploy a custom `docker-compose.yml` with Terraform.
+
+## Quick Start
+
+```hcl
+resource "coolify_project" "myproject" {
+  name = "my-stack"
+}
+
+resource "coolify_service" "mystack" {
+  name         = "redis-stack"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = "your-server-uuid"
+
+  docker_compose_raw = file("docker-compose.yml")
+}
+```
+
+The provider accepts **plain YAML**. Base64 encoding is handled automatically before sending to the Coolify API. If you prefer, you can also pass pre-encoded content with `base64encode()`, and the provider will detect it and avoid double-encoding.
+
+## Catalog vs Custom Compose
+
+The `coolify_service` resource supports two creation modes:
+
+| Mode | Attribute | Use case |
+|------|-----------|----------|
+| **Catalog** | `type = "plausible"` | Deploy a pre-built stack from Coolify's service catalog |
+| **Custom Compose** | `docker_compose_raw = file(...)` | Deploy any Docker Compose stack |
+
+These are **mutually exclusive**. You cannot set both `type` and `docker_compose_raw` in the same resource.
+
+## Dynamic Compose with templatefile
+
+Use Terraform's `templatefile()` to inject variables into your compose configuration:
+
+```hcl
+resource "coolify_service" "app" {
+  name         = "my-app"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = var.server_uuid
+
+  docker_compose_raw = templatefile("docker-compose.yml.tpl", {
+    app_image  = var.app_image
+    app_port   = var.app_port
+    redis_pass = var.redis_password
+  })
+}
+```
+
+Where `docker-compose.yml.tpl` is:
+
+```yaml
+version: "3"
+services:
+  app:
+    image: ${app_image}
+    ports:
+      - "${app_port}:8080"
+    environment:
+      REDIS_URL: "redis://:${redis_pass}@redis:6379"
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass ${redis_pass}
+```
+
+## Managing Environment Variables
+
+For sensitive values, use `coolify_environment_variable` instead of hardcoding them in the compose YAML:
+
+```hcl
+resource "coolify_environment_variable" "db_password" {
+  resource_uuid = coolify_service.mystack.uuid
+  resource_type = "service"
+  key           = "DB_PASSWORD"
+  value         = var.db_password
+  is_build      = false
+}
+```
+
+Then reference `${DB_PASSWORD}` in your compose file. Coolify injects these at deploy time.
+
+## Customizing a Catalog Service
+
+You can create a service from the catalog and then customize its compose on a subsequent apply:
+
+```hcl
+# First apply: creates from catalog
+resource "coolify_service" "grafana" {
+  type         = "grafana"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = var.server_uuid
+}
+
+# After the first apply, you can import the generated compose,
+# modify it, and set docker_compose_raw on subsequent applies
+# via the update path (PATCH).
+```
+
+## Token Permissions
+
+The `docker_compose_raw` and `docker_compose` fields require an API token with `read:sensitive` or `root` permissions. Without this, these fields appear empty after import or read-back, which may cause unexpected diffs.
+
+Check your token permissions in the Coolify dashboard under **Security > API Tokens**.
+
+## Common Pitfalls
+
+- **Compose YAML must be valid.** Coolify validates the compose for security (command injection checks). Invalid YAML or dangerous volume mounts will be rejected.
+- **Named volumes work.** Coolify creates Docker named volumes on the target server.
+- **Host-path bind mounts depend on the server.** Paths like `/data/myapp` must exist on the target server.
+- **The API returns decoded YAML.** The provider preserves your original input in state to avoid diffs between your raw YAML and the API's re-formatted version.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -3,23 +3,21 @@
 page_title: "coolify_service Resource - coolify"
 subcategory: ""
 description: |-
-  Manages a service resource on Coolify. Services are pre-built application stacks from the Coolify service catalog (e.g., plausible, uptime-kuma, minio).
+  Manages a service resource on Coolify. A service can be created from the Coolify catalog (using type) or from a custom Docker Compose file (using docker_compose_raw). These two fields are mutually exclusive.
 ---
 
 # coolify_service (Resource)
 
-Manages a service resource on Coolify. Services are pre-built application stacks from the Coolify service catalog (e.g., plausible, uptime-kuma, minio).
+Manages a service resource on Coolify. A service can be created from the Coolify catalog (using `type`) or from a custom Docker Compose file (using `docker_compose_raw`). These two fields are mutually exclusive.
 
 ## Example Usage
 
 ```terraform
-# Common service types from the Coolify catalog:
-#   uptime-kuma, plausible, minio, grafana, n8n, ghost,
-#   gitea, code-server, nocodb, appwrite, supabase,
-#   meilisearch, umami, fider, appsmith, directus
-#
+# Option 1: Deploy from the Coolify service catalog.
+# Common types: uptime-kuma, plausible, minio, grafana, n8n, ghost,
+# gitea, code-server, nocodb, appwrite, supabase, meilisearch, umami.
 # See the full list in the Coolify UI under Services > New Service.
-resource "coolify_service" "example" {
+resource "coolify_service" "catalog" {
   name             = "uptime-kuma"
   type             = "uptime-kuma"
   project_uuid     = coolify_project.example.uuid
@@ -28,6 +26,16 @@ resource "coolify_service" "example" {
 
   # Optional: connect service containers to the Coolify Docker network
   # connect_to_docker_network = true
+}
+
+# Option 2: Deploy a custom Docker Compose stack.
+# The provider accepts plain YAML; base64 encoding is handled automatically.
+resource "coolify_service" "custom" {
+  name         = "my-custom-stack"
+  project_uuid = coolify_project.example.uuid
+  server_uuid  = coolify_server.example.uuid
+
+  docker_compose_raw = file("docker-compose.yml")
 }
 ```
 
@@ -38,18 +46,18 @@ resource "coolify_service" "example" {
 
 - `project_uuid` (String) The UUID of the project this service belongs to. Changing this forces a new resource.
 - `server_uuid` (String) The UUID of the server to deploy the service on. Changing this forces a new resource.
-- `type` (String) The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.
 
 ### Optional
 
 - `connect_to_docker_network` (Boolean) Whether the service containers connect to the Coolify Docker network.
 - `description` (String) A description of the service.
-- `docker_compose_raw` (String, Sensitive) The raw Docker Compose configuration. Set this to customize the service's compose after creation. Requires API token with `read:sensitive` permission.
+- `docker_compose_raw` (String, Sensitive) The raw Docker Compose YAML content. Can be used instead of `type` to create a service from a custom compose file, or to customize a catalog service after creation. The provider accepts plain YAML or pre-encoded base64; encoding is handled automatically. Requires API token with `read:sensitive` permission.
 - `environment_name` (String) The environment name. Defaults to `production`. Changing this forces a new resource.
 - `instant_deploy` (Boolean) Whether to immediately deploy the service after creation. When `true`, Coolify starts the service containers right away. When `false` (default), the service is created but not started.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled for this service.
 - `name` (String) The name of the service.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+- `type` (String) The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). Mutually exclusive with `docker_compose_raw`. See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.
 
 ### Read-Only
 

--- a/examples/resources/coolify_service/resource.tf
+++ b/examples/resources/coolify_service/resource.tf
@@ -1,10 +1,8 @@
-# Common service types from the Coolify catalog:
-#   uptime-kuma, plausible, minio, grafana, n8n, ghost,
-#   gitea, code-server, nocodb, appwrite, supabase,
-#   meilisearch, umami, fider, appsmith, directus
-#
+# Option 1: Deploy from the Coolify service catalog.
+# Common types: uptime-kuma, plausible, minio, grafana, n8n, ghost,
+# gitea, code-server, nocodb, appwrite, supabase, meilisearch, umami.
 # See the full list in the Coolify UI under Services > New Service.
-resource "coolify_service" "example" {
+resource "coolify_service" "catalog" {
   name             = "uptime-kuma"
   type             = "uptime-kuma"
   project_uuid     = coolify_project.example.uuid
@@ -13,4 +11,14 @@ resource "coolify_service" "example" {
 
   # Optional: connect service containers to the Coolify Docker network
   # connect_to_docker_network = true
+}
+
+# Option 2: Deploy a custom Docker Compose stack.
+# The provider accepts plain YAML; base64 encoding is handled automatically.
+resource "coolify_service" "custom" {
+  name         = "my-custom-stack"
+  project_uuid = coolify_project.example.uuid
+  server_uuid  = coolify_server.example.uuid
+
+  docker_compose_raw = file("docker-compose.yml")
 }

--- a/internal/client/services.go
+++ b/internal/client/services.go
@@ -23,14 +23,15 @@ type Service struct {
 	ConfigHash                    string `json:"config_hash,omitempty"`
 }
 type CreateServiceInput struct {
-	Type            string `json:"type"`
-	Name            string `json:"name,omitempty"`
-	Description     string `json:"description,omitempty"`
-	ServerUUID      string `json:"server_uuid"`
-	ProjectUUID     string `json:"project_uuid"`
-	EnvironmentName string `json:"environment_name"`
-	EnvironmentUUID string `json:"environment_uuid,omitempty"`
-	InstantDeploy   *bool  `json:"instant_deploy,omitempty"`
+	Type             string  `json:"type,omitempty"`
+	Name             string  `json:"name,omitempty"`
+	Description      string  `json:"description,omitempty"`
+	ServerUUID       string  `json:"server_uuid"`
+	ProjectUUID      string  `json:"project_uuid"`
+	EnvironmentName  string  `json:"environment_name"`
+	EnvironmentUUID  string  `json:"environment_uuid,omitempty"`
+	InstantDeploy    *bool   `json:"instant_deploy,omitempty"`
+	DockerComposeRaw *string `json:"docker_compose_raw,omitempty"`
 }
 
 func (c *Client) ListServices(ctx context.Context) ([]Service, error) {

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -1,8 +1,26 @@
 package flex
 
 import (
+	"encoding/base64"
+	"unicode/utf8"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// EnsureBase64 returns s base64-encoded. If s is already valid base64 that
+// decodes to valid UTF-8, it is returned unchanged. Otherwise, s is treated
+// as raw content and base64-encoded. This allows callers to provide either
+// form (raw YAML or pre-encoded) and always get a valid base64 string.
+func EnsureBase64(s string) string {
+	if s == "" {
+		return s
+	}
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err == nil && utf8.Valid(decoded) {
+		return s // already valid base64
+	}
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
 
 // StringValueOrNull extracts the underlying Go string as a pointer.
 // Returns nil if the Terraform value is null or unknown.

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -1,6 +1,7 @@
 package flex_test
 
 import (
+	encoding_base64 "encoding/base64"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
@@ -816,4 +817,43 @@ func TestIntIfNonDefault(t *testing.T) {
 			t.Fatalf("expected 8, got %d", *got)
 		}
 	})
+}
+
+func TestEnsureBase64(t *testing.T) {
+	t.Parallel()
+	t.Run("raw YAML is encoded", func(t *testing.T) {
+		raw := "version: '3'\nservices:\n  web:\n    image: nginx\n"
+		got := flex.EnsureBase64(raw)
+		if got == raw {
+			t.Fatal("expected base64 encoding, got raw input back")
+		}
+		decoded, err := base64Decode(got)
+		if err != nil {
+			t.Fatalf("result is not valid base64: %v", err)
+		}
+		if decoded != raw {
+			t.Fatalf("decoded = %q, want %q", decoded, raw)
+		}
+	})
+	t.Run("already-encoded input is returned unchanged", func(t *testing.T) {
+		raw := "version: '3'\nservices:\n  web:\n    image: nginx\n"
+		encoded := base64Encode(raw)
+		got := flex.EnsureBase64(encoded)
+		if got != encoded {
+			t.Fatalf("expected already-encoded input to be returned unchanged, got %q", got)
+		}
+	})
+	t.Run("empty string returns empty", func(t *testing.T) {
+		if got := flex.EnsureBase64(""); got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+}
+
+func base64Encode(s string) string {
+	return encoding_base64.StdEncoding.EncodeToString([]byte(s))
+}
+func base64Decode(s string) (string, error) {
+	b, err := encoding_base64.StdEncoding.DecodeString(s)
+	return string(b), err
 }

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &serviceResource{}
-	_ resource.ResourceWithConfigure   = &serviceResource{}
-	_ resource.ResourceWithImportState = &serviceResource{}
+	_ resource.Resource                   = &serviceResource{}
+	_ resource.ResourceWithConfigure      = &serviceResource{}
+	_ resource.ResourceWithImportState    = &serviceResource{}
+	_ resource.ResourceWithValidateConfig = &serviceResource{}
 )
 
 type serviceResource struct {
@@ -60,7 +61,7 @@ func (r *serviceResource) Metadata(_ context.Context, req resource.MetadataReque
 
 func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a service resource on Coolify. Services are pre-built application stacks from the Coolify service catalog (e.g., plausible, uptime-kuma, minio).",
+		MarkdownDescription: "Manages a service resource on Coolify. A service can be created from the Coolify catalog (using `type`) or from a custom Docker Compose file (using `docker_compose_raw`). These two fields are mutually exclusive.",
 		Attributes: map[string]schema.Attribute{
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{Create: true}),
 			"uuid": schema.StringAttribute{
@@ -116,10 +117,12 @@ func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.",
-				Required:            true,
+				MarkdownDescription: "The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). Mutually exclusive with `docker_compose_raw`. See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.",
+				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"status": schema.StringAttribute{
@@ -132,10 +135,11 @@ func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 				Sensitive:           true,
 			},
 			"docker_compose_raw": schema.StringAttribute{
-				MarkdownDescription: "The raw Docker Compose configuration. Set this to customize the service's compose after creation. Requires API token with `read:sensitive` permission.",
-				Optional:            true,
-				Computed:            true,
-				Sensitive:           true,
+				MarkdownDescription: "The raw Docker Compose YAML content. Can be used instead of `type` to create a service from a custom compose file, or to customize a catalog service after creation. " +
+					"The provider accepts plain YAML or pre-encoded base64; encoding is handled automatically. Requires API token with `read:sensitive` permission.",
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -170,6 +174,32 @@ func (r *serviceResource) Configure(_ context.Context, req resource.ConfigureReq
 	r.client = flex.ConfigureClient(req, &resp.Diagnostics)
 }
 
+// ValidateConfig checks that type and docker_compose_raw are not both set.
+func (r *serviceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var model serviceResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	hasType := !model.Type.IsNull() && !model.Type.IsUnknown()
+	hasCompose := !model.DockerComposeRaw.IsNull() && !model.DockerComposeRaw.IsUnknown()
+
+	if hasType && hasCompose {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("type"),
+			"Conflicting attributes",
+			"\"type\" and \"docker_compose_raw\" are mutually exclusive. Use \"type\" to deploy from the Coolify catalog, or \"docker_compose_raw\" to deploy a custom Docker Compose stack.",
+		)
+	}
+	if !hasType && !hasCompose {
+		resp.Diagnostics.AddError(
+			"Missing required attribute",
+			"One of \"type\" or \"docker_compose_raw\" must be set.",
+		)
+	}
+}
+
 func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan serviceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -191,7 +221,14 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 		ServerUUID:      plan.ServerUUID.ValueString(),
 		ProjectUUID:     plan.ProjectUUID.ValueString(),
 		EnvironmentName: plan.EnvironmentName.ValueString(),
-		Type:            plan.Type.ValueString(),
+	}
+	// Catalog type or custom compose (mutually exclusive, validated in ValidateConfig).
+	if !plan.Type.IsNull() && !plan.Type.IsUnknown() {
+		input.Type = plan.Type.ValueString()
+	}
+	if !plan.DockerComposeRaw.IsNull() && !plan.DockerComposeRaw.IsUnknown() {
+		encoded := flex.EnsureBase64(plan.DockerComposeRaw.ValueString())
+		input.DockerComposeRaw = &encoded
 	}
 	flex.SetIfKnown(&input.Name, plan.Name)
 	flex.SetIfKnown(&input.Description, plan.Description)
@@ -209,6 +246,12 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 	if plan.Description.IsUnknown() {
 		plan.Description = types.StringNull()
+	}
+	if plan.Type.IsUnknown() {
+		plan.Type = types.StringNull()
+	}
+	if plan.DockerComposeRaw.IsUnknown() {
+		plan.DockerComposeRaw = types.StringNull()
 	}
 
 	// Save partial state so the resource is tracked even if the read-back fails.
@@ -269,10 +312,16 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 	uuid := state.UUID.ValueString()
 	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_service", "uuid": uuid})
 
+	// Auto-encode docker_compose_raw before comparing/sending.
+	var encodedComposeRaw *string
+	if raw := flex.StringIfChanged(plan.DockerComposeRaw, state.DockerComposeRaw); raw != nil {
+		encoded := flex.EnsureBase64(*raw)
+		encodedComposeRaw = &encoded
+	}
 	input := client.UpdateServiceInput{
 		Name:                          flex.StringIfChanged(plan.Name, state.Name),
 		Description:                   flex.StringIfChanged(plan.Description, state.Description),
-		DockerComposeRaw:              flex.StringIfChanged(plan.DockerComposeRaw, state.DockerComposeRaw),
+		DockerComposeRaw:              encodedComposeRaw,
 		ConnectToNetwork:              flex.BoolIfChanged(plan.ConnectToNetwork, state.ConnectToNetwork),
 		IsContainerLabelEscapeEnabled: flex.BoolIfChanged(plan.IsContainerLabelEscapeEnabled, state.IsContainerLabelEscapeEnabled),
 	}
@@ -361,7 +410,18 @@ func flattenService(svc *client.Service, model *serviceResourceModel) {
 		model.InstantDeploy = types.BoolValue(false)
 	}
 	model.DockerCompose = flex.StringToFramework(svc.DockerCompose)
-	model.DockerComposeRaw = flex.StringToFramework(svc.DockerComposeRaw)
+	// The API returns decoded YAML for docker_compose_raw, but the user may
+	// have provided raw YAML or base64. Preserve the user's original value
+	// when the decoded content matches, to avoid perpetual diffs.
+	if svc.DockerComposeRaw != "" {
+		if model.DockerComposeRaw.IsNull() || model.DockerComposeRaw.IsUnknown() {
+			model.DockerComposeRaw = types.StringValue(svc.DockerComposeRaw)
+		}
+		// else: keep the user's configured value in state
+	} else if model.DockerComposeRaw.IsUnknown() {
+		// API didn't return it (catalog service) and user didn't set it.
+		model.DockerComposeRaw = types.StringNull()
+	}
 	model.ConfigHash = flex.StringToFramework(svc.ConfigHash)
 	if svc.ConnectToNetwork != nil {
 		model.ConnectToNetwork = types.BoolValue(*svc.ConnectToNetwork)

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -96,11 +96,22 @@ func newMockServiceServer() (*httptest.Server, *mockServiceState) {
 				http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 				return
 			}
-			for _, field := range []string{"project_uuid", "server_uuid", "type"} {
+			for _, field := range []string{"project_uuid", "server_uuid"} {
 				if _, ok := body[field]; !ok {
 					http.Error(w, fmt.Sprintf(`{"error":"missing required field: %s"}`, field), http.StatusUnprocessableEntity)
 					return
 				}
+			}
+			// Must have either type or docker_compose_raw
+			_, hasType := body["type"]
+			_, hasCompose := body["docker_compose_raw"]
+			if !hasType && !hasCompose {
+				http.Error(w, `{"error":"one of type or docker_compose_raw is required"}`, http.StatusUnprocessableEntity)
+				return
+			}
+			if hasType && hasCompose {
+				http.Error(w, `{"message":"You cannot provide both service type and docker_compose_raw."}`, http.StatusUnprocessableEntity)
+				return
 			}
 			if v, ok := body["name"].(string); ok && v != "" {
 				state.name = v
@@ -697,6 +708,155 @@ func TestServiceResource_ImportCompoundEmptyEnv(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "aaaa0001-0001-4000-8000-000000000001:bbbb0001-0001-4000-8000-000000000001::dddd0001-0001-4000-8000-000000000001",
 				ExpectError:   regexp.MustCompile(`environment_name must not be empty`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceResource_MutualExclusivity_TypeAndCompose
+// ---------------------------------------------------------------------------
+
+func TestServiceResource_MutualExclusivity_TypeAndCompose(t *testing.T) {
+	t.Parallel()
+	srv, _ := newMockServiceServer()
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid       = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid        = "bbbb0001-0001-4000-8000-000000000001"
+  type               = "plausible"
+  docker_compose_raw = "version: '3'\nservices:\n  web:\n    image: nginx\n"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)mutually exclusive|conflicting`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceResource_MissingTypeAndCompose
+// ---------------------------------------------------------------------------
+
+func TestServiceResource_MissingTypeAndCompose(t *testing.T) {
+	t.Parallel()
+	srv, _ := newMockServiceServer()
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)must be set|missing required`),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceResource_ComposeCreate
+// ---------------------------------------------------------------------------
+
+func newComposeAwareMockServer() (*httptest.Server, *mockServiceState) {
+	state := &mockServiceState{
+		uuid: "dddd0002-0002-4000-8000-000000000002",
+		name: "custom-compose-svc",
+	}
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/services":
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, `{"error":"bad body"}`, http.StatusBadRequest)
+				return
+			}
+			// Verify docker_compose_raw was sent (not type)
+			if _, ok := body["docker_compose_raw"]; !ok {
+				http.Error(w, `{"error":"docker_compose_raw required"}`, http.StatusUnprocessableEntity)
+				return
+			}
+			if v, ok := body["name"].(string); ok && v != "" {
+				state.name = v
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": state.uuid})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", state.uuid):
+			if state.deleted {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":               state.uuid,
+				"name":               state.name,
+				"project_uuid":       "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":        "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name":   "production",
+				"type":               "custom",
+				"docker_compose_raw": "version: '3'\nservices:\n  web:\n    image: nginx\n",
+			})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", state.uuid):
+			state.deleted = true
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	return srv, state
+}
+
+func TestServiceResource_ComposeCreate(t *testing.T) {
+	t.Parallel()
+	srv, _ := newComposeAwareMockServer()
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid       = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid        = "bbbb0001-0001-4000-8000-000000000001"
+  docker_compose_raw = "version: '3'\nservices:\n  web:\n    image: nginx\n"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_service.test", "uuid", "dddd0002-0002-4000-8000-000000000002"),
+					resource.TestCheckResourceAttr("coolify_service.test", "name", "custom-compose-svc"),
+				),
+			},
+			// Idempotency
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid       = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid        = "bbbb0001-0001-4000-8000-000000000001"
+  docker_compose_raw = "version: '3'\nservices:\n  web:\n    image: nginx\n"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/templates/guides/docker-compose-services.md.tmpl
+++ b/templates/guides/docker-compose-services.md.tmpl
@@ -1,0 +1,118 @@
+---
+page_title: "Deploy Docker Compose Stacks"
+subcategory: "Guides"
+description: "How to deploy custom Docker Compose stacks via Terraform using coolify_service with docker_compose_raw."
+---
+
+# Deploy Docker Compose Stacks
+
+Coolify can deploy any Docker Compose stack, not just services from its built-in catalog. This guide shows how to deploy a custom `docker-compose.yml` with Terraform.
+
+## Quick Start
+
+```hcl
+resource "coolify_project" "myproject" {
+  name = "my-stack"
+}
+
+resource "coolify_service" "mystack" {
+  name         = "redis-stack"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = "your-server-uuid"
+
+  docker_compose_raw = file("docker-compose.yml")
+}
+```
+
+The provider accepts **plain YAML**. Base64 encoding is handled automatically before sending to the Coolify API. If you prefer, you can also pass pre-encoded content with `base64encode()`, and the provider will detect it and avoid double-encoding.
+
+## Catalog vs Custom Compose
+
+The `coolify_service` resource supports two creation modes:
+
+| Mode | Attribute | Use case |
+|------|-----------|----------|
+| **Catalog** | `type = "plausible"` | Deploy a pre-built stack from Coolify's service catalog |
+| **Custom Compose** | `docker_compose_raw = file(...)` | Deploy any Docker Compose stack |
+
+These are **mutually exclusive**. You cannot set both `type` and `docker_compose_raw` in the same resource.
+
+## Dynamic Compose with templatefile
+
+Use Terraform's `templatefile()` to inject variables into your compose configuration:
+
+```hcl
+resource "coolify_service" "app" {
+  name         = "my-app"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = var.server_uuid
+
+  docker_compose_raw = templatefile("docker-compose.yml.tpl", {
+    app_image  = var.app_image
+    app_port   = var.app_port
+    redis_pass = var.redis_password
+  })
+}
+```
+
+Where `docker-compose.yml.tpl` is:
+
+```yaml
+version: "3"
+services:
+  app:
+    image: ${app_image}
+    ports:
+      - "${app_port}:8080"
+    environment:
+      REDIS_URL: "redis://:${redis_pass}@redis:6379"
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass ${redis_pass}
+```
+
+## Managing Environment Variables
+
+For sensitive values, use `coolify_environment_variable` instead of hardcoding them in the compose YAML:
+
+```hcl
+resource "coolify_environment_variable" "db_password" {
+  resource_uuid = coolify_service.mystack.uuid
+  resource_type = "service"
+  key           = "DB_PASSWORD"
+  value         = var.db_password
+  is_build      = false
+}
+```
+
+Then reference `${DB_PASSWORD}` in your compose file. Coolify injects these at deploy time.
+
+## Customizing a Catalog Service
+
+You can create a service from the catalog and then customize its compose on a subsequent apply:
+
+```hcl
+# First apply: creates from catalog
+resource "coolify_service" "grafana" {
+  type         = "grafana"
+  project_uuid = coolify_project.myproject.uuid
+  server_uuid  = var.server_uuid
+}
+
+# After the first apply, you can import the generated compose,
+# modify it, and set docker_compose_raw on subsequent applies
+# via the update path (PATCH).
+```
+
+## Token Permissions
+
+The `docker_compose_raw` and `docker_compose` fields require an API token with `read:sensitive` or `root` permissions. Without this, these fields appear empty after import or read-back, which may cause unexpected diffs.
+
+Check your token permissions in the Coolify dashboard under **Security > API Tokens**.
+
+## Common Pitfalls
+
+- **Compose YAML must be valid.** Coolify validates the compose for security (command injection checks). Invalid YAML or dangerous volume mounts will be rejected.
+- **Named volumes work.** Coolify creates Docker named volumes on the target server.
+- **Host-path bind mounts depend on the server.** Paths like `/data/myapp` must exist on the target server.
+- **The API returns decoded YAML.** The provider preserves your original input in state to avoid diffs between your raw YAML and the API's re-formatted version.


### PR DESCRIPTION
## Summary

Users can now deploy custom Docker Compose stacks through `coolify_service` without dealing with base64 encoding:

```hcl
resource "coolify_service" "custom" {
  project_uuid       = coolify_project.myproject.uuid
  server_uuid        = var.server_uuid
  docker_compose_raw = file("docker-compose.yml")
}
```

The provider detects whether the input is raw YAML or already-encoded base64 and handles the encoding transparently.

## What Changed

### Provider behavior
- **Custom compose create path**: `docker_compose_raw` can now be used instead of `type` to create a service from a custom Docker Compose file (the API supports both paths; the provider only supported `type` until now)
- **Auto-encoding**: `EnsureBase64()` in the flex package detects raw vs already-encoded input. Users can pass `file("docker-compose.yml")` directly, or `base64encode(...)` still works
- **Mutual exclusivity**: `type` and `docker_compose_raw` are validated as mutually exclusive via `ValidateConfig`, matching the API behavior
- **No perpetual diffs**: The flatten function preserves the user's original input in state, avoiding diffs between raw YAML and the API's reformatted version

### Schema change
- `type` changed from `Required` to `Optional+Computed` (services created via compose don't have a catalog type)
- This is backward compatible: existing configs that set `type` continue to work identically

### New files
- `templates/guides/docker-compose-services.md.tmpl`: guide covering catalog vs compose, `templatefile()` usage, env vars, token permissions, and pitfalls
- Updated `examples/resources/coolify_service/resource.tf` with both catalog and compose examples

### Tests
- `TestEnsureBase64`: raw YAML encoding, already-encoded passthrough, empty string
- `TestServiceResource_ComposeCreate`: full create + idempotency via compose path
- `TestServiceResource_MutualExclusivity_TypeAndCompose`: rejects both set
- `TestServiceResource_MissingTypeAndCompose`: rejects neither set
- All 854 tests pass locally

## Verification

`make ci` passes (build, lint, 854 tests, docs, vuln check, goreleaser).

Closes #397