### PR TITLE
ci: rename CodeQL job to match required status check names

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    name: CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Problem

PR #509 (and all future PRs) are stuck with `mergeStateStatus: BLOCKED` despite all checks passing and review approved. Auto-merge never fires.

## Root Cause

The repository ruleset requires status checks named `CodeQL (go)` and `CodeQL (actions)`, but the CodeQL workflow job was named `Analyze`, producing check names `Analyze (go)` and `Analyze (actions)`. The name mismatch meant the required checks were never satisfied.

## Fix

Rename the job from `Analyze` to `CodeQL` so the matrix produces `CodeQL (go)`, `CodeQL (python)`, and `CodeQL (actions)`, matching the ruleset expectations.

## Impact

Once merged, PR #509 (and any other blocked PRs) should unblock and auto-merge will proceed.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>