### PR TITLE
ci: add DCO check and expand CodeQL language coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          for sha in $(git rev-list "${BASE_SHA}"..HEAD); do
+          for sha in $(git rev-list --no-merges "${BASE_SHA}"..HEAD); do
             author=$(git log -1 --format='%an' "$sha")
             if [[ "$author" == *"[bot]" ]]; then
               echo "Skipping bot commit $sha by $author"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,33 @@ jobs:
               - 'examples/scenarios/**'
               - '.github/workflows/ci.yml'
 
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Check DCO sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          for sha in $(git rev-list "${BASE_SHA}"..HEAD); do
+            author=$(git log -1 --format='%an' "$sha")
+            if [[ "$author" == *"[bot]" ]]; then
+              echo "Skipping bot commit $sha by $author"
+              continue
+            fi
+            if ! git log -1 --format='%B' "$sha" | grep -qi '^Signed-off-by:'; then
+              echo "::error::Commit $sha by $author is missing Signed-off-by"
+              exit 1
+            fi
+          done
+          echo "All commits have DCO sign-off"
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -716,7 +743,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [test, lint, validate, scenario-tests, acceptance-tests]
+    needs: [dco, test, lint, validate, scenario-tests, acceptance-tests]
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,19 +22,36 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, python, actions]
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: matrix.language == 'go'
         with:
           go-version-file: go.mod
           cache: false
       - uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          languages: go
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
       - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        if: matrix.build-mode == 'autobuild'
       - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Two CI improvements:

### DCO sign-off enforcement
Add a DCO (Developer Certificate of Origin) job that verifies every commit in a PR has a `Signed-off-by` trailer.
- Runs only on `pull_request` events
- Skips bot commits (author name ending with `[bot]`)
- Skips merge commits (`--no-merges`) to handle GitHub's synthetic PR merge ref
- Added to the CI gate job so missing sign-off blocks merge

### CodeQL multi-language coverage
Expand CodeQL analysis from Go-only to Go + Python + Actions using a matrix strategy.
- Fixes the 'Code scanning configuration error' on the security page (GitHub detected 3 languages but only Go was analyzed)
- `actions` language catches script injection vulnerabilities in workflow YAML
- `python` language covers scripts in `scripts/`
- Adds `actions: read` permission needed by codeql-action/analyze
- Python and Actions use `build-mode: none` (interpreted, no build step needed)