### PR TITLE
refactor: extract PopulateBaseCreateInput to eliminate Create boilerplate

### DIFF
--- a/internal/service/database/clickhouse/resource.go
+++ b/internal/service/database/clickhouse/resource.go
@@ -61,19 +61,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
-	in := client.CreateClickhouseInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
+	var in client.CreateClickhouseInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.ClickhouseAdminUser, p.ClickhouseAdminUser)
 	flex.SetIfKnown(&in.ClickhouseAdminPassword, p.ClickhouseAdminPassword)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
 	c, err := r.client.CreateDatabase(ctx, "clickhouse", in)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ClickHouse database",

--- a/internal/service/database/common.go
+++ b/internal/service/database/common.go
@@ -104,6 +104,20 @@ func (m *CommonModel) CommonPtrs() DatabaseCommonPtrs {
 	}
 }
 
+// PopulateBaseCreateInput sets the shared fields on a CreateDatabaseBaseInput
+// from the CommonModel, reducing boilerplate in each database Create method.
+func PopulateBaseCreateInput(base *client.CreateDatabaseBaseInput, m *CommonModel) {
+	base.ServerUUID = m.ServerUUID.ValueString()
+	base.ProjectUUID = m.ProjectUUID.ValueString()
+	base.EnvironmentName = m.EnvironmentName.ValueString()
+	flex.SetIfKnown(&base.Name, m.Name)
+	flex.SetIfKnown(&base.Description, m.Description)
+	flex.SetIfKnown(&base.Image, m.Image)
+	base.IsPublic = flex.BoolValueOrNull(m.IsPublic)
+	base.PublicPort = flex.Int64PtrFromFramework(m.PublicPort)
+	base.InstantDeploy = flex.BoolValueOrNull(m.InstantDeploy)
+}
+
 // CommonDatabaseAttrs returns the shared schema attributes for all database types.
 func CommonDatabaseAttrs(ctx context.Context, extra map[string]schema.Attribute) map[string]schema.Attribute {
 	attrs := map[string]schema.Attribute{

--- a/internal/service/database/dragonfly/resource.go
+++ b/internal/service/database/dragonfly/resource.go
@@ -58,17 +58,8 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_dragonfly"})
 
-	in := client.CreateDragonflyInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
+	var in client.CreateDragonflyInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.DragonflyPassword, p.DragonflyPassword)
 	c, err := r.client.CreateDatabase(ctx, "dragonfly", in)
 	if err != nil {

--- a/internal/service/database/keydb/resource.go
+++ b/internal/service/database/keydb/resource.go
@@ -60,17 +60,8 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_keydb"})
 
-	in := client.CreateKeydbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
+	var in client.CreateKeydbInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.KeydbPassword, p.KeydbPassword)
 	c, err := r.client.CreateDatabase(ctx, "keydb", in)
 	if err != nil {

--- a/internal/service/database/mariadb/resource.go
+++ b/internal/service/database/mariadb/resource.go
@@ -68,21 +68,12 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mariadb"})
 
-	in := client.CreateMariadbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
+	var in client.CreateMariadbInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.MariadbUser, p.MariadbUser)
 	flex.SetIfKnown(&in.MariadbPassword, p.MariadbPassword)
 	flex.SetIfKnown(&in.MariadbDatabase, p.MariadbDatabase)
 	flex.SetIfKnown(&in.MariadbRootPassword, p.MariadbRootPassword)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
 	c, err := r.client.CreateDatabase(ctx, "mariadb", in)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating MariaDB database",

--- a/internal/service/database/mongodb/resource.go
+++ b/internal/service/database/mongodb/resource.go
@@ -66,20 +66,11 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mongodb"})
 
-	in := client.CreateMongodbInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
+	var in client.CreateMongodbInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.MongoInitdbRootUsername, p.MongoInitdbRootUsername)
 	flex.SetIfKnown(&in.MongoInitdbRootPassword, p.MongoInitdbRootPassword)
 	flex.SetIfKnown(&in.MongoInitdbDatabase, p.MongoInitdbDatabase)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
 	c, err := r.client.CreateDatabase(ctx, "mongodb", in)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating MongoDB database",

