### PR TITLE
ci: enable CodeQL security-and-quality queries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
       - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         if: matrix.build-mode == 'autobuild'
       - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0


### PR DESCRIPTION
Switch from default query suite (security-only) to `security-and-quality` to populate the /security/quality page with code quality findings (unused variables, dead code, complexity issues).

This enables the Code Quality tab at https://github.com/coolify-terraform/terraform-provider-coolify/security/quality