### PR TITLE
fix: broken env var example in compose guide, add design comments

### DIFF
--- a/docs/guides/docker-compose-services.md
+++ b/docs/guides/docker-compose-services.md
@@ -77,11 +77,9 @@ For sensitive values, use `coolify_environment_variable` instead of hardcoding t
 
 ```hcl
 resource "coolify_environment_variable" "db_password" {
-  resource_uuid = coolify_service.mystack.uuid
-  resource_type = "service"
-  key           = "DB_PASSWORD"
-  value         = var.db_password
-  is_build      = false
+  service_uuid = coolify_service.mystack.uuid
+  key          = "DB_PASSWORD"
+  value        = var.db_password
 }
 ```
 
@@ -92,17 +90,27 @@ Then reference `${DB_PASSWORD}` in your compose file. Coolify injects these at d
 You can create a service from the catalog and then customize its compose on a subsequent apply:
 
 ```hcl
-# First apply: creates from catalog
+# First apply: creates from the catalog
 resource "coolify_service" "grafana" {
   type         = "grafana"
   project_uuid = coolify_project.myproject.uuid
   server_uuid  = var.server_uuid
 }
-
-# After the first apply, you can import the generated compose,
-# modify it, and set docker_compose_raw on subsequent applies
-# via the update path (PATCH).
 ```
+
+After the first apply, export the generated compose from state (`terraform state show coolify_service.grafana`), save it to a file, customize it, then switch your config:
+
+```hcl
+# Subsequent apply: replace "type" with your customized compose.
+# The provider preserves the original type value from state automatically.
+resource "coolify_service" "grafana" {
+  project_uuid       = coolify_project.myproject.uuid
+  server_uuid        = var.server_uuid
+  docker_compose_raw = file("grafana-custom.yml")
+}
+```
+
+Note: you must remove `type` from config when adding `docker_compose_raw`, since they are mutually exclusive.
 
 ## Token Permissions
 

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -175,6 +175,10 @@ func (r *serviceResource) Configure(_ context.Context, req resource.ConfigureReq
 }
 
 // ValidateConfig checks that type and docker_compose_raw are not both set.
+// We use ValidateConfig instead of stringvalidator.ExactlyOneOf because type
+// is Optional+Computed with UseStateForUnknown. ExactlyOneOf operates at the
+// attribute level and would misfire when the computed value is populated from
+// state, incorrectly rejecting configs that only set docker_compose_raw.
 func (r *serviceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var model serviceResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)

--- a/scripts/extract-contract.py
+++ b/scripts/extract-contract.py
@@ -489,6 +489,12 @@ def extract_routes(routes_file: Path) -> list[dict]:
 
     Parses Laravel Route:: calls and returns a sorted list of
     {method, path, controller, action, middleware} dicts.
+
+    Note: This parser assumes all routes specify their full relative path
+    inline (e.g., '/applications/{uuid}/envs'). Coolify's api.php uses a
+    single Route::group with prefix 'v1' for middleware, but each route
+    inside defines its complete path. If Coolify adds nested Route::prefix()
+    groups, this parser would need to track prefix scope.
     """
     if not routes_file.exists():
         return []

--- a/templates/guides/docker-compose-services.md.tmpl
+++ b/templates/guides/docker-compose-services.md.tmpl
@@ -77,11 +77,9 @@ For sensitive values, use `coolify_environment_variable` instead of hardcoding t
 
 ```hcl
 resource "coolify_environment_variable" "db_password" {
-  resource_uuid = coolify_service.mystack.uuid
-  resource_type = "service"
-  key           = "DB_PASSWORD"
-  value         = var.db_password
-  is_build      = false
+  service_uuid = coolify_service.mystack.uuid
+  key          = "DB_PASSWORD"
+  value        = var.db_password
 }
 ```
 
@@ -92,17 +90,27 @@ Then reference `${DB_PASSWORD}` in your compose file. Coolify injects these at d
 You can create a service from the catalog and then customize its compose on a subsequent apply:
 
 ```hcl
-# First apply: creates from catalog
+# First apply: creates from the catalog
 resource "coolify_service" "grafana" {
   type         = "grafana"
   project_uuid = coolify_project.myproject.uuid
   server_uuid  = var.server_uuid
 }
-
-# After the first apply, you can import the generated compose,
-# modify it, and set docker_compose_raw on subsequent applies
-# via the update path (PATCH).
 ```
+
+After the first apply, export the generated compose from state (`terraform state show coolify_service.grafana`), save it to a file, customize it, then switch your config:
+
+```hcl
+# Subsequent apply: replace "type" with your customized compose.
+# The provider preserves the original type value from state automatically.
+resource "coolify_service" "grafana" {
+  project_uuid       = coolify_project.myproject.uuid
+  server_uuid        = var.server_uuid
+  docker_compose_raw = file("grafana-custom.yml")
+}
+```
+
+Note: you must remove `type` from config when adding `docker_compose_raw`, since they are mutually exclusive.
 
 ## Token Permissions
 


### PR DESCRIPTION
Fixes found during multi-perspective improvement cycle:

- **Fix broken env var example** in the Docker Compose guide: used non-existent `resource_uuid`/`resource_type` attributes and `is_build` on a service-scoped variable (would produce two Terraform errors if copy-pasted)
- **Complete catalog customization section** with actual step-2 HCL
- **Add design comment** explaining why `ValidateConfig` is used instead of `ExactlyOneOf` for type/docker_compose_raw mutual exclusivity
- **Document route parser assumption** about inline full paths in `extract_routes()`