### PR TITLE
fix: release notes cleanup respects branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      pull-requests: write
     timeout-minutes: 30
     env:
       RELEASE_TAG: ${{ needs.release-please.outputs.tag_name || github.event.inputs.tag || github.ref_name }}
@@ -157,18 +158,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      # Generate a GitHub App token for the cleanup PR so that push events
+      # trigger CI and auto-approve (GITHUB_TOKEN suppresses both).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: cleanup-token
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - name: Clean up release notes file
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
         run: |
           if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
             echo "Removing RELEASE_NOTES.md from main..."
-            # Use the GitHub API to delete the file (persist-credentials: false
-            # means git push has no credentials).
-            SHA=$(gh api "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
+            # Branch protection prevents direct pushes to main, so create a
+            # short-lived PR to delete the file. The auto-approve workflow
+            # handles approval, and auto-merge closes it once CI passes.
+            BRANCH="chore/cleanup-release-notes-${{ env.RELEASE_TAG }}"
+            gh api "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$BRANCH" \
+              -f sha="$(git rev-parse HEAD)"
+            FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/RELEASE_NOTES.md?ref=$BRANCH" \
               --jq '.sha')
             gh api --method DELETE "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
-              -f message="chore: remove release notes override [skip ci]" \
-              -f sha="$SHA" \
-              -f branch="main"
+              -f message="chore: remove release notes override" \
+              -f sha="$FILE_SHA" \
+              -f branch="$BRANCH"
+            PR_URL=$(gh pr create --base main --head "$BRANCH" \
+              --title "chore: remove release notes override" \
+              --body "Auto-cleanup of \`RELEASE_NOTES.md\` after ${{ env.RELEASE_TAG }} release.")
+            gh pr merge "$PR_URL" --auto --squash
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ The correct sequence for curated releases:
 5. Release workflow applies the curated notes and cleans up the file
 
 Published to both [Terraform Registry](https://registry.terraform.io/providers/coolify-terraform/coolify)
-and [OpenTofu Registry](https://registry.opentofu.org/providers/coolify-terraform/coolify).
+and [OpenTofu Registry](https://search.opentofu.org/provider/coolify-terraform/coolify).
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Three bugs found while walking through the release workflow end-to-end:

### 1. Cleanup step blocked by branch protection

The cleanup step tried to delete `RELEASE_NOTES.md` from main via the GitHub Contents API. Branch protection (no bypass actors) blocks this. Fix: create a short-lived PR to delete the file instead of pushing directly.

### 2. Cleanup PR never auto-approved

PRs created by `GITHUB_TOKEN` suppress `pull_request` events, so the auto-approve workflow never fires. Additionally, `github-actions[bot]` is not in the auto-approve actor allow list. Fix: use the GitHub App token (same one used by release-please) for the cleanup PR, so it appears as `coolify-terraform-auto-approve[bot]` and triggers auto-approve.

### 3. Broken OpenTofu Registry URL

The URL added in #527 used `registry.opentofu.org/providers/...` which returns 404. The correct URL is `search.opentofu.org/provider/...`.

## Verification

Traced both release paths end-to-end:

- **Path A (automated, no RELEASE_NOTES.md)**: all steps no-op correctly, cleanup step skipped
- **Path B (AI-assisted, RELEASE_NOTES.md present)**: override applies, GoReleaser runs, cleanup creates PR with App token, auto-approve triggers, auto-merge set

Ref #526