### PR TITLE
fix(ci): use original filename for FOSSA CLI sha256 verification

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -41,10 +41,10 @@ jobs:
         env:
           FOSSA_VERSION: "3.17.10"
         run: |
-          curl -fsSL "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz" -o fossa.tar.gz
-          curl -fsSL "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256" -o fossa.tar.gz.sha256
-          sha256sum -c fossa.tar.gz.sha256
-          tar xzf fossa.tar.gz fossa
+          curl -fsSL "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz" -o "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256" -o "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256"
+          sha256sum -c "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256"
+          tar xzf "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz" fossa
           sudo install fossa /usr/local/bin/fossa
       - name: Run FOSSA test with false-positive filtering
         env:


### PR DESCRIPTION
The `.sha256` file from GitHub references the original tarball filename (`fossa_VERSION_linux_amd64.tar.gz`), but the download saved it as `fossa.tar.gz`. `sha256sum -c` then fails with "No such file or directory" because it looks for the filename listed in the checksum file.

Fix: save the download with the original filename so the checksum verification matches.