### PR TITLE
ci: add release approval gate and fix remaining JSON decode suppressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       (needs.release-please.outputs.release_created == 'true' ||
        github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       actions: read
       contents: write

--- a/internal/service/environmentvariable/resource_test.go
+++ b/internal/service/environmentvariable/resource_test.go
@@ -40,7 +40,10 @@ func TestEnvironmentVariableResource_Create(t *testing.T) {
 			return
 		}
 		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"invalid json body"}`, http.StatusBadRequest)
+			return
+		}
 		mu.Lock()
 		_, createBuildtimePresent = body["is_buildtime"]
 		mu.Unlock()
@@ -160,7 +163,10 @@ func TestEnvironmentVariableResource_Update(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		var body map[string]any
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"invalid json body"}`, http.StatusBadRequest)
+			return
+		}
 		if v, ok := body["value"].(string); ok {
 			currentEnvVar.Value = v
 		}
@@ -266,7 +272,10 @@ func TestEnvironmentVariableResource_ReadPreservesValueWhenAPIHidesIt(t *testing
 			return
 		}
 		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"invalid json body"}`, http.StatusBadRequest)
+			return
+		}
 		if v, ok := body["value"].(string); ok {
 			currentEnvVar.Value = v
 		}


### PR DESCRIPTION
## Changes

- **Release approval gate**: Add `environment: release` to the release job in `release.yml`. The `release` GitHub environment is configured with required reviewer (SebTardif), so GoReleaser will not run until explicitly approved. Matches the pattern used in attune-io/attune.

- **Test fix**: Replace 3 remaining `_ = json.NewDecoder().Decode()` error suppressions in environment variable mock handlers with proper error handling (follow-up to #483).