### PR TITLE
ci: auto-approve release-please PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,7 +12,8 @@ jobs:
     name: Auto Approve
     if: >-
       github.actor == 'SebTardif' ||
-      github.actor == 'dependabot[bot]'
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'github-actions[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:


### PR DESCRIPTION
The auto-approve workflow only covered `SebTardif` and `dependabot[bot]`. Release-please PRs are authored by `github-actions[bot]`, so they never got auto-approved.

Combined with `dismiss_stale_reviews_on_push: true` in the branch ruleset, this made release PRs (like #455) permanently unmergeable without admin bypass: the review was dismissed on every new commit, and auto-approve never re-fired because the actor didn't match.

**Fix:** Add `github-actions[bot]` to the auto-approve actor list.