### PR TITLE
test: add error path tests for API/MCP toggle client methods

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5076,3 +5076,65 @@ func TestDecodeGitHubBranches_InvalidJSON(t *testing.T) {
 	_, err := decodeGitHubBranches(raw)
 	require.Error(t, err)
 }
+
+// --- API/MCP toggle error paths ---
+
+func TestClient_EnableAPI_APIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/enable", r.URL.Path)
+		http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	err := c.EnableAPI(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enabling API")
+}
+
+func TestClient_DisableAPI_APIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/disable", r.URL.Path)
+		http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	err := c.DisableAPI(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabling API")
+}
+
+func TestClient_EnableMCP_APIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/mcp/enable", r.URL.Path)
+		http.Error(w, `{"message":"not root team"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	err := c.EnableMCP(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enabling MCP server")
+}
+
+func TestClient_DisableMCP_APIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/mcp/disable", r.URL.Path)
+		http.Error(w, `{"message":"not root team"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	err := c.DisableMCP(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabling MCP server")
+}


### PR DESCRIPTION
## Changes

Add error path tests for 4 API/MCP toggle client methods (EnableAPI, DisableAPI, EnableMCP, DisableMCP) that were at 66.7% coverage because only the success path was tested.

Each test verifies the error message wraps the operation context.

## Testing

- All new tests pass locally with `go test -race`
- `make ci` passes locally (948 tests, no vulnerabilities)
- `make counts-check` validates counts