### PR TITLE
fix: stabilize flaky TestDeleteService_AddsWarningWhenPollingTimesOut

### DIFF
--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -292,7 +292,12 @@ func TestDeleteService_AddsWarningWhenPollingTimesOut(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	// Use a timeout long enough for the DELETE request to succeed but short
+	// enough that PollUntilDeleted gives up before the resource disappears
+	// (the mock always returns 200, so the resource never actually goes away).
+	// The previous 10ms timeout caused flakes under concurrent test load
+	// because the retryablehttp client couldn't complete even the DELETE.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	res := servicepkg.NewResource()


### PR DESCRIPTION
The test used a 10ms context timeout which was too short for the retryablehttp client to complete the DELETE request under concurrent test load. Increased to 2s, which is long enough for DELETE to succeed but short enough that PollUntilDeleted gives up (the mock always returns 200).

Verified stable: 3/3 passes under full concurrent service test suite (9.5s each run).

Closes #400