### PR TITLE
ci: skip FOSSA on Dependabot PRs

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -19,7 +19,11 @@ jobs:
     name: FOSSA Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name != 'pull_request' || (
+        github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]'
+      )
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Dependabot PRs open from within the same repo, so they pass the existing fork check (`head.repo == repository`). But Dependabot runs cannot access regular repo secrets (only Dependabot secrets), causing FOSSA Analyze to fail with `api-key not supplied`.

This adds an actor check to skip FOSSA on Dependabot PRs. Push-to-main still runs FOSSA (secrets are always available on push events), so license scan coverage is not reduced.