### PR TITLE
fix: use workflow badge for FOSSA instead of API badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml/badge.svg)](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13051/badge)](https://www.bestpractices.dev/projects/13051)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/coolify-terraform/terraform-provider-coolify/badge)](https://scorecard.dev/viewer/?uri=github.com/coolify-terraform/terraform-provider-coolify)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B62586%2Fgithub.com%2Fcoolify-terraform%2Fterraform-provider-coolify.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B62586%2Fgithub.com%2Fcoolify-terraform%2Fterraform-provider-coolify?ref=badge_shield&issueType=license)
+[![FOSSA Status](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/fossa.yml/badge.svg)](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/fossa.yml)
 ![Go Version](https://img.shields.io/github/go-mod/go-version/coolify-terraform/terraform-provider-coolify)
 ![License](https://img.shields.io/github/license/coolify-terraform/terraform-provider-coolify)
 


### PR DESCRIPTION
The FOSSA API badge shows raw project status (24 known false positives flagged as failures). Our CI filters these via `scripts/fossa-filter.py` and passes. Switch to the GitHub Actions workflow badge which reflects the actual CI result.