### PR TITLE
fix: remove unused Python imports and variables

### DIFF
--- a/scripts/extract-contract.py
+++ b/scripts/extract-contract.py
@@ -11,7 +11,6 @@ Usage:
 
 import argparse
 import json
-import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -364,7 +363,6 @@ def extract_shared_validation(helpers_dir: Path) -> dict[str, str]:
         r"function\s+(\w+)\(\).*?return\s*\[(.*?)\];", re.DOTALL
     )
     for match in pattern.finditer(content):
-        func_name = match.group(1)
         block = match.group(2)
         for field, rule_parts in re.findall(
             r"'([^']+)'\s*=>\s*\[([^\]]*)\]", block

--- a/scripts/generate-openapi.py
+++ b/scripts/generate-openapi.py
@@ -70,7 +70,6 @@ def patch_schema(schema: dict, contract_model: dict) -> dict:
     all_fields = {**fields, **settings_fields}
 
     properties = schema.get("properties", {})
-    required = []
 
     for field_name, field_info in all_fields.items():
         if field_name not in properties:

--- a/scripts/test_extract_contract.py
+++ b/scripts/test_extract_contract.py
@@ -6,9 +6,7 @@ Run with:
 """
 
 import json
-import os
 import shutil
-import sys
 import tempfile
 import unittest
 from pathlib import Path


### PR DESCRIPTION
Fix all 5 CodeQL quality findings:

- `scripts/extract-contract.py`: remove unused `os` import and `func_name` variable
- `scripts/test_extract_contract.py`: remove unused `os` and `sys` imports
- `scripts/generate-openapi.py`: remove unused `required` variable

All 101 Python tests pass.