### PR TITLE
test: improve cycle 7 — hetzner helper + destroy test coverage

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,6 +142,44 @@ data "%s" "%s" {
   %s
 }
 `, ProviderBlockForURL(endpoint), dataSourceType, dataSourceName, attrs)
+}
+
+// DeleteOnceFailGate fails the first DELETE request when armed, then succeeds on
+// later calls so post-test destroy cleanup does not false-fail ExpectError steps.
+type DeleteOnceFailGate struct {
+	Armed atomic.Bool
+	Calls atomic.Int32
+}
+
+// Wrap returns a DELETE handler that responds with failStatus/failBody on the
+// first call while armed, and okStatus on subsequent calls.
+func (g *DeleteOnceFailGate) Wrap(okStatus, failStatus int, failBody string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if g.Armed.Load() && g.Calls.Add(1) == 1 {
+			http.Error(w, failBody, failStatus)
+			return
+		}
+		w.WriteHeader(okStatus)
+	}
+}
+
+// DestroyRemoveResourceStep removes all resources from config, triggering destroy.
+func DestroyRemoveResourceStep(serverURL string) resource.TestStep {
+	return resource.TestStep{
+		Config:             ProviderBlockForURL(serverURL),
+		ExpectNonEmptyPlan: false,
+	}
+}
+
+// DestroyExpectErrorStep expects destroy to fail after arming the delete gate.
+func DestroyExpectErrorStep(serverURL string, expectError *regexp.Regexp, gate *DeleteOnceFailGate) resource.TestStep {
+	return resource.TestStep{
+		PreConfig: func() {
+			gate.Armed.Store(true)
+		},
+		Config:      ProviderBlockForURL(serverURL),
+		ExpectError: expectError,
+	}
 }
 
 // CheckResourceDisappears returns a TestCheckFunc that deletes a resource

--- a/internal/acctest/destroy_test.go
+++ b/internal/acctest/destroy_test.go
@@ -1,0 +1,29 @@
+package acctest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDeleteOnceFailGate_Wrap(t *testing.T) {
+	t.Parallel()
+	var gate DeleteOnceFailGate
+	gate.Armed.Store(true)
+
+	handler := gate.Wrap(http.StatusOK, http.StatusInternalServerError, `{"message":"fail"}`)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/test", nil)
+
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("first call: expected 500, got %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	handler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second call: expected 200, got %d", rec.Code)
+	}
+}

--- a/internal/service/apisettings/resource_test.go
+++ b/internal/service/apisettings/resource_test.go
@@ -222,6 +222,45 @@ func TestAPISettingsResource_BothSettings(t *testing.T) {
 // TestAPISettingsResource_CreateAPIError
 // ---------------------------------------------------------------------------
 
+func TestAPISettingsResource_DestroyRestoreWarning(t *testing.T) {
+	t.Parallel()
+	var enableCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/enable", func(w http.ResponseWriter, _ *http.Request) {
+		if enableCalls.Add(1) == 1 {
+			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"API enabled."}`))
+	})
+	mux.HandleFunc("GET /api/v1/disable", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"API disabled."}`))
+	})
+	mux.HandleFunc("POST /api/v1/mcp/disable", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"MCP server disabled."}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_api_settings", "test", `
+					enabled = false
+				`),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if enableCalls.Load() < 1 {
+		t.Fatalf("expected enable API call on destroy restore, got %d", enableCalls.Load())
+	}
+}
+
 func TestAPISettingsResource_CreateAPIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/internal/service/applicationpreview/resource_test.go
+++ b/internal/service/applicationpreview/resource_test.go
@@ -3,6 +3,7 @@ package applicationpreview_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync/atomic"
 	"testing"
 
@@ -61,4 +62,65 @@ func TestApplicationPreviewResource_DeleteCalled(t *testing.T) {
 	if !deleted.Load() {
 		t.Error("expected DELETE to be called on destroy")
 	}
+}
+
+func TestApplicationPreviewResource_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440042/previews/7", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Preview not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_application_preview", "test", `
+					application_uuid = "550e8400-e29b-41d4-a716-446655440042"
+					pull_request_id  = 7
+				`),
+			},
+			{
+				Config:             acctest.ProviderBlockForURL(srv.URL),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestApplicationPreviewResource_DeleteError(t *testing.T) {
+	t.Parallel()
+	var failDelete atomic.Bool
+	var deleteCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440043/previews/8", func(w http.ResponseWriter, _ *http.Request) {
+		if failDelete.Load() && deleteCalls.Add(1) == 1 {
+			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_application_preview", "test", `
+					application_uuid = "550e8400-e29b-41d4-a716-446655440043"
+					pull_request_id  = 8
+				`),
+			},
+			{
+				PreConfig: func() {
+					failDelete.Store(true)
+				},
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error deleting preview deployment`),
+			},
+		},
+	})
 }

