### PR TITLE
docs: add Silver badge documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,8 +196,58 @@ To test the provider against a real Coolify instance without publishing:
 4. Start a local Coolify instance for testing (see [TESTING.md](TESTING.md)
    for the full setup procedure).
 
+## DCO Sign-Off
+
+All commits must carry a `Signed-off-by` trailer (the
+[Developer Certificate of Origin](https://developercertificate.org/)). This is
+enforced by CI on every pull request.
+
+Add the sign-off automatically with the `-s` flag:
+
+```bash
+git commit -s -m "Add widget resource"
+```
+
+If you forgot on an existing commit, amend it:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+For multiple unsigned commits on a branch:
+
+```bash
+git rebase --signoff HEAD~N   # N = number of commits to fix
+```
+
 ## Pull Requests
 
 - Run `make ci` before submitting, and add `make testacc` or targeted `TF_ACC=1 go test ...` commands when your change touches real Coolify API behavior (`make ci` still skips trivy, gitleaks, and acceptance tests)
 - Include tests for new functionality
 - Keep PRs focused on a single change
+- All commits must have a DCO sign-off (see above)
+
+## Coding Standards
+
+This project follows idiomatic Go conventions enforced by automated tooling:
+
+- **Formatting**: `gofmt -s` (enforced by CI via golangci-lint)
+- **Linting**: golangci-lint v2 with 20 linters including errcheck, govet, staticcheck,
+  funlen (150 lines / 80 statements), gocognit (complexity 20), nestif (depth 5),
+  dupl (250 tokens), and forbidigo (no fmt.Print)
+- **Error handling**: Wrap all errors with context using `fmt.Errorf("verb resource %s: %w", id, err)`
+- **Framework**: Use `terraform-plugin-framework` (not SDK v2)
+- **File organization**: One file per resource/data source, co-locate tests
+- **Documentation**: Use `MarkdownDescription` on all schema attributes
+- **Security**: Mark passwords and keys as `Sensitive: true`, never commit real credentials
+
+## Test Policy
+
+All new features and bug fixes require tests:
+
+- **Unit tests** use `httptest` mock servers (no Coolify instance needed)
+- **Acceptance tests** run against a real Coolify instance (`TF_ACC=1`)
+- **Minimum test coverage**: Create, Update, Import, and Disappears tests for every resource
+- **Race detection**: All tests run with the `-race` flag
+- **CI enforcement**: Tests must pass in CI before merge; coverage is reported via
+  GitHub native code coverage

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,68 @@
+# Governance
+
+## Overview
+
+terraform-provider-coolify is maintained by a single maintainer with full
+commit, release, and administrative access.
+
+## Roles
+
+| Role | Responsibility | Current |
+|------|---------------|---------|
+| Maintainer | Code review, merge, release, infrastructure | [@SebTardif](https://github.com/SebTardif) |
+| Contributor | Submit issues, pull requests, documentation | Anyone |
+
+## Decision Making
+
+Decisions are made by the maintainer. For significant changes (new resources,
+breaking API changes, architectural shifts), an issue is opened for discussion
+before implementation begins. Contributors are encouraged to open an issue
+describing their proposed change before investing time in a pull request.
+
+## Contributions
+
+All contributions are welcome via pull requests. Requirements:
+
+1. All commits must carry a DCO sign-off (`Signed-off-by` trailer)
+2. CI must pass (build, lint, test, validate)
+3. New features require tests
+4. Breaking changes require discussion in an issue first
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full development setup and
+submission guidelines.
+
+## Releases
+
+Releases follow [Semantic Versioning](https://semver.org/). The release process
+is automated via release-please and GoReleaser:
+
+1. Conventional commits on `main` trigger release-please to open a release PR
+2. The maintainer merges the release PR
+3. GoReleaser builds binaries, signs checksums with GPG, and publishes to GitHub
+   Releases and the Terraform Registry
+
+## Access Continuity
+
+The project is hosted under the
+[coolify-terraform](https://github.com/coolify-terraform) GitHub organization.
+Organization-level settings (branch protection, required CI checks, Dependabot)
+ensure that security and quality controls persist regardless of individual
+availability.
+
+In the event the maintainer becomes unavailable:
+
+- The repository and all CI/CD infrastructure are under the organization, not a
+  personal account
+- GPG signing keys for releases are stored in the Terraform Registry namespace
+- All automation (CI, Dependabot, release-please) continues to function
+  without manual intervention
+
+## Code of Conduct
+
+All participants are expected to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Changes to Governance
+
+This governance model may evolve as the project grows. Changes to this document
+follow the same pull request process as code changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,61 @@
+# Roadmap
+
+This document outlines the planned direction for terraform-provider-coolify.
+Priorities may shift based on community feedback and upstream Coolify API changes.
+
+## Current Status (v0.1.x)
+
+The provider covers the core Coolify resource model:
+
+- 33 managed resources (projects, servers, applications, databases, services,
+  backups, environment variables, deployments, and more)
+- 44 data sources for reading existing infrastructure
+- 16 ACME Corp scenario examples with integration tests
+- Full import support for adopting existing Coolify resources
+
+## Near Term
+
+### OpenTofu Registry publication
+
+Register the provider on the OpenTofu Registry for users who use OpenTofu
+instead of HashiCorp Terraform. ([#414](https://github.com/coolify-terraform/terraform-provider-coolify/issues/414))
+
+### Notification channel resources
+
+Add resources for managing Coolify notification channels (Slack, Discord, email,
+Telegram, etc.) once the upstream API supports full CRUD.
+([#394](https://github.com/coolify-terraform/terraform-provider-coolify/issues/394),
+blocked on upstream)
+
+### S3 storage resource
+
+Add a `coolify_s3_storage` resource for managing S3-compatible backup
+destinations once the upstream API exposes top-level S3 storage endpoints.
+([#393](https://github.com/coolify-terraform/terraform-provider-coolify/issues/393),
+blocked on upstream)
+
+## Medium Term
+
+### Upstream API parity
+
+As Coolify v4 stabilizes its API, update the provider to track new endpoints
+and fields. The contract extraction pipeline (`make contract-extract`) and spec
+compliance tests (`make spec-check`) automate detection of API drift.
+
+### Additional scenario examples
+
+Expand the ACME Corp scenario library with more real-world deployment patterns
+(multi-server setups, database clustering, blue-green deployments).
+
+## Long Term
+
+### Coolify v5 support
+
+When Coolify v5 is released, evaluate API changes and plan a migration path.
+Breaking changes will follow semantic versioning with a deprecation period.
+
+## Contributing
+
+Feature requests and priority feedback are welcome via
+[GitHub Issues](https://github.com/coolify-terraform/terraform-provider-coolify/issues).
+If a feature you need is missing, open an issue describing your use case.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,9 +16,47 @@ confirmed, a fix will be released as soon as possible.
 |---------|-----------|
 | latest main | Yes |
 
+## Security Design Principles
+
+This provider follows these security principles:
+
+1. **Minimal privilege**: The provider only requires a Coolify API token. It does
+   not need SSH access, database credentials, or host-level permissions.
+2. **No credential storage**: API tokens are passed via environment variables or
+   provider configuration, never stored in state beyond what Terraform requires.
+   Sensitive fields (private keys, passwords, tokens) are marked `Sensitive: true`
+   in the schema, which tells Terraform to redact them from plan output.
+3. **Input validation at plan time**: UUID format, FQDN, and cron syntax validators
+   catch malformed input before any API call is made.
+4. **TLS by default**: All API communication uses HTTPS. The HTTP client enforces
+   TLS certificate verification.
+5. **No shell execution**: The provider never executes shell commands or spawns
+   subprocesses. All operations are HTTP API calls.
+6. **FIPS 140-3 compliance**: Release builds use `GOFIPS140=latest` for
+   FIPS-compliant cryptographic primitives.
+
 ## Security Practices
 
 - Dependencies are scanned weekly by Govulncheck, Trivy, and Gitleaks
 - Dependabot monitors Go modules and GitHub Actions for updates
+- GitHub Dependency Review checks every PR for known vulnerabilities in new dependencies
+- FOSSA monitors license compliance
+- CodeQL runs on every push and PR for static application security testing (SAST)
+- OpenSSF Scorecard runs weekly and reports supply chain security posture
 - Test credentials use placeholder values (`"test-token"`)
 - No real API tokens or secrets are committed to the repository
+- `.gitleaks.toml` allowlists suppress false positives in test fixtures and examples
+
+## Assurance Case
+
+The following measures provide confidence that this provider handles credentials
+and infrastructure state correctly:
+
+| Threat | Mitigation | Verification |
+|--------|-----------|-------------|
+| Credential leakage in logs | All sensitive fields marked `Sensitive: true` | Unit tests verify plan output redaction |
+| Credential leakage in state | Terraform encrypts state at rest (user responsibility) | Provider does not control state backend |
+| Malicious dependency | Dependabot, Govulncheck, Trivy, Dependency Review | Automated weekly scans + PR-level checks |
+| Supply chain attack on CI | Pinned action SHAs, Scorecard monitoring | `scorecard.yml` workflow, no mutable tags |
+| API token exposure in examples | Placeholder values enforced by Gitleaks | `.gitleaks.toml` rules + CI enforcement |
+| Injection via user input | No shell execution; all input is HTTP API parameters | Static analysis via CodeQL |

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,154 @@
+---
+page_title: "Architecture"
+subcategory: "Development"
+description: |-
+  Internal architecture of the Coolify Terraform provider.
+---
+
+# Architecture
+
+This guide describes the internal structure of the provider for contributors
+and maintainers. End users do not need to read this; see the
+[Quick Start](quickstart) instead.
+
+## Layer diagram
+
+```
+┌─────────────────────────────────────────────────┐
+│  Terraform CLI / Plugin Protocol (gRPC)         │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Provider (internal/provider/)                   │
+│  - Schema: endpoint + token configuration        │
+│  - Configure: health check via GET /api/v1/ver.  │
+│  - Registration: lists all resources + data src  │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Service Layer (internal/service/<type>/)         │
+│  - One subpackage per resource type              │
+│  - resource.go: CRUD + ImportState               │
+│  - data_source.go: Read-only                     │
+│  - Expand (HCL -> API) / Flatten (API -> HCL)   │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Client (internal/client/)                       │
+│  - One file per resource type                    │
+│  - retryablehttp with 3 retries, 30s timeout     │
+│  - NotFoundError + IsNotFound() helper           │
+│  - context.Context on every method               │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Coolify API (HTTPS)                             │
+└─────────────────────────────────────────────────┘
+```
+
+## Package responsibilities
+
+| Package | Purpose |
+|---------|---------|
+| `internal/provider/` | Provider schema, `Configure` (creates the HTTP client), resource and data source registration |
+| `internal/service/<type>/` | One subpackage per Coolify resource type. Contains the resource, data source(s), expand/flatten helpers, and unit tests |
+| `internal/client/` | Typed HTTP client. One file per resource type with Create/Get/Update/Delete/List methods |
+| `internal/flex/` | Type conversion between Go native types and Terraform Plugin Framework types (`types.String`, `types.Int64`, etc.) |
+| `internal/acctest/` | Shared test utilities: provider factories, mock server wrappers (`WithVersionEndpoint`), acceptance test helpers |
+| `internal/validate/` | Custom validators: UUID format, FQDN URL, cron syntax |
+| `internal/filter/` | Generic filtering helpers for plural data sources |
+| `internal/spectest/` | OpenAPI spec compliance tests, API coverage tracking, contract coverage verification |
+| `scripts/` | Python tooling: contract extraction from Coolify source, OpenAPI spec generation, contract diffing |
+| `testdata/contracts/` | Versioned contract JSON extracted from Coolify PHP source (source of truth for field definitions) |
+
+## Request lifecycle
+
+A typical `terraform apply` for a resource follows this path:
+
+1. **Terraform CLI** calls the provider's gRPC `ApplyResourceChange` endpoint
+2. **Provider framework** routes to the resource's `Create`, `Update`, or `Delete` method
+3. **Service layer** expands the Terraform plan into an API request struct
+4. **Client** sends the HTTP request to Coolify with retries and timeout
+5. **Client** parses the response, returns a typed struct or `NotFoundError`
+6. **Service layer** flattens the API response back into Terraform state
+7. **Provider framework** returns the new state to Terraform CLI
+
+## Expand / Flatten pattern
+
+Every resource has two directional conversions:
+
+- **Expand**: Reads Terraform plan attributes (`types.String`, `types.Bool`) and
+  builds the Go struct that the client sends to the API. Runs during Create and
+  Update.
+- **Flatten**: Takes the API response struct and writes values back into the
+  Terraform state model. Runs during Create (read-back), Read, and Import.
+
+Sensitive fields (passwords, private keys) require special flatten handling:
+when the API returns an empty string for a sensitive field, the flatten function
+preserves the value from Terraform state rather than overwriting it.
+
+## Testing architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Unit Tests (make test)                  │
+│  - httptest mock servers per resource    │
+│  - resource.UnitTest wrapper             │
+│  - No real Coolify instance needed       │
+│  - Race detector enabled (-race)         │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Acceptance Tests (make testacc)         │
+│  - Real Coolify instance (TF_ACC=1)     │
+│  - resource.Test wrapper                 │
+│  - Serialized execution (no parallelism) │
+│  - Full CRUD + import verification       │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Scenario Tests (terraform test)         │
+│  - .tftest.hcl files in examples/scen.   │
+│  - Multi-resource integration tests      │
+│  - Real Coolify instance                 │
+│  - 16 ACME Corp scenarios                │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Spec Compliance (make spec-check)       │
+│  - Contract coverage verification        │
+│  - OpenAPI spec drift detection          │
+│  - API endpoint coverage tracking        │
+└─────────────────────────────────────────┘
+```
+
+## Contract extraction pipeline
+
+The provider uses a contract-first approach anchored to the Coolify PHP source
+code (not the OpenAPI spec):
+
+1. `make contract-extract` clones the Coolify repo and runs
+   `scripts/extract-contract.py` to parse PHP models, controllers, and
+   migrations into `testdata/contracts/coolify-v4.json`
+2. `make contract-check` verifies that Go client structs cover all contract
+   fields
+3. `make spec-generate` produces an OpenAPI spec from the contract
+4. `make spec-check` runs the spec compliance test suite
+
+This pipeline catches API drift automatically when Coolify updates its models.
+
+## CI pipeline
+
+The CI pipeline runs 9 jobs on every push and PR:
+
+| Job | What it checks |
+|-----|---------------|
+| Detect Changes | Path-based filtering to skip unchanged jobs |
+| DCO | Signed-off-by trailer on all PR commits |
+| Test | Unit tests with race detector + code coverage |
+| Lint | golangci-lint (20 linters) + Govulncheck + GoReleaser check |
+| Validate | HCL formatting + tfplugindocs + Trivy + Gitleaks |
+| Acceptance Tests | Full suite against a bootstrapped Coolify instance |
+| Scenario Tests | `terraform test` against a real Coolify instance |
+| Contract Freshness | Weekly check that the contract matches upstream |
+| CI | Gate job that requires all other jobs to pass |

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -1,0 +1,154 @@
+---
+page_title: "Architecture"
+subcategory: "Development"
+description: |-
+  Internal architecture of the Coolify Terraform provider.
+---
+
+# Architecture
+
+This guide describes the internal structure of the provider for contributors
+and maintainers. End users do not need to read this; see the
+[Quick Start](quickstart) instead.
+
+## Layer diagram
+
+```
+┌─────────────────────────────────────────────────┐
+│  Terraform CLI / Plugin Protocol (gRPC)         │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Provider (internal/provider/)                   │
+│  - Schema: endpoint + token configuration        │
+│  - Configure: health check via GET /api/v1/ver.  │
+│  - Registration: lists all resources + data src  │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Service Layer (internal/service/<type>/)         │
+│  - One subpackage per resource type              │
+│  - resource.go: CRUD + ImportState               │
+│  - data_source.go: Read-only                     │
+│  - Expand (HCL -> API) / Flatten (API -> HCL)   │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Client (internal/client/)                       │
+│  - One file per resource type                    │
+│  - retryablehttp with 3 retries, 30s timeout     │
+│  - NotFoundError + IsNotFound() helper           │
+│  - context.Context on every method               │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│  Coolify API (HTTPS)                             │
+└─────────────────────────────────────────────────┘
+```
+
+## Package responsibilities
+
+| Package | Purpose |
+|---------|---------|
+| `internal/provider/` | Provider schema, `Configure` (creates the HTTP client), resource and data source registration |
+| `internal/service/<type>/` | One subpackage per Coolify resource type. Contains the resource, data source(s), expand/flatten helpers, and unit tests |
+| `internal/client/` | Typed HTTP client. One file per resource type with Create/Get/Update/Delete/List methods |
+| `internal/flex/` | Type conversion between Go native types and Terraform Plugin Framework types (`types.String`, `types.Int64`, etc.) |
+| `internal/acctest/` | Shared test utilities: provider factories, mock server wrappers (`WithVersionEndpoint`), acceptance test helpers |
+| `internal/validate/` | Custom validators: UUID format, FQDN URL, cron syntax |
+| `internal/filter/` | Generic filtering helpers for plural data sources |
+| `internal/spectest/` | OpenAPI spec compliance tests, API coverage tracking, contract coverage verification |
+| `scripts/` | Python tooling: contract extraction from Coolify source, OpenAPI spec generation, contract diffing |
+| `testdata/contracts/` | Versioned contract JSON extracted from Coolify PHP source (source of truth for field definitions) |
+
+## Request lifecycle
+
+A typical `terraform apply` for a resource follows this path:
+
+1. **Terraform CLI** calls the provider's gRPC `ApplyResourceChange` endpoint
+2. **Provider framework** routes to the resource's `Create`, `Update`, or `Delete` method
+3. **Service layer** expands the Terraform plan into an API request struct
+4. **Client** sends the HTTP request to Coolify with retries and timeout
+5. **Client** parses the response, returns a typed struct or `NotFoundError`
+6. **Service layer** flattens the API response back into Terraform state
+7. **Provider framework** returns the new state to Terraform CLI
+
+## Expand / Flatten pattern
+
+Every resource has two directional conversions:
+
+- **Expand**: Reads Terraform plan attributes (`types.String`, `types.Bool`) and
+  builds the Go struct that the client sends to the API. Runs during Create and
+  Update.
+- **Flatten**: Takes the API response struct and writes values back into the
+  Terraform state model. Runs during Create (read-back), Read, and Import.
+
+Sensitive fields (passwords, private keys) require special flatten handling:
+when the API returns an empty string for a sensitive field, the flatten function
+preserves the value from Terraform state rather than overwriting it.
+
+## Testing architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Unit Tests (make test)                  │
+│  - httptest mock servers per resource    │
+│  - resource.UnitTest wrapper             │
+│  - No real Coolify instance needed       │
+│  - Race detector enabled (-race)         │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Acceptance Tests (make testacc)         │
+│  - Real Coolify instance (TF_ACC=1)     │
+│  - resource.Test wrapper                 │
+│  - Serialized execution (no parallelism) │
+│  - Full CRUD + import verification       │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Scenario Tests (terraform test)         │
+│  - .tftest.hcl files in examples/scen.   │
+│  - Multi-resource integration tests      │
+│  - Real Coolify instance                 │
+│  - 16 ACME Corp scenarios                │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Spec Compliance (make spec-check)       │
+│  - Contract coverage verification        │
+│  - OpenAPI spec drift detection          │
+│  - API endpoint coverage tracking        │
+└─────────────────────────────────────────┘
+```
+
+## Contract extraction pipeline
+
+The provider uses a contract-first approach anchored to the Coolify PHP source
+code (not the OpenAPI spec):
+
+1. `make contract-extract` clones the Coolify repo and runs
+   `scripts/extract-contract.py` to parse PHP models, controllers, and
+   migrations into `testdata/contracts/coolify-v4.json`
+2. `make contract-check` verifies that Go client structs cover all contract
+   fields
+3. `make spec-generate` produces an OpenAPI spec from the contract
+4. `make spec-check` runs the spec compliance test suite
+
+This pipeline catches API drift automatically when Coolify updates its models.
+
+## CI pipeline
+
+The CI pipeline runs 9 jobs on every push and PR:
+
+| Job | What it checks |
+|-----|---------------|
+| Detect Changes | Path-based filtering to skip unchanged jobs |
+| DCO | Signed-off-by trailer on all PR commits |
+| Test | Unit tests with race detector + code coverage |
+| Lint | golangci-lint (20 linters) + Govulncheck + GoReleaser check |
+| Validate | HCL formatting + tfplugindocs + Trivy + Gitleaks |
+| Acceptance Tests | Full suite against a bootstrapped Coolify instance |
+| Scenario Tests | `terraform test` against a real Coolify instance |
+| Contract Freshness | Weekly check that the contract matches upstream |
+| CI | Gate job that requires all other jobs to pass |


### PR DESCRIPTION
Add governance model, roadmap, architecture guide, and enhance existing CONTRIBUTING.md and SECURITY.md for OpenSSF Best Practices Silver criteria.

**New files:**
- `GOVERNANCE.md`: solo maintainer model, decision making, access continuity
- `ROADMAP.md`: near/medium/long term priorities linked to open issues
- `templates/guides/architecture.md.tmpl`: internal provider architecture guide
- `docs/guides/architecture.md`: generated from template

**Enhanced files:**
- `CONTRIBUTING.md`: DCO sign-off instructions, coding standards, test policy
- `SECURITY.md`: security design principles, assurance case table

All changes are documentation-only. `make ci` passes locally.