### PR TITLE
fix: increase polling timeout test context + bump Go 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coolify-terraform/terraform-provider-coolify
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/internal/service/database/common_test.go
+++ b/internal/service/database/common_test.go
@@ -110,7 +110,7 @@ func TestDeleteDatabase_AddsWarningWhenPollingTimesOut(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "test-token")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	resp := &resource.DeleteResponse{}
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/coolify-terraform/terraform-provider-coolify/tools
 
-go 1.26.3
+go 1.26.4
 
 require github.com/hashicorp/terraform-plugin-docs v0.25.0
 


### PR DESCRIPTION
**Changes:**

1. **Flaky test fix:** The 10ms context timeout in `TestDeleteDatabase_AddsWarningWhenPollingTimesOut` was too tight for HTTP roundtrips under heavy parallel load with the race detector. Increased to 100ms (still well under the 500ms initial polling delay in `PollUntilDeleted`).

2. **Go 1.26.4:** Fixes three newly-disclosed standard library vulnerabilities:
   - GO-2026-5037 (crypto/x509)
   - GO-2026-5038 (mime)
   - GO-2026-5039 (net/textproto)

   These were disclosed after the last CI run on main, blocking govulncheck on all new PRs.