### PR TITLE
chore(ci): add weekly link check schedule and harden test-cloud-bootstrap

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "**/*.md"
       - ".github/workflows/link-check.yml"
+  schedule:
+    - cron: "0 12 * * 1"  # Weekly Monday noon UTC
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-cloud-bootstrap.yml
+++ b/.github/workflows/test-cloud-bootstrap.yml
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: test-cloud-bootstrap
+  cancel-in-progress: true
+
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
@@ -13,6 +17,8 @@ jobs:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Start SSH server with root access
         run: |


### PR DESCRIPTION
## Changes

- **link-check.yml**: Add weekly Monday schedule (`0 12 * * 1`) for proactive broken link detection beyond push/PR triggers
- **test-cloud-bootstrap.yml**: Add concurrency group to prevent duplicate runs, add `persist-credentials: false` to checkout step for security hardening

These are the remaining CI hygiene improvements from the audit that were not covered by Dependabot PR #424.