### PR TITLE
docs: add OpenTofu Registry badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # Terraform Provider for Coolify
 
 [![Terraform Registry](https://img.shields.io/badge/Terraform%20Registry-coolify-844FBA?logo=terraform)](https://registry.terraform.io/providers/coolify-terraform/coolify/latest)
+[![OpenTofu Registry](https://img.shields.io/badge/OpenTofu%20Registry-coolify-blue?logo=opentofu)](https://search.opentofu.org/provider/coolify-terraform/coolify)
 [![CI](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml/badge.svg)](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13051/badge)](https://www.bestpractices.dev/projects/13051)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/coolify-terraform/terraform-provider-coolify/badge)](https://scorecard.dev/viewer/?uri=github.com/coolify-terraform/terraform-provider-coolify)


### PR DESCRIPTION
Adds an OpenTofu Registry badge to the README, linking to [search.opentofu.org/provider/coolify-terraform/coolify](https://search.opentofu.org/provider/coolify-terraform/coolify).

The provider has been registered on the OpenTofu Registry:
- GPG signing key: opentofu/registry#4363 (PR opentofu/registry#4365)
- Provider registration: opentofu/registry#4364 (PR opentofu/registry#4366)

Both submissions passed automated validation and are pending auto-merge.

Closes #414