### PR TITLE
test: handle ignored errors in githubapp and storage tests

### DIFF
--- a/internal/service/githubapp/resource_test.go
+++ b/internal/service/githubapp/resource_test.go
@@ -512,7 +512,10 @@ resource "coolify_github_app" "test" {
 							return fmt.Errorf("resource not found in state")
 						}
 						idStr := rs.Primary.Attributes["id"]
-						id, _ := strconv.ParseInt(idStr, 10, 64)
+						id, err := strconv.ParseInt(idStr, 10, 64)
+						if err != nil {
+							return fmt.Errorf("invalid resource id %q: %w", idStr, err)
+						}
 						store.Delete(id)
 						return nil
 					},
@@ -866,15 +869,24 @@ func TestGitHubAppResource_UpgradeStateV0(t *testing.T) {
 	// Verify core fields were preserved.
 	var name, uuid, clientID, clientSecret, webhookSecret, orgName types.String
 	var id, appID, installationID types.Int64
-	resp.State.GetAttribute(ctx, path.Root("name"), &name)
-	resp.State.GetAttribute(ctx, path.Root("uuid"), &uuid)
-	resp.State.GetAttribute(ctx, path.Root("client_id"), &clientID)
-	resp.State.GetAttribute(ctx, path.Root("client_secret"), &clientSecret)
-	resp.State.GetAttribute(ctx, path.Root("webhook_secret"), &webhookSecret)
-	resp.State.GetAttribute(ctx, path.Root("organization_name"), &orgName)
-	resp.State.GetAttribute(ctx, path.Root("id"), &id)
-	resp.State.GetAttribute(ctx, path.Root("app_id"), &appID)
-	resp.State.GetAttribute(ctx, path.Root("installation_id"), &installationID)
+	for _, tc := range []struct {
+		name string
+		dest any
+	}{
+		{"name", &name},
+		{"uuid", &uuid},
+		{"client_id", &clientID},
+		{"client_secret", &clientSecret},
+		{"webhook_secret", &webhookSecret},
+		{"organization_name", &orgName},
+		{"id", &id},
+		{"app_id", &appID},
+		{"installation_id", &installationID},
+	} {
+		if diags := resp.State.GetAttribute(ctx, path.Root(tc.name), tc.dest); diags.HasError() {
+			t.Fatalf("failed to get state attribute %q: %v", tc.name, diags)
+		}
+	}
 
 	if name.ValueString() != "my-github-app" {
 		t.Errorf("name = %q, want %q", name.ValueString(), "my-github-app")
@@ -906,7 +918,9 @@ func TestGitHubAppResource_UpgradeStateV0(t *testing.T) {
 
 	// private_key_uuid should be Unknown (can't convert raw PEM to UUID).
 	var pkUUID types.String
-	resp.State.GetAttribute(ctx, path.Root("private_key_uuid"), &pkUUID)
+	if diags := resp.State.GetAttribute(ctx, path.Root("private_key_uuid"), &pkUUID); diags.HasError() {
+		t.Fatalf("failed to get state attribute %q: %v", "private_key_uuid", diags)
+	}
 	if !pkUUID.IsUnknown() {
 		t.Errorf("private_key_uuid should be Unknown after migration, got %q", pkUUID.ValueString())
 	}

--- a/internal/service/storage/resource_test.go
+++ b/internal/service/storage/resource_test.go
@@ -903,7 +903,10 @@ func checkStorageDestroy(serverURL, listPath string) resource.TestCheckFunc {
 				PersistentStorages []client.Storage `json:"persistent_storages"`
 				FileStorages       []client.Storage `json:"file_storages"`
 			}
-			json.NewDecoder(resp.Body).Decode(&result)
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				resp.Body.Close()
+				return fmt.Errorf("error decoding destroy-check response for coolify_storage/%s: %w", uuid, err)
+			}
 			resp.Body.Close()
 			for _, stor := range result.PersistentStorages {
 				if stor.UUID == uuid {


### PR DESCRIPTION
## Summary

Fix 3 silently-ignored errors in test code identified by GitHub AI Code Quality findings.

## Changes

### 1. `strconv.ParseInt` error handled (`githubapp/resource_test.go:515`)

The disappears test discarded the parse error with `_`. If the resource ID were malformed, `store.Delete(0)` would silently no-op, and the test would not actually simulate deletion.

### 2. `resp.State.GetAttribute` diagnostics checked (`githubapp/resource_test.go:869-909`)

10 calls to `GetAttribute` in the state upgrade test discarded their diagnostics. A schema mismatch during refactoring would produce confusing zero-value assertion failures instead of a clear "failed to get attribute" message. Refactored into a table-driven loop with `t.Fatalf` on error.

### 3. `json.Decode` error handled (`storage/resource_test.go:906`)

The storage destroy check discarded the decode error. A malformed response would leave both slices empty, causing the check to report the resource as destroyed (return nil) even though the response was unparseable.

## Testing

- `make test-pkg PKG=./internal/service/githubapp/` passes (76.1% coverage)
- `make test-pkg PKG=./internal/service/storage/` passes (75.5% coverage)
- `make ci` passes (883 tests, 0 vulnerabilities)

Closes #487, Closes #488, Closes #489
