### PR TITLE
feat: add urls and force_domain_override to coolify_service

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -36,6 +36,12 @@ resource "coolify_service" "custom" {
   server_uuid  = coolify_server.example.uuid
 
   docker_compose_raw = file("docker-compose.yml")
+
+  # Assign domains to service containers
+  urls = [{
+    name = "web"
+    url  = "https://app.example.com"
+  }]
 }
 ```
 
@@ -53,11 +59,13 @@ resource "coolify_service" "custom" {
 - `description` (String) A description of the service.
 - `docker_compose_raw` (String, Sensitive) The raw Docker Compose YAML content. Can be used instead of `type` to create a service from a custom compose file, or to customize a catalog service after creation. The provider accepts plain YAML or pre-encoded base64; encoding is handled automatically. Requires API token with `read:sensitive` permission.
 - `environment_name` (String) The environment name. Defaults to `production`. Changing this forces a new resource.
+- `force_domain_override` (Boolean) Force domain assignment even if conflicts with other resources are detected. Only relevant when `urls` is set.
 - `instant_deploy` (Boolean) Whether to immediately deploy the service after creation. When `true`, Coolify starts the service containers right away. When `false` (default), the service is created but not started.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled for this service.
 - `name` (String) The name of the service.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `type` (String) The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). Mutually exclusive with `docker_compose_raw`. See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.
+- `urls` (Attributes List) Domain URL mappings for service containers. Each entry maps a compose service name to one or more comma-separated URLs (e.g., `https://app.example.com`). Read-back reconstructs mappings from the service's application FQDNs. (see [below for nested schema](#nestedatt--urls))
 
 ### Read-Only
 
