### PR TITLE
fix: database health_check 422 on Coolify < v4.1.2, bump min version to 4.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ mismatches, and zero validation rules when we compared it against the source.
 - API coverage doc: `make api-coverage`
 - Extract contract from Coolify source: `make contract-extract VERSION=v4.1.2`
 - Verify client structs cover contract: `make contract-check`
+- Cross-version endpoint field compatibility: `make contract-compat`
 - Regenerate OpenAPI spec from contract: `make spec-generate`
 - Scaffold a new resource: `make scaffold NAME=myresource`
 - Merge a PR (sole maintainer): `make merge PR=123`
@@ -149,6 +150,30 @@ Coolify controller source. If `GET` does not include the field in its response
 builder, it falls into one of these patterns. Use the matching schema
 configuration and flatten handling to avoid "inconsistent result after apply"
 errors and import failures.
+
+#### Version-aware field additions
+
+Not all Coolify API versions accept the same fields. Before adding a new field
+to the provider schema, check the endpoint's `$allowedFields` across all
+supported contract versions (`testdata/contracts/coolify-v4.*.json`):
+
+```bash
+make contract-compat
+```
+
+If a field is not in `$allowedFields` for all supported versions:
+
+1. **Never use `Default`** for that field. `Default` creates a diff after import
+   on older Coolify versions (state is null, Default fills the plan, update sends
+   the field, API rejects with 422). Use `UseStateForUnknown()` instead.
+2. **Document the minimum Coolify version** in the attribute's
+   `MarkdownDescription` (e.g., `"Requires Coolify >= v4.1.2."`).
+3. **The `*IfChanged` helpers protect normal updates** (`flex.BoolIfChanged`,
+   `flex.Int64IfChanged`): if the user doesn't change the value, it won't be
+   sent. The risk is only on import (null state) and on create's post-create PATCH.
+
+This rule was added after issue #549, where health_check fields used `Default`
+values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 
 ### Client
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -85,6 +85,9 @@ contract-extract: check-python3 ## Extract contract from Coolify source (usage: 
 contract-check: ## Verify client structs cover all contract fields
 	go test -race -count=1 -run 'TestContractCoverage' ./internal/spectest/ -v
 
+contract-compat: check-python3 ## Check endpoint field compatibility across Coolify versions
+	python3 scripts/check-contract-compat.py --ci
+
 contract-matrix: check-python3 ## Generate API contract accuracy matrix page
 	python3 scripts/generate-contract-matrix.py
 
@@ -103,7 +106,7 @@ test-import-gen: ## Test terraform plan -generate-config-out compatibility (need
 scaffold: ## Scaffold a new resource (usage: make scaffold NAME=webhook)
 	@./scripts/new-resource.sh $(NAME)
 
-ci: build lint test validate actionlint-check python-test docs-check api-coverage-check counts-check vulncheck goreleaser-check modverify ## Run all checks (CI also runs trivy + gitleaks security scans)
+ci: build lint test validate actionlint-check python-test docs-check api-coverage-check counts-check contract-compat vulncheck goreleaser-check modverify ## Run all checks (CI also runs trivy + gitleaks security scans)
 
 modverify: ## Verify module cache integrity against go.sum
 	go mod verify
@@ -222,4 +225,4 @@ merge: ## Merge a PR as sole maintainer (usage: make merge PR=123)
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build test testacc acc-bootstrap acc-preflight check-pkg test-pkg testacc-pkg lint fmt docs docs-check api-coverage-check counts-check validate python-test install spec-update spec-check spec-generate api-coverage contract-extract contract-check contract-matrix vulncheck check-golangci-lint-version check-goreleaser-version check-python3 check-actionlint-version check-tfplugindocs actionlint-check goreleaser-check modverify ci scaffold test-import-gen tools merge help
+.PHONY: build test testacc acc-bootstrap acc-preflight check-pkg test-pkg testacc-pkg lint fmt docs docs-check api-coverage-check counts-check validate python-test install spec-update spec-check spec-generate api-coverage contract-extract contract-check contract-compat contract-matrix vulncheck check-golangci-lint-version check-goreleaser-version check-python3 check-actionlint-version check-tfplugindocs actionlint-check goreleaser-check modverify ci scaffold test-import-gen tools merge help

