### PR TITLE
test: use defer for resp.Body.Close in storage destroy check

### DIFF
--- a/internal/service/storage/resource_test.go
+++ b/internal/service/storage/resource_test.go
@@ -899,15 +899,14 @@ func checkStorageDestroy(serverURL, listPath string) resource.TestCheckFunc {
 			if err != nil {
 				return fmt.Errorf("error checking destroy for coolify_storage/%s: %w", uuid, err)
 			}
+			defer resp.Body.Close()
 			var result struct {
 				PersistentStorages []client.Storage `json:"persistent_storages"`
 				FileStorages       []client.Storage `json:"file_storages"`
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				resp.Body.Close()
 				return fmt.Errorf("error decoding destroy-check response for coolify_storage/%s: %w", uuid, err)
 			}
-			resp.Body.Close()
 			for _, stor := range result.PersistentStorages {
 				if stor.UUID == uuid {
 					return fmt.Errorf("coolify_storage %s still exists in persistent_storages", uuid)


### PR DESCRIPTION
## Summary

Replace manual `resp.Body.Close()` calls with a single `defer` immediately after `http.Get` in the storage destroy-check helper. This ensures the body is always closed regardless of which return path is taken.

## Before

```go
if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
    resp.Body.Close()   // close #1
    return fmt.Errorf(...)
}
resp.Body.Close()       // close #2
```

## After

```go
defer resp.Body.Close() // single defer, always runs
if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
    return fmt.Errorf(...)
}
```

## Testing

- `make test-pkg PKG=./internal/service/storage/` passes (75.5% coverage)

Source: GitHub AI Code Quality findings.