### PR TITLE
chore: post-public hardening

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [SebTardif]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Coolify Documentation
+    url: https://coolify.io/docs
+    about: Check the Coolify docs for general Coolify questions (not provider-specific).
+  - name: Discussions
+    url: https://github.com/coolify-terraform/terraform-provider-coolify/discussions
+    about: Ask questions or share ideas in GitHub Discussions.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,12 +16,14 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,13 +8,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,15 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: read
-  contents: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Changes

Post-public launch hardening based on Scorecard alerts and community profile audit.

### Scorecard TokenPermissions (fixes 3 alerts)
- **codeql.yml**: Move `security-events: write` from top-level to job-level
- **release.yml**: Move `contents: write` from top-level to job-level
- **dependabot-auto-merge.yml**: Move `contents: write` + `pull-requests: write` from top-level to job-level

All three workflows now declare `permissions: contents: read` at workflow level and only grant write at the job level, satisfying the OpenSSF Scorecard Token-Permissions check.

### Community health
- **FUNDING.yml**: Enable GitHub Sponsors link
- **Issue template config.yml**: Add template chooser with contact links to Coolify docs and Discussions, disable blank issues

### Settings (already applied)
- Branch protection: enabled dismiss stale reviews and require code owner reviews