### PR TITLE
ci: trigger scenario tests on internal/ changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/ci.yml'
             scenarios:
+              - 'internal/**'
               - 'examples/scenarios/**'
               - '.github/workflows/ci.yml'
 

--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -52,10 +52,12 @@ jobs:
             | awk -F: '{s+=$2}END{print s}')
           TESTS=$(python3 -c "print((${RAW_TESTS}//50)*50)")
 
-          echo "resources=$RESOURCES" >> "$GITHUB_OUTPUT"
-          echo "datasources=$DATASOURCES" >> "$GITHUB_OUTPUT"
-          echo "tests=${TESTS}+" >> "$GITHUB_OUTPUT"
-          echo "raw_tests=$RAW_TESTS" >> "$GITHUB_OUTPUT"
+          {
+            echo "resources=$RESOURCES"
+            echo "datasources=$DATASOURCES"
+            echo "tests=${TESTS}+"
+            echo "raw_tests=$RAW_TESTS"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Resources: $RESOURCES"
           echo "Data Sources: $DATASOURCES"


### PR DESCRIPTION
The scenarios path filter only matched `examples/scenarios/` and `ci.yml`. Changes to provider code under `internal/` did not trigger scenario tests, meaning real-API coverage was silently skipped when provider logic changed.

This adds `internal/**` to the scenarios path filter so scenario tests run whenever provider code changes.