--- a/docs/guides/day-two-operations.md
+++ b/docs/guides/day-two-operations.md
@@ -25,7 +25,7 @@ the API may gain new fields, endpoints, or changed defaults.
   it only works if your Coolify instance is v4.1+.
 - **The provider validates the Coolify version.** On every `plan` and
   `apply`, the provider checks `/api/v1/version`. If the version is
-  below v4.0.0, it refuses to continue.
+  below v4.1.0, it refuses to continue.
 
 ### Before upgrading
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -71,22 +71,24 @@ provider "coolify" {
 ## Version requirements
 
 The provider validates the Coolify version on `terraform plan` /
-`terraform apply`. If your instance is older than **v4.0.0**, the provider
+`terraform apply`. If your instance is older than **v4.1.0**, the provider
 will return an error and refuse to continue. Upgrade your Coolify instance
 before using the provider.
 
 ### Version compatibility matrix
 
 The provider tracks the latest Coolify v4 release. Older Coolify versions
-work for core resources, but newer features require a recent version.
+may work for basic resources, but the API surface changed significantly
+between v4.0.0 and v4.1.0 (69 application fields were added), so v4.1.0
+is the minimum supported version.
 
 | Provider Version | Min Coolify | Key Features |
 |-----------------|-------------|--------------|
-| 0.1.x | 4.0.0 | Core resources: projects, servers, applications, environments |
-| 0.2.x | 4.0.0 | Databases (8 types), services, environment variables, private keys |
-| 0.3.x | 4.0.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
-| 0.4.x | 4.0.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
-| 0.5.x | 4.0.0 | Server `connection_timeout`, `railpack` build pack (requires Coolify 4.1.0+), versioned API contracts |
+| 0.1.x | 4.1.0 | Core resources: projects, servers, applications, environments |
+| 0.2.x | 4.1.0 | Databases (8 types), services, environment variables, private keys |
+| 0.3.x | 4.1.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
+| 0.4.x | 4.1.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
+| 0.5.x | 4.1.0 | Server `connection_timeout`, `railpack` build pack, versioned API contracts |
 
 -> **Tip:** Run `data "coolify_version" "current" {}` to check your
 instance version programmatically.

--- a/docs/guides/scenario-testing.md
+++ b/docs/guides/scenario-testing.md
@@ -177,7 +177,7 @@ Verify it works:
 
 ```bash
 curl -s http://localhost:8000/api/v1/version -H "Authorization: Bearer $COOLIFY_TOKEN"
-# Should print: 4.0.0
+# Should print a version >= 4.1.0
 ```
 
 ## Step 4: Register a Server

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -33,7 +33,7 @@ func WithVersionEndpoint(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/version" {
 			w.Header().Set("Content-Type", "text/html")
-			_, _ = w.Write([]byte(`v4.0.0-test`))
+			_, _ = w.Write([]byte(`v4.1.0-test`))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -15,7 +15,7 @@ func TestAccTestServerUUID_UsesVisibleOverride(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "v4.0.0-test"})
+		json.NewEncoder(w).Encode(map[string]string{"version": "v4.1.0-test"})
 	})
 	mux.HandleFunc("GET /api/v1/servers", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -43,7 +43,7 @@ func TestAccTestServerUUID_FallsBackToFirstVisibleServer(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "v4.0.0-test"})
+		json.NewEncoder(w).Encode(map[string]string{"version": "v4.1.0-test"})
 	})
 	mux.HandleFunc("GET /api/v1/servers", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -72,7 +72,7 @@ func TestAccTestServerUUID_SkipsWhenOverrideIsNotVisible(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"version": "v4.0.0-test"})