--- a/internal/service/applicationpreview/resource_test.go
+++ b/internal/service/applicationpreview/resource_test.go
@@ -82,26 +82,20 @@ func TestApplicationPreviewResource_DeleteNotFound(t *testing.T) {
 					pull_request_id  = 7
 				`),
 			},
-			{
-				Config:             acctest.ProviderBlockForURL(srv.URL),
-				ExpectNonEmptyPlan: false,
-			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
 		},
 	})
 }
 
 func TestApplicationPreviewResource_DeleteError(t *testing.T) {
 	t.Parallel()
-	var failDelete atomic.Bool
-	var deleteCalls atomic.Int32
+	var gate acctest.DeleteOnceFailGate
 	mux := http.NewServeMux()
-	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440043/previews/8", func(w http.ResponseWriter, _ *http.Request) {
-		if failDelete.Load() && deleteCalls.Add(1) == 1 {
-			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	mux.HandleFunc("DELETE /api/v1/applications/550e8400-e29b-41d4-a716-446655440043/previews/8", gate.Wrap(
+		http.StatusOK,
+		http.StatusInternalServerError,
+		`{"message":"internal server error"}`,
+	))
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()
 
@@ -114,13 +108,7 @@ func TestApplicationPreviewResource_DeleteError(t *testing.T) {
 					pull_request_id  = 8
 				`),
 			},
-			{
-				PreConfig: func() {
-					failDelete.Store(true)
-				},
-				Config:      acctest.ProviderBlockForURL(srv.URL),
-				ExpectError: regexp.MustCompile(`Error deleting preview deployment`),
-			},
+			acctest.DestroyExpectErrorStep(srv.URL, regexp.MustCompile(`Error deleting preview deployment`), &gate),
 		},
 	})
 }

--- a/internal/service/backupexecution/resource_test.go
+++ b/internal/service/backupexecution/resource_test.go
@@ -39,6 +39,69 @@ func TestBackupExecutionResource_Create(t *testing.T) {
 	})
 }
 
+func TestBackupExecutionResource_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440010/backups/550e8400-e29b-41d4-a716-446655440011/executions/550e8400-e29b-41d4-a716-446655440012", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Execution not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_backup_execution", "test", `
+					database_uuid  = "550e8400-e29b-41d4-a716-446655440010"
+					backup_uuid    = "550e8400-e29b-41d4-a716-446655440011"
+					execution_uuid = "550e8400-e29b-41d4-a716-446655440012"
+				`),
+			},
+			{
+				Config:             acctest.ProviderBlockForURL(srv.URL),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestBackupExecutionResource_DeleteError(t *testing.T) {
+	t.Parallel()
+	var failDelete atomic.Bool
+	var deleteCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440013/backups/550e8400-e29b-41d4-a716-446655440014/executions/550e8400-e29b-41d4-a716-446655440015", func(w http.ResponseWriter, _ *http.Request) {
+		if failDelete.Load() && deleteCalls.Add(1) == 1 {
+			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_backup_execution", "test", `
+					database_uuid  = "550e8400-e29b-41d4-a716-446655440013"
+					backup_uuid    = "550e8400-e29b-41d4-a716-446655440014"
+					execution_uuid = "550e8400-e29b-41d4-a716-446655440015"
+				`),
+			},
+			{
+				PreConfig: func() {
+					failDelete.Store(true)
+				},
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error deleting backup execution`),
+			},
+		},
+	})
+}
+
 func TestBackupExecutionResource_DeleteCalled(t *testing.T) {
 	t.Parallel()
 	var deleted atomic.Bool

--- a/internal/service/backupexecution/resource_test.go
+++ b/internal/service/backupexecution/resource_test.go
@@ -58,26 +58,20 @@ func TestBackupExecutionResource_DeleteNotFound(t *testing.T) {
 					execution_uuid = "550e8400-e29b-41d4-a716-446655440012"
 				`),
 			},
-			{
-				Config:             acctest.ProviderBlockForURL(srv.URL),
-				ExpectNonEmptyPlan: false,
-			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
 		},
 	})
 }
 
 func TestBackupExecutionResource_DeleteError(t *testing.T) {
 	t.Parallel()
-	var failDelete atomic.Bool
-	var deleteCalls atomic.Int32
+	var gate acctest.DeleteOnceFailGate
 	mux := http.NewServeMux()
-	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440013/backups/550e8400-e29b-41d4-a716-446655440014/executions/550e8400-e29b-41d4-a716-446655440015", func(w http.ResponseWriter, _ *http.Request) {
-		if failDelete.Load() && deleteCalls.Add(1) == 1 {
-			http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	mux.HandleFunc("DELETE /api/v1/databases/550e8400-e29b-41d4-a716-446655440013/backups/550e8400-e29b-41d4-a716-446655440014/executions/550e8400-e29b-41d4-a716-446655440015", gate.Wrap(
+		http.StatusOK,
+		http.StatusInternalServerError,
+		`{"message":"internal server error"}`,
+	))
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()
 
@@ -91,13 +85,7 @@ func TestBackupExecutionResource_DeleteError(t *testing.T) {
 					execution_uuid = "550e8400-e29b-41d4-a716-446655440015"
 				`),
 			},