@@ -72,6 +80,18 @@ resource "coolify_service" "custom" {
 Optional:
 
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+
+<a id="nestedatt--urls"></a>
+### Nested Schema for `urls`
+
+Required:
+
+- `name` (String) The service container name as defined in docker-compose (e.g., `web`, `api`).
+
+Optional:
+
+- `url` (String) Comma-separated list of URLs to assign to this container (e.g., `https://app.example.com,https://www.example.com`).
 
 ## Import
 

--- a/examples/resources/coolify_service/resource.tf
+++ b/examples/resources/coolify_service/resource.tf
@@ -21,4 +21,10 @@ resource "coolify_service" "custom" {
   server_uuid  = coolify_server.example.uuid
 
   docker_compose_raw = file("docker-compose.yml")
+
+  # Assign domains to service containers
+  urls = [{
+    name = "web"
+    url  = "https://app.example.com"
+  }]
 }

--- a/internal/client/services.go
+++ b/internal/client/services.go
@@ -7,31 +7,47 @@ import (
 	"net/url"
 )
 
+// ServiceApplication represents a container within a service (from the
+// applications relation loaded by GET /services/{uuid}).
+type ServiceApplication struct {
+	Name string `json:"name"`
+	FQDN string `json:"fqdn,omitempty"`
+}
+
 type Service struct {
-	UUID                          string `json:"uuid"`
-	Name                          string `json:"name"`
-	Description                   string `json:"description,omitempty"`
-	Type                          string `json:"type"`
-	ServerUUID                    string `json:"server_uuid,omitempty"`
-	ProjectUUID                   string `json:"project_uuid,omitempty"`
-	EnvironmentName               string `json:"environment_name,omitempty"`
-	Status                        string `json:"status,omitempty"`
-	DockerCompose                 string `json:"docker_compose,omitempty"`
-	DockerComposeRaw              string `json:"docker_compose_raw,omitempty"`
-	ConnectToNetwork              *bool  `json:"connect_to_docker_network,omitempty"`
-	IsContainerLabelEscapeEnabled *bool  `json:"is_container_label_escape_enabled,omitempty"`
-	ConfigHash                    string `json:"config_hash,omitempty"`
+	UUID                          string               `json:"uuid"`
+	Name                          string               `json:"name"`
+	Description                   string               `json:"description,omitempty"`
+	Type                          string               `json:"type"`
+	ServerUUID                    string               `json:"server_uuid,omitempty"`
+	ProjectUUID                   string               `json:"project_uuid,omitempty"`
+	EnvironmentName               string               `json:"environment_name,omitempty"`
+	Status                        string               `json:"status,omitempty"`
+	DockerCompose                 string               `json:"docker_compose,omitempty"`
+	DockerComposeRaw              string               `json:"docker_compose_raw,omitempty"`
+	ConnectToNetwork              *bool                `json:"connect_to_docker_network,omitempty"`
+	IsContainerLabelEscapeEnabled *bool                `json:"is_container_label_escape_enabled,omitempty"`
+	ConfigHash                    string               `json:"config_hash,omitempty"`
+	Applications                  []ServiceApplication `json:"applications,omitempty"`
+}
+
+// ServiceURL maps a compose service name to one or more URLs.
+type ServiceURL struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 type CreateServiceInput struct {
-	Type             string  `json:"type,omitempty"`
-	Name             string  `json:"name,omitempty"`
-	Description      string  `json:"description,omitempty"`
-	ServerUUID       string  `json:"server_uuid"`
-	ProjectUUID      string  `json:"project_uuid"`
-	EnvironmentName  string  `json:"environment_name"`
-	EnvironmentUUID  string  `json:"environment_uuid,omitempty"`
-	InstantDeploy    *bool   `json:"instant_deploy,omitempty"`
-	DockerComposeRaw *string `json:"docker_compose_raw,omitempty"`
+	Type                string       `json:"type,omitempty"`
+	Name                string       `json:"name,omitempty"`
+	Description         string       `json:"description,omitempty"`
+	ServerUUID          string       `json:"server_uuid"`
+	ProjectUUID         string       `json:"project_uuid"`
+	EnvironmentName     string       `json:"environment_name"`
+	EnvironmentUUID     string       `json:"environment_uuid,omitempty"`
+	InstantDeploy       *bool        `json:"instant_deploy,omitempty"`
+	DockerComposeRaw    *string      `json:"docker_compose_raw,omitempty"`
+	URLs                []ServiceURL `json:"urls,omitempty"`
+	ForceDomainOverride *bool        `json:"force_domain_override,omitempty"`
 }
 
 func (c *Client) ListServices(ctx context.Context) ([]Service, error) {
@@ -60,14 +76,14 @@ func (c *Client) CreateService(ctx context.Context, input CreateServiceInput) (*
 }
 
 type UpdateServiceInput struct {
-	Name                          *string `json:"name,omitempty"`
-	Description                   *string `json:"description,omitempty"`
-	DockerComposeRaw              *string `json:"docker_compose_raw,omitempty"`
-	ConnectToNetwork              *bool   `json:"connect_to_docker_network,omitempty"`
-	IsContainerLabelEscapeEnabled *bool   `json:"is_container_label_escape_enabled,omitempty"`
-	InstantDeploy                 *bool   `json:"instant_deploy,omitempty"`
-	URLs                          *string `json:"urls,omitempty"`
-	ForceDomainOverride           *bool   `json:"force_domain_override,omitempty"`
+	Name                          *string      `json:"name,omitempty"`
+	Description                   *string      `json:"description,omitempty"`
+	DockerComposeRaw              *string      `json:"docker_compose_raw,omitempty"`
+	ConnectToNetwork              *bool        `json:"connect_to_docker_network,omitempty"`
+	IsContainerLabelEscapeEnabled *bool        `json:"is_container_label_escape_enabled,omitempty"`
+	InstantDeploy                 *bool        `json:"instant_deploy,omitempty"`
+	URLs                          []ServiceURL `json:"urls,omitempty"`
+	ForceDomainOverride           *bool        `json:"force_domain_override,omitempty"`
 }
 
 func (c *Client) UpdateService(ctx context.Context, uuid string, input UpdateServiceInput) (*Service, error) {

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -34,21 +34,28 @@ type serviceResource struct {
 }
 
 type serviceResourceModel struct {
-	Timeouts                      timeouts.Value `tfsdk:"timeouts"`
-	UUID                          types.String   `tfsdk:"uuid"`
-	Name                          types.String   `tfsdk:"name"`
-	Description                   types.String   `tfsdk:"description"`
-	ProjectUUID                   types.String   `tfsdk:"project_uuid"`
-	ServerUUID                    types.String   `tfsdk:"server_uuid"`
-	EnvironmentName               types.String   `tfsdk:"environment_name"`
-	Type                          types.String   `tfsdk:"type"`
-	Status                        types.String   `tfsdk:"status"`
-	DockerCompose                 types.String   `tfsdk:"docker_compose"`
-	DockerComposeRaw              types.String   `tfsdk:"docker_compose_raw"`
-	ConnectToNetwork              types.Bool     `tfsdk:"connect_to_docker_network"`
-	IsContainerLabelEscapeEnabled types.Bool     `tfsdk:"is_container_label_escape_enabled"`
-	ConfigHash                    types.String   `tfsdk:"config_hash"`
-	InstantDeploy                 types.Bool     `tfsdk:"instant_deploy"`
+	Timeouts                      timeouts.Value    `tfsdk:"timeouts"`
+	UUID                          types.String      `tfsdk:"uuid"`
+	Name                          types.String      `tfsdk:"name"`
+	Description                   types.String      `tfsdk:"description"`
+	ProjectUUID                   types.String      `tfsdk:"project_uuid"`
+	ServerUUID                    types.String      `tfsdk:"server_uuid"`
+	EnvironmentName               types.String      `tfsdk:"environment_name"`
+	Type                          types.String      `tfsdk:"type"`
+	Status                        types.String      `tfsdk:"status"`
+	DockerCompose                 types.String      `tfsdk:"docker_compose"`
+	DockerComposeRaw              types.String      `tfsdk:"docker_compose_raw"`
+	ConnectToNetwork              types.Bool        `tfsdk:"connect_to_docker_network"`
+	IsContainerLabelEscapeEnabled types.Bool        `tfsdk:"is_container_label_escape_enabled"`
+	ConfigHash                    types.String      `tfsdk:"config_hash"`
+	InstantDeploy                 types.Bool        `tfsdk:"instant_deploy"`
+	URLs                          []serviceURLModel `tfsdk:"urls"`
+	ForceDomainOverride           types.Bool        `tfsdk:"force_domain_override"`
+}
+
+type serviceURLModel struct {
+	Name types.String `tfsdk:"name"`
+	URL  types.String `tfsdk:"url"`
 }
 
 func NewResource() resource.Resource {
@@ -166,6 +173,27 @@ func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
+			"urls": schema.ListNestedAttribute{
+				MarkdownDescription: "Domain URL mappings for service containers. Each entry maps a compose service name to one or more comma-separated URLs (e.g., `https://app.example.com`). " +
+					"Read-back reconstructs mappings from the service's application FQDNs.",
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "The service container name as defined in docker-compose (e.g., `web`, `api`).",
+							Required:            true,
+						},
+						"url": schema.StringAttribute{
+							MarkdownDescription: "Comma-separated list of URLs to assign to this container (e.g., `https://app.example.com,https://www.example.com`).",
+							Optional:            true,
+						},
+					},
+				},
+			},
+			"force_domain_override": schema.BoolAttribute{
+				MarkdownDescription: "Force domain assignment even if conflicts with other resources are detected. Only relevant when `urls` is set.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -237,6 +265,8 @@ func (r *serviceResource) Create(ctx context.Context, req resource.CreateRequest
 	flex.SetIfKnown(&input.Name, plan.Name)
 	flex.SetIfKnown(&input.Description, plan.Description)
 	input.InstantDeploy = flex.BoolValueOrNull(plan.InstantDeploy)
+	input.URLs = expandServiceURLs(plan.URLs)
+	input.ForceDomainOverride = flex.BoolValueOrNull(plan.ForceDomainOverride)
 	created, err := r.client.CreateService(ctx, input)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating service",
@@ -328,6 +358,8 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 		DockerComposeRaw:              encodedComposeRaw,
 		ConnectToNetwork:              flex.BoolIfChanged(plan.ConnectToNetwork, state.ConnectToNetwork),
 		IsContainerLabelEscapeEnabled: flex.BoolIfChanged(plan.IsContainerLabelEscapeEnabled, state.IsContainerLabelEscapeEnabled),
+		URLs:                          expandServiceURLs(plan.URLs),
+		ForceDomainOverride:           flex.BoolValueOrNull(plan.ForceDomainOverride),
 	}
 	if _, err := r.client.UpdateService(ctx, uuid, input); err != nil {
 		resp.Diagnostics.AddError("Error updating service", fmt.Sprintf("service %s: %s", uuid, err))
@@ -452,4 +484,49 @@ func flattenService(svc *client.Service, model *serviceResourceModel) {
 	if svc.EnvironmentName != "" {
 		model.EnvironmentName = flex.StringToFramework(svc.EnvironmentName)
 	}
+
+	model.URLs = flattenServiceURLs(svc.Applications, model.URLs)
+	// force_domain_override is request-only, never returned by the API.
+	// Preserve the user's value in state; it is not read back.
+}
+
+// flattenServiceURLs reconstructs URL mappings from the service's applications.
+// The GET response includes applications with name + fqdn; we map those back
+// to the urls schema shape. Only includes entries that have an FQDN assigned.
+func flattenServiceURLs(apps []client.ServiceApplication, current []serviceURLModel) []serviceURLModel {
+	if len(apps) == 0 {
+		return current
+	}
+	var urls []serviceURLModel
+	for _, app := range apps {
+		if app.FQDN != "" {
+			urls = append(urls, serviceURLModel{
+				Name: types.StringValue(app.Name),
+				URL:  types.StringValue(app.FQDN),
+			})
+		}
+	}
+	if len(urls) > 0 {
+		return urls
+	}
+	if current != nil {
+		// User had URLs configured but API shows none now (cleared externally).
+		return nil
+	}
+	return current
+}
+
+// expandServiceURLs converts the Terraform model to the client input format.
+func expandServiceURLs(urls []serviceURLModel) []client.ServiceURL {
+	if len(urls) == 0 {
+		return nil
+	}
+	result := make([]client.ServiceURL, len(urls))
+	for i, u := range urls {
+		result[i] = client.ServiceURL{
+			Name: u.Name.ValueString(),
+			URL:  u.URL.ValueString(),
+		}
+	}
+	return result
 }

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -70,6 +70,12 @@ func serviceConfig(serverURL string) string {
 	return acctest.ProviderBlockForURL(serverURL) + serviceTestConfig
 }
 
+// serviceURLEntry mirrors the service URL model shape for test state structs.
+type serviceURLEntry struct {
+	Name types.String `tfsdk:"name"`
+	URL  types.String `tfsdk:"url"`
+}
+
 type mockServiceState struct {
 	mu          sync.Mutex
 	uuid        string
@@ -319,21 +325,23 @@ func TestDeleteService_AddsWarningWhenPollingTimesOut(t *testing.T) {
 
 	state := tfsdk.State{Schema: schemaResp.Schema}
 	setDiags := state.Set(ctx, struct {
-		Timeouts                      timeouts.Value `tfsdk:"timeouts"`
-		UUID                          types.String   `tfsdk:"uuid"`
-		Name                          types.String   `tfsdk:"name"`
-		Description                   types.String   `tfsdk:"description"`
-		ProjectUUID                   types.String   `tfsdk:"project_uuid"`
-		ServerUUID                    types.String   `tfsdk:"server_uuid"`
-		EnvironmentName               types.String   `tfsdk:"environment_name"`
-		Type                          types.String   `tfsdk:"type"`
-		Status                        types.String   `tfsdk:"status"`
-		DockerCompose                 types.String   `tfsdk:"docker_compose"`
-		DockerComposeRaw              types.String   `tfsdk:"docker_compose_raw"`
-		ConnectToNetwork              types.Bool     `tfsdk:"connect_to_docker_network"`
-		IsContainerLabelEscapeEnabled types.Bool     `tfsdk:"is_container_label_escape_enabled"`
-		ConfigHash                    types.String   `tfsdk:"config_hash"`
-		InstantDeploy                 types.Bool     `tfsdk:"instant_deploy"`
+		Timeouts                      timeouts.Value    `tfsdk:"timeouts"`
+		UUID                          types.String      `tfsdk:"uuid"`
+		Name                          types.String      `tfsdk:"name"`
+		Description                   types.String      `tfsdk:"description"`
+		ProjectUUID                   types.String      `tfsdk:"project_uuid"`
+		ServerUUID                    types.String      `tfsdk:"server_uuid"`
+		EnvironmentName               types.String      `tfsdk:"environment_name"`
+		Type                          types.String      `tfsdk:"type"`
+		Status                        types.String      `tfsdk:"status"`
+		DockerCompose                 types.String      `tfsdk:"docker_compose"`
+		DockerComposeRaw              types.String      `tfsdk:"docker_compose_raw"`
+		ConnectToNetwork              types.Bool        `tfsdk:"connect_to_docker_network"`
+		IsContainerLabelEscapeEnabled types.Bool        `tfsdk:"is_container_label_escape_enabled"`
+		ConfigHash                    types.String      `tfsdk:"config_hash"`
+		InstantDeploy                 types.Bool        `tfsdk:"instant_deploy"`
+		URLs                          []serviceURLEntry `tfsdk:"urls"`
+		ForceDomainOverride           types.Bool        `tfsdk:"force_domain_override"`
 	}{
 		Timeouts:                      timeouts.Value{Object: types.ObjectNull(map[string]attr.Type{"create": types.StringType})},
 		UUID:                          types.StringValue(uuid),
@@ -350,6 +358,8 @@ func TestDeleteService_AddsWarningWhenPollingTimesOut(t *testing.T) {
 		IsContainerLabelEscapeEnabled: types.BoolNull(),
 		ConfigHash:                    types.StringNull(),
 		InstantDeploy:                 types.BoolNull(),
+		URLs:                          nil,
+		ForceDomainOverride:           types.BoolNull(),
 	})
 	if setDiags.HasError() {
 		t.Fatalf("unexpected state set errors: %v", setDiags.Errors())
@@ -858,6 +868,128 @@ resource "coolify_service" "test" {
   project_uuid       = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid        = "bbbb0001-0001-4000-8000-000000000001"
   docker_compose_raw = "version: '3'\nservices:\n  web:\n    image: nginx\n"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceResource_WithURLs
+// ---------------------------------------------------------------------------
+
+func TestServiceResource_WithURLs(t *testing.T) {
+	t.Parallel()
+	mu := sync.Mutex{}
+	deleted := false
+	svcUUID := "svc-urls-uuid-001"
+	var lastURLs []map[string]interface{}
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/services":
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if urls, ok := body["urls"].([]interface{}); ok {
+				lastURLs = nil
+				for _, u := range urls {
+					if m, ok := u.(map[string]interface{}); ok {
+						lastURLs = append(lastURLs, m)
+					}
+				}
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": svcUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", svcUUID):
+			if deleted {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			// Return applications with fqdn to simulate the read-back.
+			apps := []map[string]interface{}{}
+			for _, u := range lastURLs {
+				apps = append(apps, map[string]interface{}{
+					"name": u["name"],
+					"fqdn": u["url"],
+				})
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             svcUUID,
+				"name":             "plausible-svc",
+				"type":             "plausible",
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"applications":     apps,
+			})
+
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/api/v1/services/"):
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if urls, ok := body["urls"].([]interface{}); ok {
+				lastURLs = nil
+				for _, u := range urls {
+					if m, ok := u.(map[string]interface{}); ok {
+						lastURLs = append(lastURLs, m)
+					}
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": svcUUID})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", svcUUID):
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+  type         = "plausible"
+
+  urls = [{
+    name = "web"
+    url  = "https://app.example.com"
+  }]
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_service.test", "uuid", svcUUID),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.#", "1"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.name", "web"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.url", "https://app.example.com"),
+				),
+			},
+			// Idempotency
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+  type         = "plausible"
+
+  urls = [{
+    name = "web"
+    url  = "https://app.example.com"
+  }]
 }
 `,
 				PlanOnly:           true,


### PR DESCRIPTION
## Summary

Users can now assign domains to service containers directly from Terraform:

```hcl
resource "coolify_service" "mystack" {
  type         = "plausible"
  project_uuid = coolify_project.example.uuid
  server_uuid  = var.server_uuid

  urls = [{
    name = "plausible"
    url  = "https://analytics.example.com"
  }]
}
```

Previously, domain assignment required manual UI configuration after Terraform created the service.

## Changes

### Client (`internal/client/services.go`)
- Add `ServiceApplication` struct (name + fqdn from GET response)
- Add `ServiceURL` struct (name + url for create/update input)
- Add `Applications` field to `Service` (loaded by GET)
- Change `URLs` from `*string` to `[]ServiceURL` in both `CreateServiceInput` and `UpdateServiceInput`

### Resource (`internal/service/service/resource.go`)
- Add `urls` as `ListNestedAttribute` with `name` (required) and `url` (optional) sub-attributes
- Add `force_domain_override` as `Optional` bool
- Wire both into Create and Update input building
- Add `flattenServiceURLs()` that reconstructs URL mappings from the service's `applications` relation on read-back
- Add `expandServiceURLs()` for model-to-client conversion

### Tests
- Add `TestServiceResource_WithURLs`: create with URL mapping + idempotency check
- Update delete-timeout test state struct with new fields

## API Behavior

| Direction | Format |
|-----------|--------|
| **Write** (create/update) | `urls: [{name: "web", url: "https://..."}]` |
| **Read** (GET) | `applications: [{name: "web", fqdn: "https://..."}]` |
| **Response** (create/update) | `domains: ["https://..."]` (flat array) |

The read-back path reconstructs the `{name, url}` mapping from the loaded applications relation.

`force_domain_override` is request-only (bypasses domain conflict detection); it is not persisted or returned by the API.

## Verification

`make ci` passes (855 tests, lint clean, docs generated).

Closes #399