### PR TITLE
test: improve cycle 6 — state-only delete error paths

### DIFF
--- a/internal/service/applicationpreview/resource_test.go
+++ b/internal/service/applicationpreview/resource_test.go
@@ -3,6 +3,7 @@ package applicationpreview_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync/atomic"
 	"testing"
 
@@ -61,4 +62,65 @@ func TestApplicationPreviewResource_DeleteCalled(t *testing.T) {
 	if !deleted.Load() {
 		t.Error("expected DELETE to be called on destroy")
 	}
+}
+
+func TestApplicationPreviewResource_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440042/previews/7", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Preview not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_application_preview", "test", `
+					application_uuid = "550e8400-e29b-41d4-a716-446655440042"
+					pull_request_id  = 7
+				`),
+			},
+			{
+				Config:             acctest.ProviderBlockForURL(srv.URL),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestApplicationPreviewResource_DeleteError(t *testing.T) {
+	t.Parallel()
+	var failDelete atomic.Bool
+	var deleteCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440043/previews/8", func(w http.ResponseWriter, _ *http.Request) {
+		if failDelete.Load() && deleteCalls.Add(1) == 1 {
+			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_application_preview", "test", `
+					application_uuid = "550e8400-e29b-41d4-a716-446655440043"
+					pull_request_id  = 8
+				`),
+			},
+			{
+				PreConfig: func() {
+					failDelete.Store(true)
+				},
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error deleting preview deployment`),
+			},
+		},
+	})
 }

--- a/internal/service/backupexecution/resource_test.go
+++ b/internal/service/backupexecution/resource_test.go
@@ -39,6 +39,69 @@ func TestBackupExecutionResource_Create(t *testing.T) {
 	})
 }
 
+func TestBackupExecutionResource_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440010/backups/550e8400-e29b-41d4-a716-446655440011/executions/550e8400-e29b-41d4-a716-446655440012", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Execution not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_backup_execution", "test", `
+					database_uuid  = "550e8400-e29b-41d4-a716-446655440010"
+					backup_uuid    = "550e8400-e29b-41d4-a716-446655440011"
+					execution_uuid = "550e8400-e29b-41d4-a716-446655440012"
+				`),
+			},
+			{
+				Config:             acctest.ProviderBlockForURL(srv.URL),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestBackupExecutionResource_DeleteError(t *testing.T) {
+	t.Parallel()
+	var failDelete atomic.Bool
+	var deleteCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440013/backups/550e8400-e29b-41d4-a716-446655440014/executions/550e8400-e29b-41d4-a716-446655440015", func(w http.ResponseWriter, _ *http.Request) {
+		if failDelete.Load() && deleteCalls.Add(1) == 1 {
+			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_backup_execution", "test", `
+					database_uuid  = "550e8400-e29b-41d4-a716-446655440013"
+					backup_uuid    = "550e8400-e29b-41d4-a716-446655440014"
+					execution_uuid = "550e8400-e29b-41d4-a716-446655440015"
+				`),
+			},
+			{
+				PreConfig: func() {
+					failDelete.Store(true)
+				},
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error deleting backup execution`),
+			},
+		},
+	})
+}
+
 func TestBackupExecutionResource_DeleteCalled(t *testing.T) {
 	t.Parallel()
 	var deleted atomic.Bool

--- a/internal/service/hetzner/data_source_images.go
+++ b/internal/service/hetzner/data_source_images.go
@@ -1,4 +1,4 @@
-//nolint:dupl // shared hetzner list data source extraction tracked in #11
+//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
 package hetzner
 
 import (

--- a/internal/service/hetzner/data_source_ssh_keys.go
+++ b/internal/service/hetzner/data_source_ssh_keys.go
@@ -1,4 +1,4 @@
-//nolint:dupl // shared hetzner list data source extraction tracked in #11
+//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
 package hetzner
 
 import (


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 6 for the Coolify Terraform provider.

### Changes

- **QA:** Add `DeleteNotFound` and `DeleteError` unit tests for `coolify_application_preview` and `coolify_backup_execution`. These state-only resources had no coverage for 404-tolerant destroy or non-404 API failures.
- **Developer:** Fix stale `//nolint:dupl` comments in hetzner data sources that referenced closed issue #11.

### Deferred (filed as issues)

- #545 — Extract shared hetzner list data source helper
- #544 — Extend delete error-path tests to remaining state-only resources

### Gate work (merged separately)

- #543 — Skip FOSSA on Dependabot PRs (merged to main before this branch)

## Test plan

- [x] `make ci` (green locally)
- [x] Targeted package tests for `applicationpreview` and `backupexecution`