-			{
-				PreConfig: func() {
-					failDelete.Store(true)
-				},
-				Config:      acctest.ProviderBlockForURL(srv.URL),
-				ExpectError: regexp.MustCompile(`Error deleting backup execution`),
-			},
+			acctest.DestroyExpectErrorStep(srv.URL, regexp.MustCompile(`Error deleting backup execution`), &gate),
 		},
 	})
 }

--- a/internal/service/hetzner/data_source_common.go
+++ b/internal/service/hetzner/data_source_common.go
@@ -1,0 +1,49 @@
+package hetzner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: fmt.Sprintf("The UUID of the cloud provider token to use for listing Hetzner %s.", resourceLabel),
+		Required:            true,
+		Validators:          []validator.String{validate.UUID()},
+	}
+}
+
+func configureHetznerDataSourceClient(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *client.Client {
+	return flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
+}
+
+func readFilteredTokenList[T any](
+	ctx context.Context,
+	tokenUUID string,
+	filters []filter.Config,
+	dataSourceType string,
+	listErrorSummary string,
+	resp *datasource.ReadResponse,
+	c *client.Client,
+	listFn func(context.Context, string) ([]T, error),
+	accessor func(T, string) (string, bool),
+) ([]T, bool) {
+	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": dataSourceType})
+
+	items, err := listFn(ctx, tokenUUID)
+	if err != nil {
+		resp.Diagnostics.AddError(listErrorSummary, err.Error())
+		return nil, false
+	}
+
+	return filter.Apply(ctx, items, filters, accessor), true
+}

--- a/internal/service/hetzner/data_source_images.go
+++ b/internal/service/hetzner/data_source_images.go
@@ -1,4 +1,4 @@
-//nolint:dupl // shared hetzner list data source extraction tracked in #11
+//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
 package hetzner
 
 import (

--- a/internal/service/hetzner/data_source_images.go
+++ b/internal/service/hetzner/data_source_images.go
@@ -1,4 +1,4 @@
-//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
+//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
 package hetzner
 
 import (
@@ -6,13 +6,9 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -47,11 +43,7 @@ func (d *imagesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Lists all available Hetzner cloud images for a given cloud provider token.",
 		Attributes: map[string]schema.Attribute{
-			"cloud_provider_token_uuid": schema.StringAttribute{
-				MarkdownDescription: "The UUID of the cloud provider token to use for listing Hetzner images.",
-				Required:            true,
-				Validators:          []validator.String{validate.UUID()},
-			},
+			"cloud_provider_token_uuid": cloudProviderTokenUUIDAttribute("images"),
 			"images": schema.ListNestedAttribute{
 				MarkdownDescription: "The list of Hetzner images.",
 				Computed:            true,
@@ -71,7 +63,7 @@ func (d *imagesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 }
 
 func (d *imagesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	d.client = flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
+	d.client = configureHetznerDataSourceClient(req, resp)
 }
 
 func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -81,26 +73,31 @@ func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_hetzner_images"})
-
-	images, err := d.client.ListHetznerImages(ctx, config.CloudProviderTokenUUID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error listing Hetzner images", err.Error())
+	images, ok := readFilteredTokenList(
+		ctx,
+		config.CloudProviderTokenUUID.ValueString(),
+		config.Filters,
+		"coolify_hetzner_images",
+		"Error listing Hetzner images",
+		resp,
+		d.client,
+		d.client.ListHetznerImages,
+		func(img client.HetznerImage, field string) (string, bool) {
+			switch field {
+			case "id":
+				return filter.Int64ToString(img.ID), true
+			case "name":
+				return img.Name, true
+			case "description":
+				return img.Description, true
+			default:
+				return "", false
+			}
+		},
+	)
+	if !ok {
 		return
 	}
-
-	images = filter.Apply(ctx, images, config.Filters, func(img client.HetznerImage, field string) (string, bool) {
-		switch field {
-		case "id":
-			return filter.Int64ToString(img.ID), true
-		case "name":
-			return img.Name, true
-		case "description":
-			return img.Description, true
-		default:
-			return "", false
-		}
-	})
 
 	state := imagesDataSourceModel{
 		CloudProviderTokenUUID: config.CloudProviderTokenUUID,

--- a/internal/service/hetzner/data_source_locations.go
+++ b/internal/service/hetzner/data_source_locations.go
@@ -5,13 +5,9 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -48,11 +44,7 @@ func (d *locationsDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Lists all available Hetzner datacenter locations for a given cloud provider token.",
 		Attributes: map[string]schema.Attribute{
-			"cloud_provider_token_uuid": schema.StringAttribute{
-				MarkdownDescription: "The UUID of the cloud provider token to use for listing Hetzner locations.",
-				Required:            true,
-				Validators:          []validator.String{validate.UUID()},
-			},
+			"cloud_provider_token_uuid": cloudProviderTokenUUIDAttribute("locations"),
 			"locations": schema.ListNestedAttribute{
 				MarkdownDescription: "The list of Hetzner locations.",
 				Computed:            true,
@@ -74,7 +66,7 @@ func (d *locationsDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 }
 
 func (d *locationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	d.client = flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
+	d.client = configureHetznerDataSourceClient(req, resp)
 }
 
 func (d *locationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -84,30 +76,35 @@ func (d *locationsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_hetzner_locations"})
-
-	locations, err := d.client.ListHetznerLocations(ctx, config.CloudProviderTokenUUID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error listing Hetzner locations", err.Error())
+	locations, ok := readFilteredTokenList(
+		ctx,
+		config.CloudProviderTokenUUID.ValueString(),
+		config.Filters,
+		"coolify_hetzner_locations",
+		"Error listing Hetzner locations",
+		resp,
+		d.client,
+		d.client.ListHetznerLocations,
+		func(loc client.HetznerLocation, field string) (string, bool) {
+			switch field {
+			case "id":
+				return filter.Int64ToString(loc.ID), true
+			case "name":
+				return loc.Name, true
+			case "description":
+				return loc.Description, true
+			case "city":
+				return loc.City, true
+			case "country":
+				return loc.Country, true
+			default:
+				return "", false
+			}
+		},
+	)
+	if !ok {
 		return
 	}
-
-	locations = filter.Apply(ctx, locations, config.Filters, func(loc client.HetznerLocation, field string) (string, bool) {
-		switch field {
-		case "id":
-			return filter.Int64ToString(loc.ID), true
-		case "name":
-			return loc.Name, true
-		case "description":
-			return loc.Description, true
-		case "city":
-			return loc.City, true
-		case "country":
-			return loc.Country, true
-		default:
-			return "", false
-		}
-	})
 
 	state := locationsDataSourceModel{
 		CloudProviderTokenUUID: config.CloudProviderTokenUUID,

--- a/internal/service/hetzner/data_source_server_types.go
+++ b/internal/service/hetzner/data_source_server_types.go
@@ -5,13 +5,9 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -49,11 +45,7 @@ func (d *serverTypesDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Lists all available Hetzner server types for a given cloud provider token.",
 		Attributes: map[string]schema.Attribute{
-			"cloud_provider_token_uuid": schema.StringAttribute{
-				MarkdownDescription: "The UUID of the cloud provider token to use for listing Hetzner server types.",
-				Required:            true,
-				Validators:          []validator.String{validate.UUID()},
-			},
+			"cloud_provider_token_uuid": cloudProviderTokenUUIDAttribute("server types"),
 			"server_types": schema.ListNestedAttribute{
 				MarkdownDescription: "The list of Hetzner server types.",
 				Computed:            true,
@@ -76,7 +68,7 @@ func (d *serverTypesDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 }
 
 func (d *serverTypesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	d.client = flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
+	d.client = configureHetznerDataSourceClient(req, resp)
 }
 
 func (d *serverTypesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -86,32 +78,37 @@ func (d *serverTypesDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_hetzner_server_types"})
-
-	serverTypes, err := d.client.ListHetznerServerTypes(ctx, config.CloudProviderTokenUUID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error listing Hetzner server types", err.Error())
+	serverTypes, ok := readFilteredTokenList(
+		ctx,
+		config.CloudProviderTokenUUID.ValueString(),
+		config.Filters,
+		"coolify_hetzner_server_types",
+		"Error listing Hetzner server types",
+		resp,
+		d.client,
+		d.client.ListHetznerServerTypes,
+		func(st client.HetznerServerType, field string) (string, bool) {
+			switch field {
+			case "id":
+				return filter.Int64ToString(st.ID), true
+			case "name":
+				return st.Name, true
+			case "description":
+				return st.Description, true
+			case "cores":
+				return filter.Int64ToString(st.Cores), true
+			case "memory":
+				return filter.Int64ToString(st.Memory), true
+			case "disk":
+				return filter.Int64ToString(st.Disk), true
+			default:
+				return "", false
+			}
+		},
+	)
+	if !ok {
 		return
 	}
-
-	serverTypes = filter.Apply(ctx, serverTypes, config.Filters, func(st client.HetznerServerType, field string) (string, bool) {
-		switch field {
-		case "id":
-			return filter.Int64ToString(st.ID), true
-		case "name":
-			return st.Name, true
-		case "description":
-			return st.Description, true
-		case "cores":
-			return filter.Int64ToString(st.Cores), true
-		case "memory":
-			return filter.Int64ToString(st.Memory), true
-		case "disk":
-			return filter.Int64ToString(st.Disk), true
-		default:
-			return "", false
-		}
-	})
 
 	state := serverTypesDataSourceModel{
 		CloudProviderTokenUUID: config.CloudProviderTokenUUID,

--- a/internal/service/hetzner/data_source_ssh_keys.go
+++ b/internal/service/hetzner/data_source_ssh_keys.go
@@ -1,4 +1,4 @@
-//nolint:dupl // shared hetzner list data source extraction tracked in #11
+//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
 package hetzner
 
 import (

--- a/internal/service/hetzner/data_source_ssh_keys.go
+++ b/internal/service/hetzner/data_source_ssh_keys.go
@@ -1,4 +1,4 @@
-//nolint:dupl // hetzner list data sources share token+filter+read pattern; extraction deferred
+//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
 package hetzner
 
 import (
@@ -6,13 +6,9 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -47,11 +43,7 @@ func (d *sshKeysDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Lists all available Hetzner SSH keys for a given cloud provider token.",
 		Attributes: map[string]schema.Attribute{
-			"cloud_provider_token_uuid": schema.StringAttribute{
-				MarkdownDescription: "The UUID of the cloud provider token to use for listing Hetzner SSH keys.",
-				Required:            true,
-				Validators:          []validator.String{validate.UUID()},
-			},
+			"cloud_provider_token_uuid": cloudProviderTokenUUIDAttribute("SSH keys"),
 			"ssh_keys": schema.ListNestedAttribute{
 				MarkdownDescription: "The list of Hetzner SSH keys.",
 				Computed:            true,
@@ -71,7 +63,7 @@ func (d *sshKeysDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 }
 
 func (d *sshKeysDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	d.client = flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
+	d.client = configureHetznerDataSourceClient(req, resp)
 }
 
 func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -81,26 +73,31 @@ func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_hetzner_ssh_keys"})
-
-	keys, err := d.client.ListHetznerSSHKeys(ctx, config.CloudProviderTokenUUID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error listing Hetzner SSH keys", err.Error())
+	keys, ok := readFilteredTokenList(
+		ctx,
+		config.CloudProviderTokenUUID.ValueString(),
+		config.Filters,
+		"coolify_hetzner_ssh_keys",
+		"Error listing Hetzner SSH keys",
+		resp,
+		d.client,
+		d.client.ListHetznerSSHKeys,
+		func(k client.HetznerSSHKey, field string) (string, bool) {
+			switch field {
+			case "id":
+				return filter.Int64ToString(k.ID), true
+			case "name":
+				return k.Name, true
+			case "fingerprint":
+				return k.Fingerprint, true
+			default:
+				return "", false
+			}
+		},
+	)
+	if !ok {
 		return
 	}
-
-	keys = filter.Apply(ctx, keys, config.Filters, func(k client.HetznerSSHKey, field string) (string, bool) {
-		switch field {
-		case "id":
-			return filter.Int64ToString(k.ID), true
-		case "name":
-			return k.Name, true
-		case "fingerprint":
-			return k.Fingerprint, true
-		default:
-			return "", false
-		}
-	})
 
 	state := sshKeysDataSourceModel{
 		CloudProviderTokenUUID: config.CloudProviderTokenUUID,

--- a/internal/service/resourceaction/resource_test.go
+++ b/internal/service/resourceaction/resource_test.go
@@ -12,6 +12,43 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestResourceActionResource_DestroyNoOp(t *testing.T) {
+	t.Parallel()
+	dbUUID := "aaaa0005-0005-4000-8000-000000000005"
+	var actionCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/databases/{uuid}/start", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != dbUUID {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		actionCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"message":"Database starting request queued."}`)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_resource_action", "test", fmt.Sprintf(`
+					resource_uuid = %q
+					resource_type = "database"
+					action        = "start"
+				`, dbUUID)),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if actionCalls.Load() != 1 {
+		t.Fatalf("expected action only on create, got %d calls", actionCalls.Load())
+	}
+}
+
 func TestResourceActionResource_StartDatabase(t *testing.T) {
 	t.Parallel()
 	dbUUID := "aaaa0001-0001-4000-8000-000000000001"

--- a/internal/service/servervalidate/resource_test.go
+++ b/internal/service/servervalidate/resource_test.go
@@ -94,3 +94,30 @@ func TestServerValidateResource_Triggers(t *testing.T) {
 		t.Errorf("expected at least 2 validation calls, got %d", callCount.Load())
 	}
 }
+
+func TestServerValidateResource_DestroyNoOp(t *testing.T) {
+	t.Parallel()
+	var validateCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/servers/550e8400-e29b-41d4-a716-446655440023/validate", func(w http.ResponseWriter, _ *http.Request) {
+		validateCalls.Add(1)
+		_, _ = w.Write([]byte(`{"valid":true,"message":"OK"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_server_validate", "test", `
+					server_uuid = "550e8400-e29b-41d4-a716-446655440023"
+				`),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if validateCalls.Load() != 1 {
+		t.Fatalf("expected validation only on create, got %d calls", validateCalls.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Cycle 7 implements #544 and #545 on top of cycle 6 (state-only delete error-path tests).

### Fixes #545 — Hetzner list data source helper

- Add `internal/service/hetzner/data_source_common.go` with shared `readFilteredTokenList`, token UUID schema helper, and client configure wrapper
- Refactor all four Hetzner token-scoped list data sources (images, SSH keys, locations, server types) to use it

### Fixes #544 — Destroy test coverage

- Add `acctest.DeleteOnceFailGate`, `DestroyRemoveResourceStep`, and `DestroyExpectErrorStep`
- Refactor `application_preview` and `backup_execution` delete tests to use shared helpers
- Add destroy tests for `api_settings` (restore warning on failed re-enable), `server_validate` and `resource_action` (no-op destroy)

Closes #544
Closes #545

## Test plan

- [x] `make ci` (green locally)
- [x] Targeted package tests for all changed packages