### PR TITLE
fix: update CI job count to 9, add DCO, validate in counts-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,13 @@ Read these skills when working in this repo:
 - `~/.grok/skills/coolify-test-instance/SKILL.md` — Local Coolify setup, API quirks, SSH validation, acc test troubleshooting. **Read first** when setting up a test instance or debugging real-API failures.
 - `~/.grok/skills/terraform-provider-coolify-contrib/SKILL.md` — Contributing conventions for the Coolify upstream project, repo namespace notes, CI gotchas.
 - `~/.grok/skills/terraform-provider/SKILL.md` — General Terraform provider patterns (resource implementation, testing, CI, releases).
-- `~/.grok/skills/self-hosted-runner/SKILL.md` — CI runner setup, Trivy DB mirrors, tool installation gotchas.
+- `~/.grok/skills/ci-workflow-hygiene/SKILL.md` — CI workflow rules: concurrency groups, timeouts, action versions, security scanners.
 
 ## Project
 
 Terraform provider for [Coolify](https://coolify.io/), the open-source self-hosted PaaS.
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
-33 resources, 44 data sources, 870+ tests (unit + acceptance), 8 CI jobs.
+33 resources, 44 data sources, 870+ tests (unit + acceptance), 9 CI jobs.
 16 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -191,8 +191,8 @@ errors and import failures.
 
 ## CI
 
-8 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
-Detect Changes, Test, Lint (includes Govulncheck + GoReleaser Check),
+9 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
+Detect Changes, DCO (PR only), Test, Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
 Acceptance Tests, Scenario Tests, Contract Freshness (weekly only), CI (gate).
 Acceptance Tests bootstrap a fresh Coolify instance on ubuntu-latest and run the full suite.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -133,8 +133,11 @@ counts-check: ## Verify AGENTS.md and README.md resource/data source/test counts
 	if [ "$$d_actual" != "$$d_doc" ]; then echo "AGENTS.md says $$d_doc data sources but provider.go has $$d_actual"; ok=false; fi; \
 	if [ -n "$$t_agents" ] && [ "$$t_agents" -gt "$$t_floor" ]; then echo "AGENTS.md says $$t_agents+ tests but actual is $$t_actual (floor $$t_floor)"; ok=false; fi; \
 	if [ -n "$$t_readme" ] && [ "$$t_readme" -gt "$$t_floor" ]; then echo "README.md says $$t_readme+ tests but actual is $$t_actual (floor $$t_floor)"; ok=false; fi; \
-	if ! $$ok; then echo "Run: update test counts (actual: $$t_actual, floor: $$t_floor+)"; exit 1; fi; \
-	echo "Counts OK: $$r_actual resources, $$d_actual data sources, $$t_actual tests ($$t_floor+ documented)"
+	j_actual=$$(sed -n '/^jobs:/,$$p' .github/workflows/ci.yml | grep -cE '^  [a-z][a-z_-]*:' | tr -d ' '); \
+	j_doc=$$(grep -Eo '^[0-9]+ GitHub Actions jobs' AGENTS.md | grep -Eo '^[0-9]+'); \
+	if [ -n "$$j_doc" ] && [ "$$j_actual" != "$$j_doc" ]; then echo "AGENTS.md says $$j_doc CI jobs but ci.yml has $$j_actual"; ok=false; fi; \
+	if ! $$ok; then echo "Run: update counts (tests actual: $$t_actual, floor: $$t_floor+; CI jobs: $$j_actual)"; exit 1; fi; \
+	echo "Counts OK: $$r_actual resources, $$d_actual data sources, $$t_actual tests ($$t_floor+ documented), $$j_actual CI jobs"
 
 api-coverage-check: ## Check API_COVERAGE.md is up to date
 	@before=$$(mktemp); after=$$(mktemp); \


### PR DESCRIPTION
- AGENTS.md: 8 -> 9 CI jobs, add DCO (PR only) to job list
- AGENTS.md: swap stale self-hosted-runner skill ref for ci-workflow-hygiene
- GNUmakefile: counts-check now validates CI job count against ci.yml

Closes #460