### PR TITLE
fix: address AI code quality findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ mismatches, and zero validation rules when we compared it against the source.
 ### Resource implementation
 
 - One package per resource type under `internal/service/`
+- **Database packages use `res` and `model` as type names by convention.** All 6 database packages (redis, mongodb, mariadb, clickhouse, keydb, dragonfly) use these short names because each is in its own package, making the names unambiguous. Do not rename them to `redisResource`/`redisModel` etc. AI code scanners flag this as "too generic" on every cycle; it is a deliberate design choice.
 - Every resource implements `resource.ResourceWithImportState`
 - Handle 404 in Read (call `resp.State.RemoveResource`) and Delete (silently return)
 - Use `stringplanmodifier.RequiresReplace()` on immutable fields (project_uuid, server_uuid, environment_name)

--- a/internal/service/application/data_source_logs_test.go
+++ b/internal/service/application/data_source_logs_test.go
@@ -123,7 +123,7 @@ func TestApplicationLogsDataSource(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/applications/{uuid}/logs", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/logs", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(logs)
 	})

--- a/internal/spectest/client_spec_test.go
+++ b/internal/spectest/client_spec_test.go
@@ -20,8 +20,6 @@ import (
 // bodies use real client input structs for cases where JSON tags do not
 // obviously match the Go field names.
 func TestClientEndpoints_SpecCompliance(t *testing.T) {
-	t.Parallel()
-
 	v, err := newValidator("coolify-v4")
 	if err != nil {
 		t.Fatalf("creating validator: %v", err)

--- a/scripts/upload-social-preview.py
+++ b/scripts/upload-social-preview.py
@@ -30,6 +30,10 @@ def main():
 
     with sync_playwright() as p:
         browser = p.chromium.connect_over_cdp("http://localhost:9222")
+        if not browser.contexts:
+            print("No browser contexts found. Open at least one tab in Chrome and try again.", file=sys.stderr)
+            browser.close()
+            sys.exit(1)
         context = browser.contexts[0]
         page = context.new_page()
         try:


### PR DESCRIPTION
Fix 3 real findings from GitHub AI code quality scanner:

1. **Unused parameter** (`data_source_logs_test.go:126`): `r *http.Request` replaced with `_`
2. **Race-prone t.Parallel** (`client_spec_test.go:23`): removed parent `t.Parallel()` since subtests intentionally skip parallel due to libopenapi-validator internal state racing
3. **Unchecked empty contexts** (`upload-social-preview.py:33`): guard against `browser.contexts` being empty when no Chrome tabs are open

9 remaining findings triaged as false positives:
- Unchecked `json.Encode` in test mocks (errcheck excluded from tests)
- Generic `res`/`model` names (deliberate convention across all 6 database packages)
- Nil validator check (redundant after `t.Fatalf`)
- Playwright `.first` without wait (element already guaranteed rendered)
- JS string fragmentation (cosmetic)
- Template `{ {pr_id} }` spaces (intentional, avoids Go template interpretation)