### PR TITLE
fix: add deleted_at to internal fields exclusion test

### DIFF
--- a/scripts/test_extract_contract.py
+++ b/scripts/test_extract_contract.py
@@ -592,11 +592,12 @@ class Item extends Model {
 Schema::create('items', function (Blueprint $table) {
     $table->string('name');
     $table->timestamps();
+    $table->softDeletes();
 });
 """
         )
         contract = ec.build_model_contract(model_file, self.migration_dir, "items")
-        for internal in ("id", "created_at", "updated_at", "team_id"):
+        for internal in ("id", "created_at", "updated_at", "deleted_at", "team_id"):
             self.assertNotIn(internal, contract["fields"])
 
 


### PR DESCRIPTION
The `internal_fields` set in `build_model_contract` includes `deleted_at`, but the test only asserted exclusion of `id`, `created_at`, `updated_at`, and `team_id`.

Add `softDeletes()` to the test fixture migration and assert `deleted_at` is also excluded, matching the full exclusion set.