### PR TITLE
ci: switch to GitHub native code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      code-quality: write
     needs: changes
     if: >-
       always() &&
@@ -110,6 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -133,6 +137,10 @@ jobs:
             -- -race -cover -coverprofile=coverage.out -count=1 -p 4 -parallel=1 -timeout=15m
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
+      - name: Convert coverage to Cobertura XML
+        run: |
+          go install github.com/boumenot/gocover-cobertura@latest
+          gocover-cobertura < coverage.out > coverage.xml
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -141,13 +149,14 @@ jobs:
           path: test-results/
           retention-days: 14
       - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
         with:
-          files: coverage.out
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.xml
+          language: Go
+          label: code-coverage/go
 
   lint:
     name: Lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         language: [go, python, actions]
         include:
           - language: go
-            build-mode: autobuild
+            build-mode: manual
           - language: python
             build-mode: none
           - language: actions
@@ -51,8 +51,10 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
-      - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        if: matrix.build-mode == 'autobuild'
+          dependency-caching: true
+      - name: Build (Go)
+        if: matrix.build-mode == 'manual'
+        run: go build ./...
       - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -175,7 +175,7 @@ check-actionlint-version: ## Verify actionlint version matches CI
 	fi
 
 actionlint-check: check-actionlint-version ## Lint GitHub Actions workflows
-	actionlint
+	actionlint -ignore 'unknown permission scope "code-quality"'
 
 check-tfplugindocs: ## Verify tfplugindocs is installed for docs generation
 	@command -v tfplugindocs >/dev/null 2>&1 || (echo "ERROR: tfplugindocs is required for docs generation. Install with: make tools"; exit 1)


### PR DESCRIPTION
## Summary

Replace Codecov with GitHub's built-in code coverage feature
(`actions/upload-code-coverage@v1`). Coverage results appear directly on
PR diffs in the GitHub UI without any external service dependency.

## Changes

- Add `code-quality: write` permission to the Test job
- Add `gocover-cobertura` conversion step (Go `coverage.out` to Cobertura XML)
- Replace `codecov/codecov-action` with `actions/upload-code-coverage@v1`
- Add PR head SHA checkout for correct coverage attribution
- Skip upload for fork PRs (no write permission to base repo)
- Remove `CODECOV_TOKEN` secret usage

## Why

- Eliminates external dependency on Codecov (one fewer secret to manage)
- Code Quality is already enabled on this repo; native coverage integrates
  with it to show line-level coverage on PR diffs
- No other major Terraform providers use Codecov; this aligns with the
  ecosystem's approach of minimal external CI dependencies

## Cleanup

After merging, the `CODECOV_TOKEN` repository secret can be deleted
from Settings > Secrets and variables > Actions.

Closes #443