### PR TITLE
fix: document RELEASE_NOTES.md must be on main, not release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,13 @@ jobs:
             echo "Deleting existing asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y || true
           done
+      # Custom release notes override:
+      # To use curated release notes instead of auto-generated ones, commit a
+      # RELEASE_NOTES.md file to main (via a prep PR) BEFORE merging the
+      # release-please PR. The file must be on main, not on the release-please
+      # branch (release-please force-pushes its branch on every new main commit,
+      # which wipes any extra files). The cleanup step below deletes the file
+      # from main after the release completes.
       - name: Apply custom release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,29 @@ Scenario Tests bootstrap Coolify and run `terraform test` against it.
 A separate Dependabot Auto-Merge workflow auto-merges minor/patch PRs.
 Format check (gofmt) is included in the Lint job via golangci-lint.
 
+## Releases
+
+Release-please manages versioning and CHANGELOG generation. Two release modes:
+
+- **Automated**: merge the release-please PR as-is. Auto-generated notes ship unchanged.
+- **AI-assisted (curated notes)**: commit a `RELEASE_NOTES.md` file to main via a prep PR,
+  merge it, then merge the release-please PR. The release workflow detects the file and
+  uses it as the GitHub Release body. A cleanup step deletes the file from main afterward.
+
+**Important**: `RELEASE_NOTES.md` must be committed to main, NOT to the release-please
+branch. Release-please force-pushes its branch on every new main commit, which wipes any
+extra files added directly to that branch.
+
+The correct sequence for curated releases:
+1. Write `RELEASE_NOTES.md` with user-facing release description
+2. Push it to main via a small PR (e.g., `docs: add release notes for vX.Y.Z`)
+3. Wait for release-please to update its PR (picks up the new commit)
+4. Merge the release-please PR
+5. Release workflow applies the curated notes and cleans up the file
+
+Published to both [Terraform Registry](https://registry.terraform.io/providers/coolify-terraform/coolify)
+and [OpenTofu Registry](https://registry.opentofu.org/providers/coolify-terraform/coolify).
+
 ## Safety
 
 - Never commit API tokens or real credentials (test files use `"test-token"`)


### PR DESCRIPTION
## Summary

Fix the `RELEASE_NOTES.md` override process documented in #524: the file must be committed to main (via a prep PR), not to the release-please branch. Release-please force-pushes its branch on every new main commit, wiping any extra files added directly to that branch.

This is what happened on v0.1.5: the curated notes were pushed to the release-please branch, PR #525 merged to main, release-please force-pushed, and the notes were lost.

## Changes

- **`.github/workflows/release.yml`**: Added inline comment explaining the correct process (commit to main, not the release branch)
- **`AGENTS.md`**: Added a "Releases" section documenting both release modes (automated and AI-assisted with curated notes), the correct sequence, and the force-push caveat

No code logic changes; the override and cleanup steps from #525 are correct as-is.

Closes #526