### PR TITLE
fix: point OpenTofu badge to registry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Terraform Provider for Coolify
 
 [![Terraform Registry](https://img.shields.io/badge/Terraform%20Registry-coolify-844FBA?logo=terraform)](https://registry.terraform.io/providers/coolify-terraform/coolify/latest)
-[![OpenTofu Registry](https://img.shields.io/badge/OpenTofu%20Registry-coolify-blue?logo=opentofu)](https://search.opentofu.org/provider/coolify-terraform/coolify)
+[![OpenTofu Registry](https://img.shields.io/badge/OpenTofu%20Registry-coolify-blue?logo=opentofu)](https://registry.opentofu.org/v1/providers/coolify-terraform/coolify/versions)
 [![CI](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml/badge.svg)](https://github.com/coolify-terraform/terraform-provider-coolify/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13051/badge)](https://www.bestpractices.dev/projects/13051)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/coolify-terraform/terraform-provider-coolify/badge)](https://scorecard.dev/viewer/?uri=github.com/coolify-terraform/terraform-provider-coolify)


### PR DESCRIPTION
The search.opentofu.org page returns a 404 for the provider (their search index hasn't picked it up yet). Points the badge to the registry API endpoint instead, which is live and verifiable:

```bash
curl -s https://registry.opentofu.org/v1/providers/coolify-terraform/coolify/versions | python3 -m json.tool
```

Once search.opentofu.org indexes the provider, we can update the link back.