+		json.NewEncoder(w).Encode(map[string]string{"version": "v4.1.0-test"})
 	})
 	mux.HandleFunc("GET /api/v1/servers", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-const minCoolifyVersion = "4.0.0"
+const minCoolifyVersion = "4.1.0"
 
 var _ provider.Provider = (*coolifyProvider)(nil)
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -142,7 +142,7 @@ func TestProvider_EnvVarPrecedence(t *testing.T) {
 	// The provider block endpoint (mock server) overrides the env var.
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("v4.0.0"))
+		_, _ = w.Write([]byte("v4.1.0"))
 	})
 	mux.HandleFunc("GET /api/v1/teams/0", func(w http.ResponseWriter, r *http.Request) {
 		// Verify the config-block token overrides the env var.
@@ -194,7 +194,7 @@ func TestProvider_CloudflareAccessHeaders(t *testing.T) {
 			http.Error(w, "missing CF headers", http.StatusForbidden)
 			return
 		}
-		_, _ = w.Write([]byte("v4.0.0"))
+		_, _ = w.Write([]byte("v4.1.0"))
 	})
 	mux.HandleFunc("GET /api/v1/teams/0", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -348,7 +348,7 @@ func TestProvider_EnvVarFallback(t *testing.T) {
 	// Configure everything via env vars only (no provider block attributes).
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("v4.0.0"))
+		_, _ = w.Write([]byte("v4.1.0"))
 	})
 	mux.HandleFunc("GET /api/v1/teams/0", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/service/database/common.go
+++ b/internal/service/database/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -153,11 +154,11 @@ func CommonDatabaseAttrs(ctx context.Context, extra map[string]schema.Attribute)
 		"public_port_timeout":       schema.Int64Attribute{MarkdownDescription: "Timeout in seconds for public port allocation.", Optional: true},
 		"is_log_drain_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, sends container logs to the configured log drain. Defaults to `false`.", Optional: true, Computed: true, Default: booldefault.StaticBool(false)},
 		"is_include_timestamps":     IsIncludeTimestampsAttr(),
-		"health_check_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, enables the Docker health check probe for this database container. Defaults to `true`.", Optional: true, Computed: true, Default: booldefault.StaticBool(true)},
-		"health_check_interval":     schema.Int64Attribute{MarkdownDescription: "Health check interval in seconds. Minimum `1`. Defaults to `15`.", Optional: true, Computed: true, Default: int64default.StaticInt64(15), Validators: []validator.Int64{int64validator.AtLeast(1)}},
-		"health_check_timeout":      schema.Int64Attribute{MarkdownDescription: "Health check timeout in seconds. Minimum `1`. Defaults to `5`.", Optional: true, Computed: true, Default: int64default.StaticInt64(5), Validators: []validator.Int64{int64validator.AtLeast(1)}},
-		"health_check_retries":      schema.Int64Attribute{MarkdownDescription: "Number of consecutive health check failures before the container is considered unhealthy. Minimum `1`. Defaults to `5`.", Optional: true, Computed: true, Default: int64default.StaticInt64(5), Validators: []validator.Int64{int64validator.AtLeast(1)}},
-		"health_check_start_period": schema.Int64Attribute{MarkdownDescription: "Grace period in seconds before health checks start counting failures after container start. Minimum `0`. Defaults to `5`.", Optional: true, Computed: true, Default: int64default.StaticInt64(5), Validators: []validator.Int64{int64validator.AtLeast(0)}},
+		"health_check_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, enables the Docker health check probe for this database container. Defaults to `true`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
+		"health_check_interval":     schema.Int64Attribute{MarkdownDescription: "Health check interval in seconds. Minimum `1`. Defaults to `15`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(1)}},
+		"health_check_timeout":      schema.Int64Attribute{MarkdownDescription: "Health check timeout in seconds. Minimum `1`. Defaults to `5`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(1)}},
+		"health_check_retries":      schema.Int64Attribute{MarkdownDescription: "Number of consecutive health check failures before the container is considered unhealthy. Minimum `1`. Defaults to `5`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(1)}},
+		"health_check_start_period": schema.Int64Attribute{MarkdownDescription: "Grace period in seconds before health checks start counting failures after container start. Minimum `0`. Defaults to `5`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(0)}},
 		"status":                    schema.StringAttribute{MarkdownDescription: "The current status of the database (e.g., `running`, `exited`).", Computed: true},
 		"internal_db_url":           schema.StringAttribute{MarkdownDescription: "Internal connection URL for the database, accessible from other containers on the same server. Contains credentials; requires an API token with sensitive-data read permission.", Computed: true, Sensitive: true},
 		"instant_deploy":            schema.BoolAttribute{MarkdownDescription: "Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.", Optional: true, Computed: true, Default: booldefault.StaticBool(false)},

--- a/internal/service/version/data_source_test.go
+++ b/internal/service/version/data_source_test.go
@@ -20,7 +20,7 @@ func TestVersionDataSource_ClientError(t *testing.T) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/version" {
 			if calls.Add(1) == 1 {
 				w.Header().Set("Content-Type", "text/html")
-				w.Write([]byte("v4.0.0"))
+				w.Write([]byte("v4.1.0"))
 				return
 			}
 			http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -48,7 +48,7 @@ func TestVersionDataSource(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/version" {
 			w.Header().Set("Content-Type", "text/html")
-			w.Write([]byte(`v4.0.0-beta.362`))
+			w.Write([]byte(`v4.1.0-beta.362`))
 			return
 		}
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
@@ -63,7 +63,7 @@ func TestVersionDataSource(t *testing.T) {
 data "coolify_version" "test" {}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.coolify_version.test", "version", "v4.0.0-beta.362"),
+					resource.TestCheckResourceAttr("data.coolify_version.test", "version", "v4.1.0-beta.362"),
 				),
 			},
 		},

--- a/internal/spectest/client_spec_test.go
+++ b/internal/spectest/client_spec_test.go
@@ -409,7 +409,7 @@ func TestClientEndpoints_SpecCompliance(t *testing.T) {
 			// Version endpoint.
 			mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/html")
-				w.Write([]byte("v4.0.0"))
+				w.Write([]byte("v4.1.0"))
 			})
 
 			srv := httptest.NewServer(withSpecValidation(t, "coolify-v4", mux, false, v))

--- a/internal/spectest/spec_test.go
+++ b/internal/spectest/spec_test.go
@@ -28,7 +28,7 @@ func TestValidatingHandler_ProjectCreate(t *testing.T) {
 	})
 	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`v4.0.0`))
