### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -13,7 +13,7 @@ jobs:
     if: >-
       github.actor == 'SebTardif' ||
       github.actor == 'dependabot[bot]' ||
-      github.actor == 'github-actions[bot]'
+      github.actor == 'coolify-terraform-auto-approve[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,20 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      # Use a GitHub App token so that release-please PR pushes trigger
+      # pull_request events (GITHUB_TOKEN suppresses them, which prevents
+      # CI and auto-approve from running on the release PR).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: rp
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
   release:
     name: Release


### PR DESCRIPTION
Release-please PRs were authored by `github-actions[bot]` (via GITHUB_TOKEN), which caused two problems:

1. GITHUB_TOKEN pushes do not trigger `pull_request` events, so CI and auto-approve never ran on release PR updates.
2. Auto-approve failed with "Can not approve your own pull request" because both the PR author and the approver were `github-actions[bot]`.

**Fix:** Use the `coolify-terraform-auto-approve` GitHub App token for release-please so PRs are authored by the App bot. This lets GITHUB_TOKEN-based auto-approve work (different identity) and ensures PR events trigger CI.

Also updates auto-approve to accept the App bot actor (`coolify-terraform-auto-approve[bot]`) instead of the overly broad `github-actions[bot]`.

After this merges, the next push to main will cause release-please to recreate PR #455 under the App identity, and the full auto-approve + CI flow will work.