### PR TITLE
fix: multi-perspective improvement cycle 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ mismatches, and zero validation rules when we compared it against the source.
 - Install locally: `make install`
 - Spec compliance: `make spec-check`
 - API coverage doc: `make api-coverage`
-- Extract contract from Coolify source: `make contract-extract VERSION=v4.1.0`
+- Extract contract from Coolify source: `make contract-extract VERSION=v4.1.2`
 - Verify client structs cover contract: `make contract-check`
 - Regenerate OpenAPI spec from contract: `make spec-generate`
 - Scaffold a new resource: `make scaffold NAME=myresource`

--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -13,7 +13,7 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.1.0` | Extracted from: `coollabsio/coolify@v4.1.0`
+Contract version: `v4.1.2` | Extracted from: `coollabsio/coolify@v4.1.2`
 
 ## Summary
 

--- a/internal/service/application/resource_dockerfile_test.go
+++ b/internal/service/application/resource_dockerfile_test.go
@@ -31,6 +31,7 @@ func TestDockerfileApplicationResource_Create(t *testing.T) {
 		ProjectUUID:        "aaaa0001-0001-4000-8000-000000000001",
 		ServerUUID:         "bbbb0001-0001-4000-8000-000000000001",
 		EnvironmentName:    "production",
+		MaxRestartCount:    func() *int64 { v := int64(10); return &v }(),
 	}
 
 	mu := sync.Mutex{}
@@ -100,6 +101,7 @@ func TestDockerfileApplicationResource_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "dockerfile_location", "/Dockerfile"),
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "ports_exposes", "80"),
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "environment_name", "production"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "max_restart_count", "10"),
 				),
 			},
 			{

--- a/internal/service/database/postgresql/resource_test.go
+++ b/internal/service/database/postgresql/resource_test.go
@@ -52,6 +52,11 @@ resource "coolify_database_postgresql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "status", "running"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_cpu_shares", "1024"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "instant_deploy", "false"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_interval", "15"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_timeout", "5"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_retries", "5"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_start_period", "5"),
 				),
 			},
 			// Plan idempotency: re-apply same config, expect empty plan
@@ -100,6 +105,33 @@ resource "coolify_database_postgresql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "ssl_mode", "require"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_log_drain_enabled", "true"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_include_timestamps", "true"),
+				),
+			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_postgresql" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-pg-db"
+  description             = "Updated description"
+  enable_ssl              = true
+  ssl_mode                = "require"
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "health_check_start_period", "15"),
 				),
 			},
 			// Import

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -13,7 +13,7 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.1.0` | Extracted from: `coollabsio/coolify@v4.1.0`
+Contract version: `v4.1.2` | Extracted from: `coollabsio/coolify@v4.1.2`
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle covering all 14 perspectives plus 5 post-cycle checks.

## Changes

### QA Engineer (fixes)
- **PostgreSQL resource test**: Added health check default value assertions to the Create step, and a new Update step with non-default values (`enabled=false`, `interval=30`, `timeout=10`, `retries=3`, `start_period=15`) to exercise the full update/flatten/read-back path.
- **Dockerfile application test**: Added `max_restart_count=10` to the mock `Application` struct and asserted it in the Create step, covering the resource flatten path.

### Developer (issue filed)
- Filed [#519](https://github.com/coolify-terraform/terraform-provider-coolify/issues/519): Extract shared base fields from 8 duplicate `Create*Input` structs in `internal/client/databases.go`.

### Documentation gaps (fixes)
- Updated contract version references from v4.1.0 to v4.1.2 in `AGENTS.md`, `templates/guides/api-contract-accuracy.md.tmpl`, and regenerated docs.

### Perspectives with no findings
End User, Maintainer, Ops/SRE, Security Engineer, Product Manager, Spec/Contract Compliance, Performance Engineer, Backward Compatibility, Adversarial Tester, Architecture Reviewer, New Contributor, Observability/Error Detective: no actionable findings. The codebase is mature with 957+ tests, 100% contract coverage, and comprehensive CI.

## Verification

`make ci` passes (957 tests, 0 lint issues, all checks green).