### PR TITLE
ci: parallelize scenario tests with unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,10 +379,9 @@ jobs:
     name: Scenario Tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [changes, test]
+    needs: [changes]
     if: >-
       always() &&
-      (needs.test.result == 'success' || needs.test.result == 'skipped') &&
       (
         needs.changes.outputs.scenarios == 'true' ||
         github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Remove `test` from the `scenario-tests` job's `needs` list so both jobs run concurrently after the `changes` job. The `ci-pass` gate still depends on both, so any failure in either blocks merge.

**Before:** Changes (4s) -> Test (7min) -> Scenario Tests (6min) = ~13min
**After:** Changes (4s) -> max(Test 7min, Scenario Tests 6min) = ~7min

Closes #493