### PR TITLE
feat: support RELEASE_NOTES.md override for curated release descriptions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,17 @@ jobs:
             echo "Deleting existing asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y || true
           done
+      - name: Apply custom release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          if [ -f RELEASE_NOTES.md ]; then
+            echo "Custom release notes found, updating release body..."
+            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+          else
+            echo "No custom release notes, using auto-generated notes"
+          fi
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         id: import_gpg
@@ -139,3 +150,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Clean up release notes file
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
+            echo "Removing RELEASE_NOTES.md from main..."
+            # Use the GitHub API to delete the file (persist-credentials: false
+            # means git push has no credentials).
+            SHA=$(gh api "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
+              --jq '.sha')
+            gh api --method DELETE "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
+              -f message="chore: remove release notes override [skip ci]" \
+              -f sha="$SHA" \
+              -f branch="main"
+          fi


### PR DESCRIPTION
## Summary

Add a `RELEASE_NOTES.md` override mechanism to the release workflow, enabling two release modes in a single workflow:

- **Automated (default)**: merge the release-please PR as-is; auto-generated notes ship unchanged
- **AI-assisted**: push a `RELEASE_NOTES.md` to the release-please branch before merging; the workflow uses it as the release body, then cleans it up from main

## Changes

Two new steps in `.github/workflows/release.yml`:

1. **Apply custom release notes**: after the release is created, checks for `RELEASE_NOTES.md` at the repo root. If present, replaces the GitHub Release body via `gh release edit`. If absent, does nothing.
2. **Clean up release notes file**: after GoReleaser completes, deletes `RELEASE_NOTES.md` from main via the GitHub Contents API (since `persist-credentials: false` is set on the checkout step).

## Why

Release-please generates notes from conventional commit messages, which are terse and developer-facing. When working with an AI assistant, we can produce richer notes that explain what actually changed for end users. Both modes should coexist without configuration changes.

The file-based approach is reviewable in the PR diff, versioned on the tagged commit, and requires no API gymnastics.

Closes #524