### PR TITLE
fix: handle PATCH decode error in mock, deduplicate test mux, simplify merge target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -211,19 +211,13 @@ tools: ## Install all required development tools
 
 merge: ## Merge a PR as sole maintainer (usage: make merge PR=123)
 	@test -n "$(PR)" || (echo "ERROR: PR is required, example: make merge PR=123"; exit 1)
-	@REPO=$$(gh repo view --json nameWithOwner --jq .nameWithOwner); \
-	echo "Approving PR #$(PR)..."; \
-	gh pr review $(PR) --approve --body "Self-approve (sole maintainer)" 2>/dev/null || true; \
-	echo "Temporarily disabling enforce-for-admins on $$REPO..."; \
-	gh api "repos/$$REPO/branches/main/protection/enforce_admins" -X DELETE --silent; \
-	echo "Merging PR #$(PR)..."; \
-	if gh pr merge $(PR) --squash --admin --delete-branch; then \
+	@echo "Merging PR #$(PR)..."; \
+	if gh pr merge $(PR) --squash --delete-branch; then \
 		echo "PR #$(PR) merged successfully."; \
 	else \
-		echo "Merge failed. Re-enabling enforce-for-admins..."; \
-	fi; \
-	gh api "repos/$$REPO/branches/main/protection/enforce_admins" -X POST --silent; \
-	echo "Re-enabled enforce-for-admins on $$REPO."
+		echo "Merge failed."; \
+		exit 1; \
+	fi
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'

--- a/internal/service/database/dbtest/mock_server.go
+++ b/internal/service/database/dbtest/mock_server.go
@@ -139,7 +139,10 @@ func NewMockServer(dbType, name, image string, extraFields map[string]interface{
 
 		case r.Method == http.MethodPatch && r.URL.Path == dbPath:
 			var body map[string]interface{}
-			_ = json.NewDecoder(r.Body).Decode(&body)
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+				return
+			}
 			state.applyPatch(body)
 			writeJSON(w, http.StatusOK, map[string]string{"message": "updated"})
 

--- a/internal/service/envsbulk/resource_test.go
+++ b/internal/service/envsbulk/resource_test.go
@@ -327,13 +327,7 @@ func newEnvsBulkImportMux() *http.ServeMux {
 
 func TestEnvsBulkResource_Import(t *testing.T) {
 	t.Parallel()
-	mux := http.NewServeMux()
-	mux.HandleFunc("PATCH /api/v1/services/550e8400-e29b-41d4-a716-446655440012/envs/bulk", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("GET /api/v1/services/550e8400-e29b-41d4-a716-446655440012/envs", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"uuid":"e1","key":"REDIS_URL","value":"redis://localhost","is_preview":false,"is_buildtime":false}]`))
-	})
+	mux := newEnvsBulkImportMux()
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()
 


### PR DESCRIPTION
## Changes

**AI Code Quality findings (2 of 4 were valid):**

- `internal/service/database/dbtest/mock_server.go`: Return 400 on malformed PATCH body instead of silently discarding the decode error. Previously, a malformed request body would result in `applyPatch(nil)`, silently producing a no-op and masking test bugs.
- `internal/service/envsbulk/resource_test.go`: Use existing `newEnvsBulkImportMux()` helper in `TestEnvsBulkResource_Import` instead of duplicating the same two route handlers inline.

**False positives (documented, not fixed):**
- GET for start/stop endpoints: Coolify API actually uses GET (confirmed in `client/databases.go`)
- ConnectionTimeout 0 vs 10: Flatten function intentionally defaults 0 to 10 (covered by `TestFlattenServerCommon_ZeroConnectionTimeoutDefaultsTo10`)

**Branch protection improvements (applied via API, not in this PR):**
- Added `pull_request` rule (require PR before merging)
- Added `deletion` rule (prevent main branch deletion)
- Added `non_fast_forward` rule (prevent force pushes)
- Removed admin bypass; auto-approve workflow provides the required approval
- Set `required_approving_review_count` to 1

**Merge target simplification:**
- Removed `--admin` flag and enforce-for-admins toggle from `make merge` since branch protection now uses rulesets with the auto-approve bot workflow.