### PR TITLE
refactor: extract CreateDatabaseBaseInput to eliminate duplication

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -501,11 +501,13 @@ func TestClient_CreateDatabase_Postgresql(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	db, err := c.CreateDatabase(context.Background(), "postgresql", CreatePostgresqlInput{
-		ServerUUID:      "srv-1",
-		ProjectUUID:     "proj-1",
-		EnvironmentName: "production",
-		PostgresUser:    "pgadmin",
-		PostgresDB:      "testdb",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
+		PostgresUser: "pgadmin",
+		PostgresDB:   "testdb",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -883,11 +885,13 @@ func TestClient_CreateDatabase_Mysql(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	db, err := c.CreateDatabase(context.Background(), "mysql", CreateMysqlInput{
-		ServerUUID:      "srv-1",
-		ProjectUUID:     "proj-1",
-		EnvironmentName: "production",
-		MysqlUser:       "myuser",
-		MysqlDatabase:   "mydb",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
+		MysqlUser:     "myuser",
+		MysqlDatabase: "mydb",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "db-mysql-new", db.UUID)
@@ -1535,9 +1539,11 @@ func TestClient_CreateDatabase_Mariadb(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	db, err := c.CreateDatabase(context.Background(), "mariadb", CreateMariadbInput{
-		ServerUUID:      "srv-1",
-		ProjectUUID:     "proj-1",
-		EnvironmentName: "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 		MariadbUser:     "mdbuser",
 		MariadbDatabase: "mdbname",
 	})
@@ -1567,9 +1573,11 @@ func TestClient_CreateDatabase_Redis(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	db, err := c.CreateDatabase(context.Background(), "redis", CreateRedisInput{
-		ServerUUID:      "srv-1",
-		ProjectUUID:     "proj-1",
-		EnvironmentName: "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "db-redis-new", db.UUID)
@@ -1599,9 +1607,11 @@ func TestClient_CreateDatabase_Mongodb(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	db, err := c.CreateDatabase(context.Background(), "mongodb", CreateMongodbInput{
-		ServerUUID:              "srv-1",
-		ProjectUUID:             "proj-1",
-		EnvironmentName:         "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 		MongoInitdbRootUsername: "mongoroot",
 		MongoInitdbDatabase:     "appdb",
 	})
@@ -2165,7 +2175,11 @@ func TestClient_CreateDatabase_Keydb(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	got, err := c.CreateDatabase(context.Background(), "keydb", CreateKeydbInput{
-		ProjectUUID: "proj-1", ServerUUID: "srv-1", EnvironmentName: "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "keydb-1", got.UUID)
@@ -2192,7 +2206,11 @@ func TestClient_CreateDatabase_Dragonfly(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	got, err := c.CreateDatabase(context.Background(), "dragonfly", CreateDragonflyInput{
-		ProjectUUID: "proj-1", ServerUUID: "srv-1", EnvironmentName: "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "df-1", got.UUID)
@@ -2220,9 +2238,11 @@ func TestClient_CreateDatabase_Clickhouse(t *testing.T) {
 
 	c := New(srv.URL, "test-token")
 	got, err := c.CreateDatabase(context.Background(), "clickhouse", CreateClickhouseInput{
-		ProjectUUID:     "proj-1",
-		ServerUUID:      "srv-1",
-		EnvironmentName: "production",
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ServerUUID:      "srv-1",
+			ProjectUUID:     "proj-1",
+			EnvironmentName: "production",
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "ch-1", got.UUID)

--- a/internal/client/databases.go
+++ b/internal/client/databases.go
@@ -77,54 +77,9 @@ type Database struct {
 	KeydbPassword          string          `json:"keydb_password,omitempty"`
 	DragonflyPassword      string          `json:"dragonfly_password,omitempty"`
 }
-type CreatePostgresqlInput struct {
-	ServerUUID       string `json:"server_uuid"`
-	ProjectUUID      string `json:"project_uuid"`
-	EnvironmentName  string `json:"environment_name"`
-	EnvironmentUUID  string `json:"environment_uuid,omitempty"`
-	Name             string `json:"name,omitempty"`
-	Description      string `json:"description,omitempty"`
-	Image            string `json:"image,omitempty"`
-	PostgresUser     string `json:"postgres_user,omitempty"`
-	PostgresPassword string `json:"postgres_password,omitempty"`
-	PostgresDB       string `json:"postgres_db,omitempty"`
-	IsPublic         *bool  `json:"is_public,omitempty"`
-	PublicPort       *int64 `json:"public_port,omitempty"`
-	InstantDeploy    *bool  `json:"instant_deploy,omitempty"`
-}
-type CreateMysqlInput struct {
-	ServerUUID        string `json:"server_uuid"`
-	ProjectUUID       string `json:"project_uuid"`
-	EnvironmentName   string `json:"environment_name"`
-	EnvironmentUUID   string `json:"environment_uuid,omitempty"`
-	Name              string `json:"name,omitempty"`
-	Description       string `json:"description,omitempty"`
-	Image             string `json:"image,omitempty"`
-	MysqlRootPassword string `json:"mysql_root_password,omitempty"`
-	MysqlUser         string `json:"mysql_user,omitempty"`
-	MysqlPassword     string `json:"mysql_password,omitempty"`
-	MysqlDatabase     string `json:"mysql_database,omitempty"`
-	IsPublic          *bool  `json:"is_public,omitempty"`
-	PublicPort        *int64 `json:"public_port,omitempty"`
-	InstantDeploy     *bool  `json:"instant_deploy,omitempty"`
-}
-type CreateMariadbInput struct {
-	ServerUUID          string `json:"server_uuid"`
-	ProjectUUID         string `json:"project_uuid"`
-	EnvironmentName     string `json:"environment_name"`
-	EnvironmentUUID     string `json:"environment_uuid,omitempty"`
-	Name                string `json:"name,omitempty"`
-	Description         string `json:"description,omitempty"`
-	Image               string `json:"image,omitempty"`
-	MariadbRootPassword string `json:"mariadb_root_password,omitempty"`
-	MariadbUser         string `json:"mariadb_user,omitempty"`
-	MariadbPassword     string `json:"mariadb_password,omitempty"`
-	MariadbDatabase     string `json:"mariadb_database,omitempty"`
-	IsPublic            *bool  `json:"is_public,omitempty"`
-	PublicPort          *int64 `json:"public_port,omitempty"`
-	InstantDeploy       *bool  `json:"instant_deploy,omitempty"`
-}
-type CreateRedisInput struct {
+
+// CreateDatabaseBaseInput contains fields shared by all database Create endpoints.
+type CreateDatabaseBaseInput struct {
 	ServerUUID      string `json:"server_uuid"`
 	ProjectUUID     string `json:"project_uuid"`
 	EnvironmentName string `json:"environment_name"`
@@ -132,65 +87,59 @@ type CreateRedisInput struct {
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
 	Image           string `json:"image,omitempty"`
-	RedisPassword   string `json:"redis_password,omitempty"`
 	IsPublic        *bool  `json:"is_public,omitempty"`
 	PublicPort      *int64 `json:"public_port,omitempty"`
 	InstantDeploy   *bool  `json:"instant_deploy,omitempty"`
 }
+
+type CreatePostgresqlInput struct {
+	CreateDatabaseBaseInput
+	PostgresUser     string `json:"postgres_user,omitempty"`
+	PostgresPassword string `json:"postgres_password,omitempty"`
+	PostgresDB       string `json:"postgres_db,omitempty"`
+}
+
+type CreateMysqlInput struct {
+	CreateDatabaseBaseInput
+	MysqlRootPassword string `json:"mysql_root_password,omitempty"`
+	MysqlUser         string `json:"mysql_user,omitempty"`
+	MysqlPassword     string `json:"mysql_password,omitempty"`
+	MysqlDatabase     string `json:"mysql_database,omitempty"`
+}
+
+type CreateMariadbInput struct {
+	CreateDatabaseBaseInput
+	MariadbRootPassword string `json:"mariadb_root_password,omitempty"`
+	MariadbUser         string `json:"mariadb_user,omitempty"`
+	MariadbPassword     string `json:"mariadb_password,omitempty"`
+	MariadbDatabase     string `json:"mariadb_database,omitempty"`
+}
+
+type CreateRedisInput struct {
+	CreateDatabaseBaseInput
+	RedisPassword string `json:"redis_password,omitempty"`
+}
+
 type CreateMongodbInput struct {
-	ServerUUID              string `json:"server_uuid"`
-	ProjectUUID             string `json:"project_uuid"`
-	EnvironmentName         string `json:"environment_name"`
-	EnvironmentUUID         string `json:"environment_uuid,omitempty"`
-	Name                    string `json:"name,omitempty"`
-	Description             string `json:"description,omitempty"`
-	Image                   string `json:"image,omitempty"`
+	CreateDatabaseBaseInput
 	MongoInitdbRootUsername string `json:"mongo_initdb_root_username,omitempty"`
 	MongoInitdbRootPassword string `json:"mongo_initdb_root_password,omitempty"`
 	MongoInitdbDatabase     string `json:"mongo_initdb_database,omitempty"`
-	IsPublic                *bool  `json:"is_public,omitempty"`
-	PublicPort              *int64 `json:"public_port,omitempty"`
-	InstantDeploy           *bool  `json:"instant_deploy,omitempty"`
 }
+
 type CreateClickhouseInput struct {
-	ProjectUUID             string `json:"project_uuid"`
-	ServerUUID              string `json:"server_uuid"`
-	EnvironmentName         string `json:"environment_name"`
-	EnvironmentUUID         string `json:"environment_uuid,omitempty"`
-	Name                    string `json:"name,omitempty"`
-	Description             string `json:"description,omitempty"`
-	Image                   string `json:"image,omitempty"`
-	IsPublic                *bool  `json:"is_public,omitempty"`
-	PublicPort              *int64 `json:"public_port,omitempty"`
-	InstantDeploy           *bool  `json:"instant_deploy,omitempty"`
+	CreateDatabaseBaseInput
 	ClickhouseAdminUser     string `json:"clickhouse_admin_user,omitempty"`
 	ClickhouseAdminPassword string `json:"clickhouse_admin_password,omitempty"`
 }
 
 type CreateKeydbInput struct {
-	ProjectUUID     string `json:"project_uuid"`
-	ServerUUID      string `json:"server_uuid"`
-	EnvironmentName string `json:"environment_name"`
-	EnvironmentUUID string `json:"environment_uuid,omitempty"`
-	Name            string `json:"name,omitempty"`
-	Description     string `json:"description,omitempty"`
-	Image           string `json:"image,omitempty"`
-	IsPublic        *bool  `json:"is_public,omitempty"`
-	PublicPort      *int64 `json:"public_port,omitempty"`
-	InstantDeploy   *bool  `json:"instant_deploy,omitempty"`
-	KeydbPassword   string `json:"keydb_password,omitempty"`
+	CreateDatabaseBaseInput
+	KeydbPassword string `json:"keydb_password,omitempty"`
 }
+
 type CreateDragonflyInput struct {
-	ProjectUUID       string `json:"project_uuid"`
-	ServerUUID        string `json:"server_uuid"`
-	EnvironmentName   string `json:"environment_name"`
-	EnvironmentUUID   string `json:"environment_uuid,omitempty"`
-	Name              string `json:"name,omitempty"`
-	Description       string `json:"description,omitempty"`
-	Image             string `json:"image,omitempty"`
-	IsPublic          *bool  `json:"is_public,omitempty"`
-	PublicPort        *int64 `json:"public_port,omitempty"`
-	InstantDeploy     *bool  `json:"instant_deploy,omitempty"`
+	CreateDatabaseBaseInput
 	DragonflyPassword string `json:"dragonfly_password,omitempty"`
 }
 

--- a/internal/service/database/clickhouse/resource.go
+++ b/internal/service/database/clickhouse/resource.go
@@ -61,7 +61,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
-	in := client.CreateClickhouseInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateClickhouseInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/service/database/dragonfly/resource.go
+++ b/internal/service/database/dragonfly/resource.go
@@ -58,7 +58,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_dragonfly"})
 
-	in := client.CreateDragonflyInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateDragonflyInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/service/database/keydb/resource.go
+++ b/internal/service/database/keydb/resource.go
@@ -60,7 +60,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_keydb"})
 
-	in := client.CreateKeydbInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateKeydbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/service/database/mariadb/resource.go
+++ b/internal/service/database/mariadb/resource.go
@@ -68,7 +68,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mariadb"})
 
-	in := client.CreateMariadbInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateMariadbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/service/database/mongodb/resource.go
+++ b/internal/service/database/mongodb/resource.go
@@ -66,7 +66,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mongodb"})
 
-	in := client.CreateMongodbInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateMongodbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/service/database/mysql/resource.go
+++ b/internal/service/database/mysql/resource.go
@@ -76,7 +76,11 @@ func (r *mysqlDatabaseResource) Create(ctx context.Context, req resource.CreateR
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mysql"})
 
-	input := client.CreateMysqlInput{ServerUUID: plan.ServerUUID.ValueString(), ProjectUUID: plan.ProjectUUID.ValueString(), EnvironmentName: plan.EnvironmentName.ValueString()}
+	input := client.CreateMysqlInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      plan.ServerUUID.ValueString(),
+		ProjectUUID:     plan.ProjectUUID.ValueString(),
+		EnvironmentName: plan.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&input.Name, plan.Name)
 	flex.SetIfKnown(&input.Description, plan.Description)
 	flex.SetIfKnown(&input.Image, plan.Image)

--- a/internal/service/database/postgresql/resource.go
+++ b/internal/service/database/postgresql/resource.go
@@ -103,9 +103,11 @@ func (r *postgresqlDatabaseResource) Create(ctx context.Context, req resource.Cr
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_postgresql"})
 
 	input := client.CreatePostgresqlInput{
-		ServerUUID:      plan.ServerUUID.ValueString(),
-		ProjectUUID:     plan.ProjectUUID.ValueString(),
-		EnvironmentName: plan.EnvironmentName.ValueString(),
+		CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+			ServerUUID:      plan.ServerUUID.ValueString(),
+			ProjectUUID:     plan.ProjectUUID.ValueString(),
+			EnvironmentName: plan.EnvironmentName.ValueString(),
+		},
 	}
 	flex.SetIfKnown(&input.Name, plan.Name)
 	flex.SetIfKnown(&input.Description, plan.Description)

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -60,7 +60,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_redis"})
-	in := client.CreateRedisInput{ServerUUID: p.ServerUUID.ValueString(), ProjectUUID: p.ProjectUUID.ValueString(), EnvironmentName: p.EnvironmentName.ValueString()}
+	in := client.CreateRedisInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+		ServerUUID:      p.ServerUUID.ValueString(),
+		ProjectUUID:     p.ProjectUUID.ValueString(),
+		EnvironmentName: p.EnvironmentName.ValueString(),
+	}}
 	flex.SetIfKnown(&in.Name, p.Name)
 	flex.SetIfKnown(&in.Description, p.Description)
 	flex.SetIfKnown(&in.Image, p.Image)

--- a/internal/spectest/client_spec_test.go
+++ b/internal/spectest/client_spec_test.go
@@ -92,10 +92,12 @@ func TestClientEndpoints_SpecCompliance(t *testing.T) {
 		// Databases
 		{"CreatePostgresql", "POST", "/api/v1/databases/postgresql",
 			client.CreatePostgresqlInput{
-				ServerUUID:      "srv-1",
-				ProjectUUID:     "proj-1",
-				EnvironmentName: "production",
-				EnvironmentUUID: "env-1",
+				CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
+					ServerUUID:      "srv-1",
+					ProjectUUID:     "proj-1",
+					EnvironmentName: "production",
+					EnvironmentUUID: "env-1",
+				},
 			}, 201, map[string]string{"uuid": "db-1"}},
 		{"GetDatabase", "GET", "/api/v1/databases/db-1",
 			nil, 200, map[string]interface{}{"uuid": "db-1", "name": "pg-db"}},


### PR DESCRIPTION
## Summary

Extract 10 shared fields from 8 duplicate `Create*Input` structs into a single `CreateDatabaseBaseInput` struct using Go embedding.

## Changes

- Added `CreateDatabaseBaseInput` with shared fields: `server_uuid`, `project_uuid`, `environment_name`, `environment_uuid`, `name`, `description`, `image`, `is_public`, `public_port`, `instant_deploy`
- Refactored `CreatePostgresqlInput`, `CreateMysqlInput`, `CreateMariadbInput`, `CreateRedisInput`, `CreateMongodbInput`, `CreateClickhouseInput`, `CreateKeydbInput`, and `CreateDragonflyInput` to embed `CreateDatabaseBaseInput`
- Updated all 8 resource Create call sites and 9 test call sites

## Why

Eliminates ~80 lines of duplicated field declarations. When a new shared field is added to the Create endpoints, it only needs to be added once in `CreateDatabaseBaseInput` instead of 8 times.

JSON wire format is unchanged because Go's `encoding/json` promotes embedded struct fields.

Closes #519