### PR TITLE
test: close audit gaps — destroy no-op coverage and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 dist/
 bin/
 terraform-provider-coolify

--- a/internal/service/cloudtokenvalidate/resource_test.go
+++ b/internal/service/cloudtokenvalidate/resource_test.go
@@ -90,3 +90,31 @@ func TestCloudTokenValidateResource_Triggers(t *testing.T) {
 		t.Errorf("expected at least 2 validation calls, got %d", callCount.Load())
 	}
 }
+
+func TestCloudTokenValidateResource_DestroyNoOp(t *testing.T) {
+	t.Parallel()
+	var validateCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/cloud-tokens/550e8400-e29b-41d4-a716-446655440033/validate", func(w http.ResponseWriter, _ *http.Request) {
+		validateCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"OK"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_cloud_token_validate", "test", `
+					cloud_token_uuid = "550e8400-e29b-41d4-a716-446655440033"
+				`),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if validateCalls.Load() != 1 {
+		t.Fatalf("expected validation only on create, got %d calls", validateCalls.Load())
+	}
+}

--- a/internal/service/deployment/resource_test.go
+++ b/internal/service/deployment/resource_test.go
@@ -876,6 +876,58 @@ resource "coolify_deployment" "test" {
 // TestDeploymentResource_CreateAPIError
 // ---------------------------------------------------------------------------
 
+func TestDeploymentResource_DestroyNoOp(t *testing.T) {
+	t.Parallel()
+	deploymentUUID := "destroy-nop-0001-4000-8000-000000000001"
+	appUUID := "cccc0008-0008-4000-8000-000000000008"
+	var restartCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
+		if !requireRestartApplicationUUID(w, r, appUUID) {
+			return
+		}
+		restartCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"deployment_uuid": deploymentUUID,
+			"message":         "Restart request queued.",
+		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"deployment_uuid": r.PathValue("uuid"),
+			"status":          "queued",
+		})
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+resource "coolify_deployment" "test" {
+  application_uuid = %q
+}
+`, srv.URL, appUUID),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if restartCalls.Load() != 1 {
+		t.Fatalf("expected restart only on create, got %d calls", restartCalls.Load())
+	}
+}
+
 func TestDeploymentResource_CreateAPIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/internal/service/envsbulk/resource_test.go
+++ b/internal/service/envsbulk/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync/atomic"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
@@ -419,6 +420,40 @@ func TestEnvsBulkResource_ImportBadUUID(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestEnvsBulkResource_DestroyNoOp(t *testing.T) {
+	t.Parallel()
+	var patchCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /api/v1/applications/550e8400-e29b-41d4-a716-446655440014/envs/bulk", func(w http.ResponseWriter, _ *http.Request) {
+		patchCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /api/v1/applications/550e8400-e29b-41d4-a716-446655440014/envs", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"uuid":"u-APP_ENV","key":"APP_ENV","value":"production","is_preview":false,"is_buildtime":false}]`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_envs_bulk", "test", `
+					resource_type = "application"
+					resource_uuid = "550e8400-e29b-41d4-a716-446655440014"
+					variables = {
+						APP_ENV = "production"
+					}
+				`),
+			},
+			acctest.DestroyRemoveResourceStep(srv.URL),
+		},
+	})
+	if patchCalls.Load() != 1 {
+		t.Fatalf("expected bulk update only on create, got %d calls", patchCalls.Load())
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes remaining items from the multi-perspective audit follow-up:

- **DestroyNoOp tests** for `cloud_token_validate`, `deployment`, and `envsbulk` (completing the #544 pattern for all noop-delete resources)
- **`.DS_Store` in `.gitignore`** to stop macOS metadata showing up as untracked files
- **Issue #475** body updated locally (880+ → 950+ test count)
- **Git stash dropped** — the `chore/auto-update-social-preview` stash was dead; main already has `release: published` trigger via #533

## Not changed

- Hetzner `//nolint:dupl` on images/ssh_keys — still required; schema boilerplate triggers dupl even after #545 helper extraction
- Release PR #528 — left for separate approval

## Verification

- `make ci` green (968 tests)