### PR TITLE
ci: improve reliability and add compliance badges

### DIFF
--- a/.github/requirements/playwright.txt
+++ b/.github/requirements/playwright.txt
@@ -1,0 +1,23 @@
+# Playwright and its transitive dependencies, hash-pinned for Scorecard
+# PinnedDependencies compliance. Regenerate with:
+#   pip-compile --generate-hashes --output-file=playwright.txt playwright.in
+# Or update manually from https://pypi.org/pypi/<package>/<version>/json
+
+playwright==1.60.0 \
+    --hash=sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e
+    # manylinux1_x86_64
+
+pyee==13.0.0 \
+    --hash=sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498
+    # py3-none-any
+
+greenlet==3.5.1 \
+    --hash=sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b \
+    --hash=sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135 \
+    --hash=sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c \
+    --hash=sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5
+    # manylinux_2_24_x86_64 cp312/cp313/cp314/cp315
+
+typing_extensions==4.15.0 \
+    --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+    # py3-none-any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Check generated docs
         if: ${{ !cancelled() }}
         run: |
-          cd tools && go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs && cd ..
+          cd tools && go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 && cd ..
           go generate ./...
           git diff --exit-code
       - name: API Coverage doc
@@ -342,7 +342,7 @@ jobs:
   scenario-tests:
     name: Scenario Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 45
     needs: [changes, test]
     if: >-
       always() &&
@@ -440,9 +440,23 @@ jobs:
 
       - name: Bootstrap Coolify test fixtures
         run: |
-          pip install playwright==1.60.0
+          pip install --require-hashes -r .github/requirements/playwright.txt
           playwright install --with-deps chromium
           COOLIFY_ENV_FILE=/tmp/coolify-env ./scripts/setup-coolify-test.sh
+
+      - name: Verify Coolify API health
+        run: |
+          set -a; source /tmp/coolify-env; set +a
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
+            -H "Accept: application/json" \
+            "$COOLIFY_ENDPOINT/api/v1/version")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Coolify API health check failed (HTTP $HTTP_CODE)"
+            docker compose -f "$COOLIFY_DATA_DIR/source/docker-compose.yml" logs --tail=30
+            exit 1
+          fi
+          echo "Coolify API healthy (HTTP $HTTP_CODE)"
 
       - name: Generate deploy key for scenarios
         run: |
@@ -515,7 +529,7 @@ jobs:
   acceptance-tests:
     name: Acceptance Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 45
     needs: [changes, test, lint]
     if: >-
       always() &&
@@ -623,9 +637,23 @@ jobs:
 
       - name: Bootstrap Coolify test fixtures
         run: |
-          pip install playwright==1.60.0
+          pip install --require-hashes -r .github/requirements/playwright.txt
           playwright install --with-deps chromium
           COOLIFY_ENV_FILE=/tmp/coolify-env ./scripts/setup-coolify-test.sh
+
+      - name: Verify Coolify API health
+        run: |
+          set -a; source /tmp/coolify-env; set +a
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
+            -H "Accept: application/json" \
+            "$COOLIFY_ENDPOINT/api/v1/version")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Coolify API health check failed (HTTP $HTTP_CODE)"
+            docker compose -f "$COOLIFY_DATA_DIR/source/docker-compose.yml" logs --tail=30
+            exit 1
+          fi
+          echo "Coolify API healthy (HTTP $HTTP_CODE)"
 
       - name: Run acceptance tests
         env:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,43 @@
+name: FOSSA License Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: fossa-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fossa:
+    name: FOSSA Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+  fossa-test:
+    name: FOSSA License Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: fossa
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,20 +37,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHA=$(git rev-parse HEAD)
-          CONCLUSION=$(gh run list \
-            --commit "$SHA" \
-            --workflow ci.yml \
-            --status completed \
-            --json conclusion \
-            --jq '.[0].conclusion // empty')
-          if [ -z "$CONCLUSION" ]; then
-            echo "::error::No completed CI run found for commit $SHA. Wait for CI to finish."
-            exit 1
-          fi
-          if [ "$CONCLUSION" != "success" ]; then
-            echo "::error::CI workflow conclusion is '${CONCLUSION}', refusing to release"
-            exit 1
-          fi
+          echo "Checking CI status for commit ${SHA:0:7}..."
+          for attempt in $(seq 1 12); do
+            CONCLUSION=$(gh run list \
+              --commit "$SHA" \
+              --workflow ci.yml \
+              --status completed \
+              --json conclusion \
+              --jq '.[0].conclusion // empty')
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "CI passed (attempt $attempt)"
+              exit 0
+            fi
+            if [ -n "$CONCLUSION" ]; then
+              echo "::error::CI workflow conclusion is '${CONCLUSION}', refusing to release"
+              exit 1
+            fi
+            echo "No completed CI run found yet (attempt $attempt/12), waiting 30s..."
+            sleep 30
+          done
+          echo "::error::No completed CI run for $SHA after 6 minutes. CI may still be running or was never triggered."
+          exit 1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/test-cloud-bootstrap.yml
+++ b/.github/workflows/test-cloud-bootstrap.yml
@@ -74,7 +74,7 @@ jobs:
           set -euo pipefail
 
           # Install Playwright for registration
-          pip install playwright==1.60.0
+          pip install --require-hashes -r .github/requirements/playwright.txt
           playwright install --with-deps chromium
 
           # Run setup script

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 # Terraform Provider for Coolify
 
 [![CI](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml/badge.svg)](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13051/badge)](https://www.bestpractices.dev/projects/13051)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/coolify-terraform/terraform-provider-coolify/badge)](https://scorecard.dev/viewer/?uri=github.com/coolify-terraform/terraform-provider-coolify)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcoolify-terraform%2Fterraform-provider-coolify.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fcoolify-terraform%2Fterraform-provider-coolify?ref=badge_shield&issueType=license)
 ![Go Version](https://img.shields.io/github/go-mod/go-version/coolify-terraform/terraform-provider-coolify)
 ![License](https://img.shields.io/github/license/coolify-terraform/terraform-provider-coolify)
 


### PR DESCRIPTION
## Changes

### Release workflow reliability (#431)
- Add retry loop (12 attempts, 30s intervals, 6 min total) for CI status check
- Previously a single-shot query that failed permanently if CI was still running

### Acceptance test hang prevention (#427)
- Reduce timeout from 60 to 45 minutes for acceptance and scenario tests
- Add Coolify API health check step before running tests; fails fast on dead instance

### Scorecard PinnedDependencies (#429)
- Pin pip dependencies with `--require-hashes` via `.github/requirements/playwright.txt`
- Pin `tfplugindocs@v0.25.0` to match `tools/go.mod`
- Both changes address 6 Scorecard PinnedDependencies alerts

### OpenSSF Best Practices badge (#432)
- Registered at bestpractices.dev (project 13051, 100% passing)
- Added badge to README

### FOSSA license compliance (#433)
- New `fossa.yml` workflow: analyze + compliance check (two-job pipeline)
- SHA-pinned actions, concurrency groups, `workflow_dispatch` for re-runs
- `FOSSA_API_KEY` secret configured (full access token)
- Added FOSSA badge to README

Closes #427, #429, #431, #432, #433