### PR TITLE
fix: prevent urls flatten from populating unconfigured catalog services

### DIFF
--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -491,9 +491,15 @@ func flattenService(svc *client.Service, model *serviceResourceModel) {
 }
 
 // flattenServiceURLs reconstructs URL mappings from the service's applications.
-// The GET response includes applications with name + fqdn; we map those back
-// to the urls schema shape. Only includes entries that have an FQDN assigned.
+// Only populates urls if the user configured them (current != nil). Coolify
+// auto-assigns FQDNs to catalog services, so the API may return application
+// FQDNs even when the user didn't set urls. Without this guard, the flatten
+// causes "inconsistent result after apply" (plan had null, state has values).
 func flattenServiceURLs(apps []client.ServiceApplication, current []serviceURLModel) []serviceURLModel {
+	if current == nil {
+		// User didn't configure urls; don't populate from API.
+		return nil
+	}
 	if len(apps) == 0 {
 		return current
 	}
@@ -509,11 +515,8 @@ func flattenServiceURLs(apps []client.ServiceApplication, current []serviceURLMo
 	if len(urls) > 0 {
 		return urls
 	}
-	if current != nil {
-		// User had URLs configured but API shows none now (cleared externally).
-		return nil
-	}
-	return current
+	// User had URLs configured but API shows none now (cleared externally).
+	return nil
 }
 
 // expandServiceURLs converts the Terraform model to the client input format.


### PR DESCRIPTION
Fixes the acceptance test failure on main (run 26349470113).

Coolify auto-assigns FQDNs to catalog service containers. The `flattenServiceURLs` function was populating the `urls` attribute from the applications relation even when the user didn't configure `urls` in their HCL. This caused `inconsistent result after apply` because the plan had null but the state had values.

Fix: only populate `urls` from the API response if the user configured `urls` in their config (`current != nil`). This matches the same pattern used for other API-defaulted fields.

`make ci` passes (855 tests).