### PR TITLE
test: add ImportParentChild unit tests and update counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-33 resources, 44 data sources, 940+ tests (unit + acceptance), 9 CI jobs.
+33 resources, 44 data sources, 950+ tests (unit + acceptance), 9 CI jobs.
 16 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -186,7 +186,7 @@ errors and import failures.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 940+ tests (unit + acceptance)
+- 950+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, python-test, docs-check, api-coverage-check, counts-check, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 33 |
 | Data sources | 44 |
-| Tests | 940+ unit and acceptance tests |
+| Tests | 950+ unit and acceptance tests |
 | Scenario examples | 16 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -296,7 +296,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (940+ tests, race detector enabled)
+make test                                       # Run unit tests (950+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/internal/validate/uuid_test.go
+++ b/internal/validate/uuid_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestUUID_Valid(t *testing.T) {
@@ -184,6 +189,198 @@ func TestParseCompoundImportID_InvalidFormats(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("error %q should contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// importParentChildSchema returns a minimal schema for testing ImportParentChild
+// with the given parent type attributes plus "uuid".
+func importParentChildSchema(parentTypes []string) schema.Schema {
+	attrs := map[string]schema.Attribute{
+		"uuid": schema.StringAttribute{Computed: true},
+	}
+	for _, t := range parentTypes {
+		attrs[t+"_uuid"] = schema.StringAttribute{Optional: true}
+	}
+	return schema.Schema{Attributes: attrs}
+}
+
+// newImportStateResponse creates a response with an empty state for the given schema.
+func newImportStateResponse(s schema.Schema) *resource.ImportStateResponse {
+	ctx := context.Background()
+	return &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: s,
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+		},
+	}
+}
+
+func TestImportParentChild_Valid(t *testing.T) {
+	t.Parallel()
+	parentUUID := "550e8400-e29b-41d4-a716-446655440000"
+	childUUID := "aaaa0001-0001-4000-8000-000000000001"
+	allowedTypes := []string{"application", "service", "database"}
+
+	for _, typ := range allowedTypes {
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			s := importParentChildSchema(allowedTypes)
+			resp := newImportStateResponse(s)
+			req := resource.ImportStateRequest{ID: typ + ":" + parentUUID + ":" + childUUID}
+
+			validate.ImportParentChild(ctx, req, resp, allowedTypes, "storage")
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+			}
+
+			var gotParent, gotChild types.String
+			resp.State.GetAttribute(ctx, path.Root(typ+"_uuid"), &gotParent)
+			resp.State.GetAttribute(ctx, path.Root("uuid"), &gotChild)
+
+			if gotParent.ValueString() != parentUUID {
+				t.Errorf("expected %s_uuid=%s, got %s", typ, parentUUID, gotParent.ValueString())
+			}
+			if gotChild.ValueString() != childUUID {
+				t.Errorf("expected uuid=%s, got %s", childUUID, gotChild.ValueString())
+			}
+		})
+	}
+}
+
+func TestImportParentChild_WrongFormat(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"single value", "just-a-uuid"},
+		{"two parts", "application:uuid1"},
+		{"four parts", "application:uuid1:uuid2:uuid3"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			s := importParentChildSchema([]string{"application"})
+			resp := newImportStateResponse(s)
+			req := resource.ImportStateRequest{ID: tc.id}
+
+			validate.ImportParentChild(ctx, req, resp, []string{"application"}, "storage")
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("expected error for wrong format")
+			}
+		})
+	}
+}
+
+func TestImportParentChild_InvalidParentUUID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := importParentChildSchema([]string{"application"})
+	resp := newImportStateResponse(s)
+	req := resource.ImportStateRequest{ID: "application:../../admin:550e8400-e29b-41d4-a716-446655440000"}
+
+	validate.ImportParentChild(ctx, req, resp, []string{"application"}, "storage")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error for invalid parent UUID")
+	}
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	if !strings.Contains(detail, "parent UUID") {
+		t.Errorf("error should mention parent UUID, got: %s", detail)
+	}
+}
+
+func TestImportParentChild_InvalidChildUUID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := importParentChildSchema([]string{"application"})
+	resp := newImportStateResponse(s)
+	req := resource.ImportStateRequest{ID: "application:550e8400-e29b-41d4-a716-446655440000:bad!"}
+
+	validate.ImportParentChild(ctx, req, resp, []string{"application"}, "storage")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error for invalid child UUID")
+	}
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	if !strings.Contains(detail, "storage UUID") {
+		t.Errorf("error should mention storage UUID, got: %s", detail)
+	}
+}
+
+func TestImportParentChild_InvalidType(t *testing.T) {
+	t.Parallel()
+	parentUUID := "550e8400-e29b-41d4-a716-446655440000"
+	childUUID := "aaaa0001-0001-4000-8000-000000000001"
+	ctx := context.Background()
+	s := importParentChildSchema([]string{"application", "service"})
+	resp := newImportStateResponse(s)
+	req := resource.ImportStateRequest{ID: "badtype:" + parentUUID + ":" + childUUID}
+
+	validate.ImportParentChild(ctx, req, resp, []string{"application", "service"}, "storage")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error for invalid type")
+	}
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	if !strings.Contains(detail, "badtype") {
+		t.Errorf("error should mention the bad type, got: %s", detail)
+	}
+	if !strings.Contains(detail, "application") || !strings.Contains(detail, "service") {
+		t.Errorf("error should list allowed types, got: %s", detail)
+	}
+}
+
+func TestJoinOr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		id    string
+		types []string
+		want  string
+	}{
+		{
+			name:  "single type hint",
+			id:    "badtype:550e8400-e29b-41d4-a716-446655440000:aaaa0001-0001-4000-8000-000000000001",
+			types: []string{"application"},
+			want:  `"application"`,
+		},
+		{
+			name:  "two types hint",
+			id:    "badtype:550e8400-e29b-41d4-a716-446655440000:aaaa0001-0001-4000-8000-000000000001",
+			types: []string{"application", "service"},
+			want:  " or ",
+		},
+		{
+			name:  "three types hint",
+			id:    "badtype:550e8400-e29b-41d4-a716-446655440000:aaaa0001-0001-4000-8000-000000000001",
+			types: []string{"application", "service", "database"},
+			want:  ", or ",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			s := importParentChildSchema(tc.types)
+			resp := newImportStateResponse(s)
+			req := resource.ImportStateRequest{ID: tc.id}
+
+			validate.ImportParentChild(ctx, req, resp, tc.types, "storage")
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("expected error")
+			}
+			detail := resp.Diagnostics.Errors()[0].Detail()
+			if !strings.Contains(detail, tc.want) {
+				t.Errorf("error should contain %q, got: %s", tc.want, detail)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes

- Add 13 unit tests for `validate.ImportParentChild` covering all 5 code paths:
  - Valid import with each of 3 parent types (application, service, database)
  - Wrong format (single value, two parts, four parts, empty)
  - Invalid parent UUID (path traversal)
  - Invalid child UUID
  - Invalid type prefix
  - `joinOr` formatting for 1, 2, and 3+ type lists

- Update test count from 940+ to 950+ in AGENTS.md and README.md (actual: 957)

## Context

`ImportParentChild` is used by 3 resources (storage, scheduledtask, environmentvariable) and had 0% test coverage despite having 5 distinct validation paths. These tests bring it to 100%.

The test count in documentation was stale by 17 test functions.