### PR TITLE
test: improve mock body validation and add Create error test

### DIFF
--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -727,6 +727,13 @@ func TestApplicationResource_GitRepoExternalChange(t *testing.T) {
 			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 			return
 		}
+		body, ok := decodeRequestBodyMap(t, w, r)
+		if !ok {
+			return
+		}
+		if _, exists := body["git_repository"]; !exists {
+			t.Error("PATCH body missing git_repository field")
+		}
 		mu.Lock()
 		repo := currentRepo
 		mu.Unlock()

--- a/internal/service/server/resource_test.go
+++ b/internal/service/server/resource_test.go
@@ -601,3 +601,30 @@ resource "coolify_server" "test" {
 		},
 	})
 }
+
+func TestServerResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/servers", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"validation failed: IP address already in use"}`, http.StatusUnprocessableEntity)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server" "test" {
+  name             = "will-fail"
+  ip               = "10.0.0.1"
+  private_key_uuid = "dddd0002-0002-4000-8000-000000000002"
+}`,
+				ExpectError: regexp.MustCompile(`Error creating server`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Changes

### PATCH body validation in GitRepoExternalChange test

The `TestApplicationResource_GitRepoExternalChange` PATCH mock handler accepted any payload without reading the request body. Added `decodeRequestBodyMap` to verify the provider sends `git_repository` in the PATCH body. Previously, a regression that stopped sending the field would have gone undetected.

### Server Create API error test

Added `TestServerResource_CreateAPIError` to cover the error-to-diagnostic translation path when the Coolify API returns 422 on server creation. This was the first resource-level Create error test in the project.

### Related issues

- Part of #505 (resource-level Create/Update API error tests)
- Part of #506 (canned mock handler body validation)