--- a/internal/service/database/mysql/resource.go
+++ b/internal/service/database/mysql/resource.go
@@ -76,21 +76,12 @@ func (r *mysqlDatabaseResource) Create(ctx context.Context, req resource.CreateR
 	defer cancel()
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_mysql"})
 
-	input := client.CreateMysqlInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      plan.ServerUUID.ValueString(),
-		ProjectUUID:     plan.ProjectUUID.ValueString(),
-		EnvironmentName: plan.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&input.Name, plan.Name)
-	flex.SetIfKnown(&input.Description, plan.Description)
-	flex.SetIfKnown(&input.Image, plan.Image)
+	var input client.CreateMysqlInput
+	dbcommon.PopulateBaseCreateInput(&input.CreateDatabaseBaseInput, &plan.CommonModel)
 	flex.SetIfKnown(&input.MysqlUser, plan.MysqlUser)
 	flex.SetIfKnown(&input.MysqlPassword, plan.MysqlPassword)
 	flex.SetIfKnown(&input.MysqlDatabase, plan.MysqlDatabase)
 	flex.SetIfKnown(&input.MysqlRootPassword, plan.MysqlRootPassword)
-	input.IsPublic = flex.BoolValueOrNull(plan.IsPublic)
-	input.PublicPort = flex.Int64PtrFromFramework(plan.PublicPort)
-	input.InstantDeploy = flex.BoolValueOrNull(plan.InstantDeploy)
 	created, err := r.client.CreateDatabase(ctx, "mysql", input)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating MySQL database",

--- a/internal/service/database/postgresql/resource.go
+++ b/internal/service/database/postgresql/resource.go
@@ -102,22 +102,11 @@ func (r *postgresqlDatabaseResource) Create(ctx context.Context, req resource.Cr
 
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_postgresql"})
 
-	input := client.CreatePostgresqlInput{
-		CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-			ServerUUID:      plan.ServerUUID.ValueString(),
-			ProjectUUID:     plan.ProjectUUID.ValueString(),
-			EnvironmentName: plan.EnvironmentName.ValueString(),
-		},
-	}
-	flex.SetIfKnown(&input.Name, plan.Name)
-	flex.SetIfKnown(&input.Description, plan.Description)
-	flex.SetIfKnown(&input.Image, plan.Image)
+	var input client.CreatePostgresqlInput
+	dbcommon.PopulateBaseCreateInput(&input.CreateDatabaseBaseInput, &plan.CommonModel)
 	flex.SetIfKnown(&input.PostgresUser, plan.PostgresUser)
 	flex.SetIfKnown(&input.PostgresPassword, plan.PostgresPassword)
 	flex.SetIfKnown(&input.PostgresDB, plan.PostgresDB)
-	input.IsPublic = flex.BoolValueOrNull(plan.IsPublic)
-	input.PublicPort = flex.Int64PtrFromFramework(plan.PublicPort)
-	input.InstantDeploy = flex.BoolValueOrNull(plan.InstantDeploy)
 
 	created, err := r.client.CreateDatabase(ctx, "postgresql", input)
 	if err != nil {

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -60,18 +60,9 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	defer cancel()
 
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_database_redis"})
-	in := client.CreateRedisInput{CreateDatabaseBaseInput: client.CreateDatabaseBaseInput{
-		ServerUUID:      p.ServerUUID.ValueString(),
-		ProjectUUID:     p.ProjectUUID.ValueString(),
-		EnvironmentName: p.EnvironmentName.ValueString(),
-	}}
-	flex.SetIfKnown(&in.Name, p.Name)
-	flex.SetIfKnown(&in.Description, p.Description)
-	flex.SetIfKnown(&in.Image, p.Image)
+	var in client.CreateRedisInput
+	dbcommon.PopulateBaseCreateInput(&in.CreateDatabaseBaseInput, &p.CommonModel)
 	flex.SetIfKnown(&in.RedisPassword, p.RedisPassword)
-	in.IsPublic = flex.BoolValueOrNull(p.IsPublic)
-	in.PublicPort = flex.Int64PtrFromFramework(p.PublicPort)
-	in.InstantDeploy = flex.BoolValueOrNull(p.InstantDeploy)
 	c, err := r.client.CreateDatabase(ctx, "redis", in)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Redis database",


### PR DESCRIPTION
## Summary

Extract a `PopulateBaseCreateInput` helper in `internal/service/database/common.go` that sets the 9 shared fields on `CreateDatabaseBaseInput` from `CommonModel`. This replaces ~60 lines of duplicated field-assignment boilerplate across all 8 database resource Create methods.

## Changes

- **`internal/service/database/common.go`**: Add `PopulateBaseCreateInput` helper after `CommonPtrs()`
- **8 database resource files**: Simplify Create methods to use `PopulateBaseCreateInput` instead of inline field assignments

## Verification

- `make ci` passes (build, lint, 957 tests, docs, vulncheck, goreleaser)
- All 8 database resource test suites pass with race detector
- Spec and contract compliance checks pass

Builds on the `CreateDatabaseBaseInput` struct embedding from #521.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>