+		w.Write([]byte(`v4.1.0`))
 	})
 
 	srv := httptest.NewServer(WithSpecValidation(t, "coolify-v4", mux))

--- a/scripts/check-contract-compat.py
+++ b/scripts/check-contract-compat.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Check endpoint field compatibility across Coolify contract versions.
+
+Compares the allowed_fields in each endpoint across all versioned contract
+files (testdata/contracts/coolify-v4.*.json, excluding coolify-v4.json and
+coolify-v4-latest.json which are aliases). Reports fields that exist in some
+versions but not others, helping identify version-dependent features that
+need UseStateForUnknown() instead of Default in the provider schema.
+
+Usage:
+    python3 scripts/check-contract-compat.py [--ci] [--all]
+
+With --ci, exits non-zero if any version-dependent fields are found that
+are not listed in the known exceptions file. Without --ci, prints a report
+only.
+
+With --all, compares across all contract versions. Without --all (default),
+only compares the two most recent versions, which is the useful check for
+catching regressions between adjacent releases.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTRACTS_DIR = ROOT / "testdata" / "contracts"
+
+# Fields we know are version-dependent and have been handled correctly
+# in the provider (UseStateForUnknown, documented minimum version, etc.).
+# Add entries here when a field is intentionally version-dependent.
+KNOWN_VERSION_DEPENDENT: dict[str, set[str]] = {
+    "DatabasesController::update_by_uuid": {
+        "health_check_enabled",
+        "health_check_interval",
+        "health_check_timeout",
+        "health_check_retries",
+        "health_check_start_period",
+    },
+}
+
+
+def _parse_version(name: str) -> tuple[int, ...]:
+    """Extract a sortable version tuple from a filename like coolify-v4.1.2."""
+    m = re.search(r"v(\d+(?:\.\d+)*)", name)
+    if not m:
+        return (0,)
+    return tuple(int(x) for x in m.group(1).split("."))
+
+
+def load_contracts() -> dict[str, dict]:
+    """Load all versioned contract files, excluding aliases."""
+    contracts = {}
+    for path in sorted(CONTRACTS_DIR.glob("coolify-v4*.json")):
+        # Skip the unversioned alias and the latest alias
+        if path.name in ("coolify-v4.json", "coolify-v4-latest.json"):
+            continue
+        contracts[path.stem] = json.loads(path.read_text())
+    return dict(sorted(contracts.items(), key=lambda kv: _parse_version(kv[0])))
+
+
+def compare_endpoints(contracts: dict[str, dict]) -> list[dict]:
+    """Compare allowed_fields across versions for each endpoint."""
+    # Collect all endpoints across all versions
+    all_endpoints: set[str] = set()
+    for data in contracts.values():
+        all_endpoints.update(data.get("endpoints", {}).keys())
+
+    results = []
+    for endpoint in sorted(all_endpoints):
+        # Gather fields per version
+        version_fields: dict[str, set[str]] = {}
+        for version, data in contracts.items():
+            ep = data.get("endpoints", {}).get(endpoint)
+            if ep is not None:
+                version_fields[version] = set(ep.get("allowed_fields", []))
+
+        if len(version_fields) < 2:
+            continue
+
+        # Find the union and intersection
+        all_fields = set().union(*version_fields.values())
+        common_fields = set.intersection(*version_fields.values())
+        version_dependent = all_fields - common_fields
+
+        if version_dependent:
+            # For each version-dependent field, find which versions have it
+            field_details = []
+            for field in sorted(version_dependent):
+                present_in = sorted(
+                    [v for v, fields in version_fields.items() if field in fields],
+                    key=_parse_version,
+                )
+                absent_from = sorted(
+                    [v for v, fields in version_fields.items() if field not in fields],
+                    key=_parse_version,
+                )
+                field_details.append({
+                    "field": field,
+                    "present_in": present_in,
+                    "absent_from": absent_from,
+                    "min_version": present_in[0] if present_in else "unknown",
+                })
+
+            results.append({
+                "endpoint": endpoint,
+                "total_fields": len(all_fields),
+                "common_fields": len(common_fields),
+                "version_dependent": field_details,
+            })
+
+    return results
+
+
+def main():
+    ci_mode = "--ci" in sys.argv
+    all_mode = "--all" in sys.argv
+
+    contracts = load_contracts()
+    if not all_mode and len(contracts) > 2:
+        # Keep only the two most recent versions
+        keys = list(contracts.keys())
+        contracts = {k: contracts[k] for k in keys[-2:]}
+    if len(contracts) < 2:
+        print("Need at least 2 versioned contracts to compare.")
+        print(f"Found: {list(contracts.keys())}")
+        sys.exit(0)
+
+    print(f"Comparing {len(contracts)} contract versions: {', '.join(contracts.keys())}")
+    print()
+
+    results = compare_endpoints(contracts)
+
+    if not results:
+        print("All endpoint fields are consistent across all versions.")
+        sys.exit(0)
+
+    unknown_count = 0
+    for r in results:
+        endpoint = r["endpoint"]
+        known = KNOWN_VERSION_DEPENDENT.get(endpoint, set())
+        unknown_fields = [
+            f for f in r["version_dependent"] if f["field"] not in known
+        ]
+        known_fields = [
+            f for f in r["version_dependent"] if f["field"] in known
+        ]
+
+        print(f"## {endpoint}")
+        print(f"   Total fields (union): {r['total_fields']}, common to all versions: {r['common_fields']}")
+
+        if known_fields:
+            print(f"   Known version-dependent (handled in provider):")
+            for f in known_fields:
+                print(f"     {f['field']}: added in {f['min_version']}, absent from {', '.join(f['absent_from'])}")
+
+        if unknown_fields:
+            print(f"   NEW version-dependent (needs provider fix):")
+            for f in unknown_fields:
+                print(f"     {f['field']}: added in {f['min_version']}, absent from {', '.join(f['absent_from'])}")
+            unknown_count += len(unknown_fields)
+
+        print()
+
+    if unknown_count > 0:
+        print(f"Found {unknown_count} version-dependent field(s) not in the known exceptions list.")
+        print("For each field, either:")
+        print("  1. Fix the provider (UseStateForUnknown instead of Default, document min version)")
+        print("  2. Add to KNOWN_VERSION_DEPENDENT in scripts/check-contract-compat.py")
+        if ci_mode:
+            sys.exit(1)
+    else:
+        print("All version-dependent fields are accounted for.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract-contract.py
+++ b/scripts/extract-contract.py
@@ -348,6 +348,22 @@ def extract_allowed_fields(content: str) -> dict[str, list[str]]:
         method_matches = re.findall(r"function\s+(\w+)\s*\(", preceding)
         method = method_matches[-1] if method_matches else "unknown"
         result[method] = fields
+
+    # Second pass: pick up array_merge($allowedFields, [...]) calls that
+    # append additional fields within the same method.
+    merge_pattern = re.compile(
+        r"\$allowedFields\s*=\s*array_merge\s*\(\s*\$allowedFields\s*,\s*\[(.*?)\]\s*\)\s*;",
+        re.DOTALL,
+    )
+    for match in merge_pattern.finditer(content):
+        extra = re.findall(r"'([^']+)'", match.group(1))
+        preceding = content[:match.start()]
+        method_matches = re.findall(r"function\s+(\w+)\s*\(", preceding)
+        method = method_matches[-1] if method_matches else "unknown"
+        if method in result:
+            result[method].extend(extra)
+        else:
+            result[method] = extra
     return result
 
 

--- a/scripts/test_check_contract_compat.py
+++ b/scripts/test_check_contract_compat.py
@@ -1,0 +1,81 @@
+"""Tests for check-contract-compat.py.
+
+Run with:
+    python3 -m pytest scripts/test_check_contract_compat.py -v
+    python3 -m unittest scripts.test_check_contract_compat
+"""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent / "check-contract-compat.py"
+_spec = importlib.util.spec_from_file_location("check_contract_compat", _SCRIPT)
+cc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cc)
+
+
+class TestParseVersion(unittest.TestCase):
+    def test_simple(self):
+        self.assertEqual(cc._parse_version("coolify-v4.1.2"), (4, 1, 2))
+
+    def test_major_only(self):
+        self.assertEqual(cc._parse_version("coolify-v4"), (4,))
+
+    def test_no_match(self):
+        self.assertEqual(cc._parse_version("unknown"), (0,))
+
+
+class TestCompareEndpoints(unittest.TestCase):
+    def _make_contract(self, endpoints: dict) -> dict:
+        return {"version": "test", "endpoints": endpoints}
+
+    def test_identical_fields(self):
+        c1 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name", "desc"]},
+        })
+        c2 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name", "desc"]},
+        })
+        results = cc.compare_endpoints({"v4.1.0": c1, "v4.1.2": c2})
+        self.assertEqual(results, [])
+
+    def test_new_field_detected(self):
+        c1 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name"]},
+        })
+        c2 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name", "color"]},
+        })
+        results = cc.compare_endpoints({"v4.1.0": c1, "v4.1.2": c2})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["endpoint"], "Ctrl::update")
+        fields = [f["field"] for f in results[0]["version_dependent"]]
+        self.assertEqual(fields, ["color"])
+
+    def test_removed_field_detected(self):
+        c1 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name", "old_field"]},
+        })
+        c2 = self._make_contract({
+            "Ctrl::update": {"allowed_fields": ["name"]},
+        })
+        results = cc.compare_endpoints({"v4.1.0": c1, "v4.1.2": c2})
+        self.assertEqual(len(results), 1)
+        fields = [f["field"] for f in results[0]["version_dependent"]]
+        self.assertEqual(fields, ["old_field"])
+
+    def test_endpoint_in_one_version_only(self):
+        c1 = self._make_contract({})
+        c2 = self._make_contract({
+            "Ctrl::create": {"allowed_fields": ["name"]},
+        })
+        # Endpoint only in one version, fewer than 2 versions, skipped
+        results = cc.compare_endpoints({"v4.1.0": c1, "v4.1.2": c2})
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_contract_compat.py
+++ b/scripts/test_check_contract_compat.py
@@ -6,8 +6,6 @@ Run with:
 """
 
 import importlib.util
-import json
-import tempfile
 import unittest
 from pathlib import Path
 

--- a/scripts/test_extract_contract.py
+++ b/scripts/test_extract_contract.py
@@ -497,6 +497,32 @@ class FooController {
         self.assertEqual(result["store"], ["a"])
         self.assertEqual(result["update"], ["b", "c"])
 
+    def test_array_merge(self):
+        php = """<?php
+class FooController {
+    public function update(Request $r) {
+        $allowedFields = ['name', 'description'];
+        $allowedFields = array_merge($allowedFields, ['health_check_enabled', 'health_check_interval']);
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(
+            result["update"],
+            ["name", "description", "health_check_enabled", "health_check_interval"],
+        )
+
+    def test_array_merge_without_base_assignment(self):
+        php = """<?php
+class FooController {
+    public function update(Request $r) {
+        $allowedFields = array_merge($allowedFields, ['extra_field']);
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(result["update"], ["extra_field"])
+
 
 # ── _clean_rule ─────────────────────────────────────────────────────
 

--- a/templates/guides/day-two-operations.md.tmpl
+++ b/templates/guides/day-two-operations.md.tmpl
@@ -25,7 +25,7 @@ the API may gain new fields, endpoints, or changed defaults.
   it only works if your Coolify instance is v4.1+.
 - **The provider validates the Coolify version.** On every `plan` and
   `apply`, the provider checks `/api/v1/version`. If the version is
-  below v4.0.0, it refuses to continue.
+  below v4.1.0, it refuses to continue.
 
 ### Before upgrading
 

--- a/templates/guides/installation.md.tmpl
+++ b/templates/guides/installation.md.tmpl
@@ -71,22 +71,24 @@ provider "coolify" {
 ## Version requirements
 
 The provider validates the Coolify version on `terraform plan` /
-`terraform apply`. If your instance is older than **v4.0.0**, the provider
+`terraform apply`. If your instance is older than **v4.1.0**, the provider
 will return an error and refuse to continue. Upgrade your Coolify instance
 before using the provider.
 
 ### Version compatibility matrix
 
 The provider tracks the latest Coolify v4 release. Older Coolify versions
-work for core resources, but newer features require a recent version.
+may work for basic resources, but the API surface changed significantly
+between v4.0.0 and v4.1.0 (69 application fields were added), so v4.1.0
+is the minimum supported version.
 
 | Provider Version | Min Coolify | Key Features |
 |-----------------|-------------|--------------|
-| 0.1.x | 4.0.0 | Core resources: projects, servers, applications, environments |
-| 0.2.x | 4.0.0 | Databases (8 types), services, environment variables, private keys |
-| 0.3.x | 4.0.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
-| 0.4.x | 4.0.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
-| 0.5.x | 4.0.0 | Server `connection_timeout`, `railpack` build pack (requires Coolify 4.1.0+), versioned API contracts |
+| 0.1.x | 4.1.0 | Core resources: projects, servers, applications, environments |
+| 0.2.x | 4.1.0 | Databases (8 types), services, environment variables, private keys |
+| 0.3.x | 4.1.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
+| 0.4.x | 4.1.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
+| 0.5.x | 4.1.0 | Server `connection_timeout`, `railpack` build pack, versioned API contracts |
 
 -> **Tip:** Run `data "coolify_version" "current" {}` to check your
 instance version programmatically.

--- a/templates/guides/scenario-testing.md.tmpl
+++ b/templates/guides/scenario-testing.md.tmpl
@@ -177,7 +177,7 @@ Verify it works:
 
 ```bash
 curl -s http://localhost:8000/api/v1/version -H "Authorization: Bearer $COOLIFY_TOKEN"
-# Should print: 4.0.0
+# Should print a version >= 4.1.0
 ```
 
 ## Step 4: Register a Server

--- a/testdata/contracts/coolify-v4.1.2.json
+++ b/testdata/contracts/coolify-v4.1.2.json
@@ -1,7 +1,7 @@
 {
   "version": "v4.1.2",
   "extracted_from": "coollabsio/coolify@v4.1.2",
-  "extracted_at": "2026-06-13T12:09:07.303515+00:00",
+  "extracted_at": "2026-06-24T19:56:41.169662+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -6805,7 +6805,12 @@
         "mysql_password",
         "mysql_user",
         "mysql_database",
-        "mysql_conf"
+        "mysql_conf",
+        "health_check_enabled",
+        "health_check_interval",
+        "health_check_timeout",
+        "health_check_retries",
+        "health_check_start_period"
       ]
     },
     "DatabasesController::create_database": {

--- a/testdata/contracts/coolify-v4.json
+++ b/testdata/contracts/coolify-v4.json
@@ -1,7 +1,7 @@
 {
   "version": "v4.1.2",
   "extracted_from": "coollabsio/coolify@v4.1.2",
-  "extracted_at": "2026-06-13T12:09:07.303515+00:00",
+  "extracted_at": "2026-06-24T19:56:41.169662+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -6805,7 +6805,12 @@
         "mysql_password",
         "mysql_user",
         "mysql_database",
-        "mysql_conf"
+        "mysql_conf",
+        "health_check_enabled",
+        "health_check_interval",
+        "health_check_timeout",
+        "health_check_retries",
+        "health_check_start_period"
       ]
     },
     "DatabasesController::create_database": {

--- a/testdata/specs/coolify-v4.json
+++ b/testdata/specs/coolify-v4.json
@@ -13037,6 +13037,10 @@
                         "nullable": true,
                         "description": "Manual webhook secret for GitLab."
                     },
+                    "max_restart_count": {
+                        "type": "string",
+                        "description": "Max restart count."
+                    },
                     "name": {
                         "type": "string",
                         "description": "The application name."
@@ -14167,6 +14171,26 @@
                         "description": "Environment id.",
                         "nullable": true
                     },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
+                    },
                     "image": {
                         "type": "string",
                         "description": "Image.",
@@ -14372,6 +14396,26 @@
                         "description": "Environment id.",
                         "nullable": true
                     },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
+                    },
                     "image": {
                         "type": "string",
                         "description": "Image.",
@@ -14563,6 +14607,26 @@
                         "description": "Environment id.",
                         "nullable": true
                     },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
+                    },
                     "image": {
                         "type": "string",
                         "description": "Image.",
@@ -14737,6 +14801,26 @@
                         "type": "integer",
                         "description": "Environment id.",
                         "nullable": true
+                    },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
                     },
                     "image": {
                         "type": "string",
@@ -14923,6 +15007,26 @@
                         "description": "Environment id.",
                         "nullable": true
                     },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
+                    },
                     "image": {
                         "type": "string",
                         "description": "Image.",
@@ -15094,6 +15198,26 @@
                         "description": "Environment id.",
                         "nullable": true
                     },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
+                    },
                     "image": {
                         "type": "string",
                         "description": "Image.",
@@ -15248,6 +15372,26 @@
                         "type": "integer",
                         "description": "Environment id.",
                         "nullable": true
+                    },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
                     },
                     "image": {
                         "type": "string",
@@ -15416,6 +15560,26 @@
                         "type": "integer",
                         "description": "Environment id.",
                         "nullable": true
+                    },
+                    "health_check_enabled": {
+                        "type": "string",
+                        "description": "Health check enabled."
+                    },
+                    "health_check_interval": {
+                        "type": "string",
+                        "description": "Health check interval."
+                    },
+                    "health_check_retries": {
+                        "type": "string",
+                        "description": "Health check retries."
+                    },
+                    "health_check_start_period": {
+                        "type": "string",
+                        "description": "Health check start period."
+                    },
+                    "health_check_timeout": {
+                        "type": "string",
+                        "description": "Health check timeout."
                     },
                     "image": {
                         "type": "string",


### PR DESCRIPTION
Fixes #549.

## Problem

On Coolify versions before v4.1.2, the database update endpoint does not accept
`health_check_*` fields in its `$allowedFields` list. The provider used
`Default` values for these 5 attributes, which created a spurious diff after
import (state is null, Default fills the plan), triggering a PATCH that the API
rejects with 422: "This field is not allowed."

Separately, the provider claimed to support Coolify v4.0.0+, but v4.0.0 only
accepts 12 of the 81 application create fields, making it unusable for real
workloads.

## Changes

### Bug fix
- Switch 5 health_check schema attributes from `Default` to
  `UseStateForUnknown()` so no diff is produced after import on older versions
- Fix `extract-contract.py` to parse `array_merge($allowedFields, [...])`
  patterns (previously silently dropped)
- Re-extract v4.1.2 contract and regenerate OpenAPI spec

### Prevention
- Add `make contract-compat` (`scripts/check-contract-compat.py`) that
  compares endpoint `allowed_fields` across all versioned contracts and fails
  CI if version-dependent fields are not in the known-exceptions list
- Wire into `make ci` so regressions are caught before push
- Add "Version-aware field additions" rule to AGENTS.md
- 9 new Python unit tests (7 for compat checker, 2 for array_merge extraction)

### Minimum version bump
- Bump `minCoolifyVersion` from `4.0.0` to `4.1.0` (69 application create
  fields were added between v4.0.0 and v4.1.0)
- Update all mock version responses in tests
- Update installation, day-two operations, and scenario testing guides