### PR TITLE
test: add health_check update coverage for remaining 5 databases

### DIFF
--- a/internal/service/database/dragonfly/resource_test.go
+++ b/internal/service/database/dragonfly/resource_test.go
@@ -16,6 +16,118 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestDragonflyDatabaseResource_CreateUpdateImport(t *testing.T) {
+	t.Parallel()
+	srv, _ := dbtest.NewMockServer("dragonfly", "dragonfly-test-db", "docker.dragonflydb.io/dragonflydb/dragonfly:latest", nil)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_database_dragonfly", "/api/v1/databases/"),
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_dragonfly" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "uuid", "aaaa0001-0001-4000-8000-000000000001"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "name", "dragonfly-test-db"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "image", "docker.dragonflydb.io/dragonflydb/dragonfly:latest"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_public", "false"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "environment_name", "production"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "false"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "false"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "status", "running"),
+				),
+			},
+			// Plan idempotency
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_dragonfly" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_dragonfly" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+  name         = "updated-dragonfly"
+  description  = "Updated Dragonfly"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "name", "updated-dragonfly"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "description", "Updated Dragonfly"),
+				),
+			},
+			// Update SSL and log drain fields
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_dragonfly" "test" {
+  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
+  name                  = "updated-dragonfly"
+  description           = "Updated Dragonfly"
+  enable_ssl            = true
+  is_log_drain_enabled  = true
+  is_include_timestamps = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "true"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "true"),
+				),
+			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_dragonfly" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-dragonfly"
+  description             = "Updated Dragonfly"
+  enable_ssl              = true
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "health_check_start_period", "15"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "coolify_database_dragonfly.test",
+				ImportState:       true,
+				ImportStateId:     "aaaa0001-0001-4000-8000-000000000001",
+				ImportStateVerify: true, ImportStateVerifyIdentifierAttribute: "uuid",
+				ImportStateVerifyIgnore: []string{"dragonfly_password"},
+			},
+		},
+	})
+}
+
 func TestDragonflyDatabaseResource_Create(t *testing.T) {
 	t.Parallel()
 	srv, _ := dbtest.NewMockServer("dragonfly", "dragonfly-test-db", "docker.dragonflydb.io/dragonflydb/dragonfly:latest", nil)

--- a/internal/service/database/keydb/resource_test.go
+++ b/internal/service/database/keydb/resource_test.go
@@ -16,6 +16,118 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestKeydbDatabaseResource_CreateUpdateImport(t *testing.T) {
+	t.Parallel()
+	srv, _ := dbtest.NewMockServer("keydb", "keydb-test-db", "eqalpha/keydb:latest", nil)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_database_keydb", "/api/v1/databases/"),
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_keydb" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "uuid", "aaaa0001-0001-4000-8000-000000000001"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "name", "keydb-test-db"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "image", "eqalpha/keydb:latest"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_public", "false"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "environment_name", "production"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "false"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "false"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "status", "running"),
+				),
+			},
+			// Plan idempotency
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_keydb" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_keydb" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+  name         = "updated-keydb"
+  description  = "Updated KeyDB"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "name", "updated-keydb"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "description", "Updated KeyDB"),
+				),
+			},
+			// Update SSL and log drain fields
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_keydb" "test" {
+  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
+  name                  = "updated-keydb"
+  description           = "Updated KeyDB"
+  enable_ssl            = true
+  is_log_drain_enabled  = true
+  is_include_timestamps = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "true"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "true"),
+				),
+			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_keydb" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-keydb"
+  description             = "Updated KeyDB"
+  enable_ssl              = true
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "health_check_start_period", "15"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "coolify_database_keydb.test",
+				ImportState:       true,
+				ImportStateId:     "aaaa0001-0001-4000-8000-000000000001",
+				ImportStateVerify: true, ImportStateVerifyIdentifierAttribute: "uuid",
+				ImportStateVerifyIgnore: []string{"keydb_password"},
+			},
+		},
+	})
+}
+
 func TestKeydbDatabaseResource_Create(t *testing.T) {
 	t.Parallel()
 	srv, _ := dbtest.NewMockServer("keydb", "keydb-test-db", "eqalpha/keydb:latest", nil)

--- a/internal/service/database/mariadb/resource_test.go
+++ b/internal/service/database/mariadb/resource_test.go
@@ -97,6 +97,33 @@ resource "coolify_database_mariadb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_include_timestamps", "true"),
 				),
 			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_mariadb" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-mariadb"
+  description             = "Updated MariaDB"
+  enable_ssl              = true
+  ssl_mode                = "REQUIRED"
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "health_check_start_period", "15"),
+				),
+			},
 			// Import
 			{
 				ResourceName:      "coolify_database_mariadb.test",

--- a/internal/service/database/mongodb/resource_test.go
+++ b/internal/service/database/mongodb/resource_test.go
@@ -96,6 +96,33 @@ resource "coolify_database_mongodb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_include_timestamps", "true"),
 				),
 			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_mongodb" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-mongo"
+  description             = "Updated MongoDB"
+  enable_ssl              = true
+  ssl_mode                = "require"
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "health_check_start_period", "15"),
+				),
+			},
 			// Import
 			{
 				ResourceName:      "coolify_database_mongodb.test",

--- a/internal/service/database/mysql/resource_test.go
+++ b/internal/service/database/mysql/resource_test.go
@@ -98,6 +98,33 @@ resource "coolify_database_mysql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_include_timestamps", "true"),
 				),
 			},
+			// Update health check fields to non-default values
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_mysql" "test" {
+  project_uuid            = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
+  name                    = "updated-mysql-db"
+  description             = "Updated MySQL"
+  enable_ssl              = true
+  ssl_mode                = "REQUIRED"
+  is_log_drain_enabled    = true
+  is_include_timestamps   = true
+  health_check_enabled    = false
+  health_check_interval   = 30
+  health_check_timeout    = 10
+  health_check_retries    = 3
+  health_check_start_period = 15
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "health_check_enabled", "false"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "health_check_interval", "30"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "health_check_timeout", "10"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "health_check_retries", "3"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "health_check_start_period", "15"),
+				),
+			},
 			// Import
 			{
 				ResourceName:      "coolify_database_mysql.test",


### PR DESCRIPTION
Add health_check update test steps for MongoDB, MariaDB, MySQL, KeyDB, and Dragonfly.

PostgreSQL, Redis, and ClickHouse already had this coverage (PR #550, PR #552).
This completes coverage across all 8 database types, guarding against regressions
of the UseStateForUnknown fix for #549.

For KeyDB and Dragonfly, which had separate Create/Update/Import test functions,
a new combined CreateUpdateImport lifecycle test was added following the pattern
from the other 6 databases.

All 5 new tests pass with `-race`.

Closes #551