### PR TITLE
test: add error path tests for application logs data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 33 |
 | Data sources | 44 |
-| Tests | 910+ unit and acceptance tests |
+| Tests | 940+ unit and acceptance tests |
 | Scenario examples | 16 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 

--- a/internal/service/application/data_source_logs_test.go
+++ b/internal/service/application/data_source_logs_test.go
@@ -5,12 +5,115 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestApplicationLogsDataSource_ContainerNotRunning(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/logs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, `{"message":"container is not running"}`)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+data "coolify_application_logs" "test" {
+  uuid = "550e8400-e29b-41d4-a716-446655440000"
+}
+`, srv.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.coolify_application_logs.test", "logs.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestApplicationLogsDataSource_UnexpectedError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/logs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprintf(w, `{"message":"unexpected validation error"}`)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+data "coolify_application_logs" "test" {
+  uuid = "550e8400-e29b-41d4-a716-446655440000"
+}
+`, srv.URL),
+				ExpectError: regexp.MustCompile(`Error reading application logs`),
+			},
+		},
+	})
+}
+
+func TestApplicationLogsDataSource_EmptyLogs(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/logs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]client.ApplicationLog{})
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+data "coolify_application_logs" "test" {
+  uuid = "550e8400-e29b-41d4-a716-446655440000"
+}
+`, srv.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.coolify_application_logs.test", "logs.#", "0"),
+				),
+			},
+		},
+	})
+}
 
 func TestApplicationLogsDataSource(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Changes

- Add 3 new test cases for `coolify_application_logs` data source error handling:
  - `TestApplicationLogsDataSource_ContainerNotRunning`: HTTP 400 returns empty logs gracefully
  - `TestApplicationLogsDataSource_UnexpectedError`: HTTP 422 surfaces as diagnostic error
  - `TestApplicationLogsDataSource_EmptyLogs`: empty API response returns empty list
- Update README test count from 910+ to 940+ (actual: 947)

## Motivation

The `Read` function in `data_source_logs.go` had 45.8% coverage. Three error handling branches (400 container not running, unexpected errors, empty logs) were completely untested. These tests cover all three branches.

## Verification

- All 947 tests pass locally (`make ci` green)
- `make counts-check` confirms updated counts