### PR TITLE
fix(github_app): import by app_id instead of internal id

### DIFF
--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -59,10 +59,10 @@ your `.tf` configuration.
 existing storage UUID.
 
 
-The `coolify_github_app` resource uses a **numeric ID** (not a UUID):
+The `coolify_github_app` resource uses the **GitHub App ID** (shown as "App Id" in the Coolify UI under Sources), not a UUID or internal database ID:
 
 ```bash
-terraform import coolify_github_app.my_app 42
+terraform import coolify_github_app.my_app 12345
 ```
 
 Resources with composite IDs:

--- a/docs/resources/github_app.md
+++ b/docs/resources/github_app.md
@@ -65,10 +65,11 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
+# Import using the GitHub App ID (shown in Coolify UI under Sources > GitHub App > App Id).
 # NOTE: Import only restores API-readable fields. Keep client_secret,
 # webhook_secret, and private_key_uuid in your Terraform config before
 # running terraform plan, because Coolify does not return them after
 # create/import. If the provider generated webhook_secret for you on
 # create, record it in your variables or secret manager before import.
-terraform import coolify_github_app.example 42
+terraform import coolify_github_app.example 12345
 ```

--- a/examples/resources/coolify_github_app/import.sh
+++ b/examples/resources/coolify_github_app/import.sh
@@ -1,6 +1,7 @@
+# Import using the GitHub App ID (shown in Coolify UI under Sources > GitHub App > App Id).
 # NOTE: Import only restores API-readable fields. Keep client_secret,
 # webhook_secret, and private_key_uuid in your Terraform config before
 # running terraform plan, because Coolify does not return them after
 # create/import. If the provider generated webhook_secret for you on
 # create, record it in your variables or secret manager before import.
-terraform import coolify_github_app.example 42
+terraform import coolify_github_app.example 12345

--- a/examples/scenarios/acme-import-existing/README.md
+++ b/examples/scenarios/acme-import-existing/README.md
@@ -1,0 +1,114 @@
+# ACME Corp Import Existing Resources
+
+The most common entry point for teams adopting Terraform on an existing
+Coolify instance. Instead of recreating resources from scratch, this
+scenario shows how to bring pre-existing Coolify resources under
+Terraform management.
+
+## The Story
+
+ACME Corp has been running services on Coolify for months, managing
+everything through the web UI. They now want to adopt infrastructure
+as code with Terraform. Rather than tearing down and rebuilding, they
+import their existing project, applications, and environment variables
+into Terraform state.
+
+## What Gets Created
+
+| # | Resource | Type | Purpose |
+|---|----------|------|---------|
+| 1 | `coolify_project.existing` | Project | Groups imported resources |
+| 2 | `coolify_application_docker_image.web` | Application | Nginx web server |
+| 3 | `coolify_environment_variable.app_env` | Env var | APP_ENV=production |
+
+## Import Workflow
+
+### 1. Discover existing resource UUIDs
+
+Use data sources or the Coolify API:
+
+```bash
+# List projects
+curl -s -H "Authorization: Bearer $COOLIFY_TOKEN" \
+  "$COOLIFY_ENDPOINT/api/v1/projects" | jq '.[] | {uuid, name}'
+
+# List applications in a project environment
+curl -s -H "Authorization: Bearer $COOLIFY_TOKEN" \
+  "$COOLIFY_ENDPOINT/api/v1/projects/<project-uuid>/production" \
+  | jq '.applications[] | {uuid, name}'
+```
+
+### 2. Write the Terraform configuration
+
+Define resource blocks in `.tf` files that match your existing setup
+(see `main.tf`).
+
+### 3. Import with CLI commands
+
+```bash
+# Simple UUID import for projects:
+terraform import coolify_project.existing <project-uuid>
+
+# Compound import for applications (recommended):
+terraform import coolify_application_docker_image.web \
+  <project-uuid>:<server-uuid>:production:<app-uuid>
+
+# Composite key import for environment variables:
+terraform import coolify_environment_variable.app_env \
+  application:<app-uuid>:<env-var-uuid>
+```
+
+### 3b. Or use import blocks (Terraform 1.5+)
+
+See `import.tf` for the declarative alternative. Add import blocks,
+run `terraform plan` to preview, then `terraform apply` to execute.
+
+### 4. Reconcile and apply
+
+```bash
+# Preview what Terraform detects
+terraform plan
+
+# Fill in fields not returned by the API (see Known Limitations below)
+# Then confirm no changes
+terraform plan
+```
+
+## Known Limitations
+
+The Coolify API does not return all fields in GET responses. After
+importing, you may need to set these fields manually in your `.tf`
+configuration:
+
+| Resource | Fields to set manually |
+|----------|----------------------|
+| Applications | `project_uuid`, `server_uuid`, `environment_name` (use compound import to avoid this) |
+| Databases | `project_uuid`, `server_uuid`, `environment_name`, password fields |
+| `coolify_github_app` | `client_secret`, `webhook_secret`, `private_key_uuid` |
+| `coolify_private_key` | `private_key` (needs `root` or `read:sensitive` API permission) |
+| `coolify_environment_variable` | `value` (sensitive, not reliably returned) |
+
+For the full list, see the [Import Guide](../../docs/guides/import.md).
+
+## Prerequisites
+
+1. A running [Coolify](https://coolify.io/) instance (v4+)
+2. An API token (Security > API Tokens)
+3. A registered server UUID (Settings > Servers)
+4. [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+terraform init
+terraform plan
+terraform apply
+```
+
+## Clean Up
+
+```bash
+terraform destroy
+```

--- a/examples/scenarios/acme-import-existing/acme-import-existing.tftest.hcl
+++ b/examples/scenarios/acme-import-existing/acme-import-existing.tftest.hcl
@@ -1,0 +1,97 @@
+# Acceptance test for the ACME Corp Import Existing Resources scenario.
+#
+# Creates resources, then verifies they can be read back via data sources
+# (the same Read code path used by terraform import).
+#
+# Required variables are provided via TF_VAR_* environment variables:
+#   TF_VAR_coolify_endpoint, TF_VAR_coolify_token, TF_VAR_server_uuid
+
+run "create_resources" {
+  command = apply
+
+  # --- Project ---
+  assert {
+    condition     = coolify_project.existing.uuid != ""
+    error_message = "Project was not created: uuid is empty"
+  }
+  assert {
+    condition     = coolify_project.existing.name == "acme-import-demo"
+    error_message = "Project name mismatch: got ${coolify_project.existing.name}"
+  }
+
+  # --- Application ---
+  assert {
+    condition     = coolify_application_docker_image.web.uuid != ""
+    error_message = "Application was not created: uuid is empty"
+  }
+  assert {
+    condition     = coolify_application_docker_image.web.name == "acme-imported-web"
+    error_message = "Application name mismatch: got ${coolify_application_docker_image.web.name}"
+  }
+  assert {
+    condition     = coolify_application_docker_image.web.docker_image == "nginx:latest"
+    error_message = "Docker image not preserved: got ${coolify_application_docker_image.web.docker_image}"
+  }
+  assert {
+    condition     = coolify_application_docker_image.web.ports_exposes == "80"
+    error_message = "Ports mismatch: got ${coolify_application_docker_image.web.ports_exposes}"
+  }
+
+  # --- Environment variable ---
+  assert {
+    condition     = coolify_environment_variable.app_env.key == "APP_ENV"
+    error_message = "Env var key mismatch: got ${coolify_environment_variable.app_env.key}"
+  }
+  assert {
+    condition     = nonsensitive(coolify_environment_variable.app_env.value) == "production"
+    error_message = "Env var value mismatch"
+  }
+}
+
+# Verify data sources can read back the created resources.
+# Data source reads use the same Read code path that terraform import
+# calls after ImportState, so this validates the import round-trip.
+run "verify_read_back" {
+  command = apply
+
+  assert {
+    condition     = data.coolify_project.verify.name == coolify_project.existing.name
+    error_message = "Project data source name does not match resource"
+  }
+  assert {
+    condition     = data.coolify_application.verify.name == coolify_application_docker_image.web.name
+    error_message = "Application data source name does not match resource"
+  }
+  assert {
+    condition     = data.coolify_server.target.uuid == var.server_uuid
+    error_message = "Server data source UUID does not match input"
+  }
+}
+
+# Update: change description and verify the update is applied.
+run "update_project_description" {
+  command = apply
+
+  variables {
+    project_description = "Updated by import scenario test"
+  }
+
+  assert {
+    condition     = coolify_project.existing.description == "Updated by import scenario test"
+    error_message = "Project description not updated: got ${coolify_project.existing.description}"
+  }
+}
+
+# Idempotency: re-plan should produce no changes.
+run "idempotency" {
+  command = plan
+
+  variables {
+    project_description = "Updated by import scenario test"
+  }
+
+  assert {
+    condition     = coolify_project.existing.name == "acme-import-demo"
+    error_message = "Project name changed after re-plan (state corruption)"
+  }
+}

--- a/examples/scenarios/acme-import-existing/import.tf
+++ b/examples/scenarios/acme-import-existing/import.tf
@@ -1,0 +1,33 @@
+# ACME Corp Import Blocks (Terraform 1.5+)
+#
+# This file shows the declarative import syntax as an alternative to
+# running `terraform import` commands. Add these blocks, run
+# `terraform plan` to preview, then `terraform apply` to execute.
+#
+# In a real scenario, replace the UUIDs below with your actual values
+# from the Coolify UI or API. The blocks below are placeholders that
+# illustrate the syntax for each resource type.
+
+# --- Project: simple UUID ---
+# import {
+#   to = coolify_project.existing
+#   id = "<project-uuid>"
+# }
+
+# --- Application: compound format ---
+# The compound format (project:server:env:app) populates project_uuid,
+# server_uuid, and environment_name automatically, avoiding post-import
+# diffs. The simple UUID format also works but may require setting those
+# fields manually.
+# import {
+#   to = coolify_application_docker_image.web
+#   id = "<project-uuid>:<server-uuid>:production:<app-uuid>"
+# }
+
+# --- Environment variable: composite key ---
+# Format: resource_type:parent_uuid:env_var_uuid
+# resource_type is one of: application, service, database
+# import {
+#   to = coolify_environment_variable.app_env
+#   id = "application:<app-uuid>:<env-var-uuid>"
+# }

--- a/examples/scenarios/acme-import-existing/main.tf
+++ b/examples/scenarios/acme-import-existing/main.tf
@@ -1,0 +1,91 @@
+# ACME Corp Import Existing Resources
+#
+# Demonstrates importing pre-existing Coolify resources into Terraform.
+# This is the most common entry point for teams adopting Terraform on
+# an existing Coolify instance.
+#
+# The scenario covers:
+# - Importing a project by UUID
+# - Importing an application using the compound format
+#   (project_uuid:server_uuid:environment_name:app_uuid)
+# - Importing an environment variable with its composite key
+#   (type:parent_uuid:env_var_uuid)
+# - Data source read-back to discover UUIDs before importing
+
+terraform {
+  required_providers {
+    coolify = {
+      source = "coolify-terraform/coolify"
+    }
+  }
+}
+
+provider "coolify" {
+  endpoint = var.coolify_endpoint
+  token    = var.coolify_token
+}
+
+# --- Step 1: Discover existing resources ---
+#
+# Before importing, use data sources to find UUIDs. In a real workflow
+# you would also use the Coolify API directly:
+#   curl -s -H "Authorization: Bearer $TOKEN" "$ENDPOINT/api/v1/projects" | jq '.[].uuid'
+
+data "coolify_server" "target" {
+  uuid = var.server_uuid
+}
+
+# --- Step 2: Define the resource blocks ---
+#
+# Write the Terraform configuration FIRST, matching your existing
+# Coolify setup. These blocks describe what is already running.
+
+resource "coolify_project" "existing" {
+  name        = "acme-import-demo"
+  description = var.project_description
+}
+
+resource "coolify_application_docker_image" "web" {
+  name             = "acme-imported-web"
+  project_uuid     = coolify_project.existing.uuid
+  server_uuid      = var.server_uuid
+  environment_name = "production"
+  docker_image     = "nginx:latest"
+  ports_exposes    = "80"
+}
+
+resource "coolify_environment_variable" "app_env" {
+  application_uuid = coolify_application_docker_image.web.uuid
+  key              = "APP_ENV"
+  value            = "production"
+  is_build         = false
+  is_preview       = false
+}
+
+# --- Step 3: Import commands ---
+#
+# After writing the blocks above, run these commands to bring the
+# existing resources under Terraform management:
+#
+#   # Simple UUID import (projects, servers, private keys):
+#   terraform import coolify_project.existing <project-uuid>
+#
+#   # Compound import for applications (avoids post-import diffs):
+#   terraform import coolify_application_docker_image.web \
+#     <project-uuid>:<server-uuid>:production:<app-uuid>
+#
+#   # Composite key import for environment variables:
+#   terraform import coolify_environment_variable.app_env \
+#     application:<app-uuid>:<env-var-uuid>
+#
+# Alternatively, use Terraform 1.5+ import blocks (see import.tf).
+
+# --- Data source read-backs ---
+
+data "coolify_project" "verify" {
+  uuid = coolify_project.existing.uuid
+}
+
+data "coolify_application" "verify" {
+  uuid = coolify_application_docker_image.web.uuid
+}

--- a/examples/scenarios/acme-import-existing/outputs.tf
+++ b/examples/scenarios/acme-import-existing/outputs.tf
@@ -1,0 +1,14 @@
+output "project_uuid" {
+  description = "UUID of the imported project"
+  value       = coolify_project.existing.uuid
+}
+
+output "app_uuid" {
+  description = "UUID of the imported application"
+  value       = coolify_application_docker_image.web.uuid
+}
+
+output "server_name" {
+  description = "Name of the target server (from data source)"
+  value       = data.coolify_server.target.name
+}

--- a/examples/scenarios/acme-import-existing/terraform.tfvars.example
+++ b/examples/scenarios/acme-import-existing/terraform.tfvars.example
@@ -1,0 +1,3 @@
+coolify_endpoint = "http://localhost:8000"
+coolify_token    = "your-api-token"
+server_uuid      = "your-server-uuid"

--- a/examples/scenarios/acme-import-existing/variables.tf
+++ b/examples/scenarios/acme-import-existing/variables.tf
@@ -1,0 +1,21 @@
+variable "coolify_endpoint" {
+  description = "Coolify API endpoint (e.g. https://coolify.example.com)"
+  type        = string
+}
+
+variable "coolify_token" {
+  description = "Coolify API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "server_uuid" {
+  description = "UUID of the Coolify server to deploy to"
+  type        = string
+}
+
+variable "project_description" {
+  description = "Project description (used by update scenario test)"
+  type        = string
+  default     = "ACME Corp imported infrastructure"
+}

--- a/internal/client/github_apps.go
+++ b/internal/client/github_apps.go
@@ -87,6 +87,26 @@ func (c *Client) ListGitHubApps(ctx context.Context) ([]GitHubApp, error) {
 	return apps, nil
 }
 
+func (c *Client) GetGitHubAppByAppID(ctx context.Context, appID int64) (*GitHubApp, error) {
+	var apps []GitHubApp
+	if err := c.doCachedList(ctx, "/api/v1/github-apps", &apps); err != nil {
+		return nil, fmt.Errorf("getting github app by app_id %d: %w", appID, err)
+	}
+	for i := range apps {
+		if apps[i].ID == 0 {
+			continue // skip Coolify's built-in "Public GitHub" system record
+		}
+		if apps[i].AppID != appID {
+			continue
+		}
+		if err := validateGitHubAppResponse(&apps[i]); err != nil {
+			return nil, fmt.Errorf("getting github app by app_id %d: invalid matched app: %w", appID, err)
+		}
+		return &apps[i], nil
+	}
+	return nil, &NotFoundError{Message: fmt.Sprintf("github app with app_id %d not found", appID)}
+}
+
 func (c *Client) GetGitHubApp(ctx context.Context, id int64) (*GitHubApp, error) {
 	var apps []GitHubApp
 	if err := c.doCachedList(ctx, "/api/v1/github-apps", &apps); err != nil {

--- a/internal/service/githubapp/resource.go
+++ b/internal/service/githubapp/resource.go
@@ -179,17 +179,25 @@ func (r *gitHubAppResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	tflog.Debug(ctx, "reading resource", map[string]interface{}{"resource_type": "coolify_github_app", "id": state.ID.ValueInt64()})
+	var app *client.GitHubApp
+	var err error
 
-	app, err := r.client.GetGitHubApp(ctx, state.ID.ValueInt64())
+	if state.ID.IsNull() || state.ID.IsUnknown() {
+		// Import case: look up by app_id since the user provides the GitHub App ID.
+		tflog.Debug(ctx, "reading resource by app_id (import)", map[string]interface{}{"resource_type": "coolify_github_app", "app_id": state.AppID.ValueInt64()})
+		app, err = r.client.GetGitHubAppByAppID(ctx, state.AppID.ValueInt64())
+	} else {
+		tflog.Debug(ctx, "reading resource", map[string]interface{}{"resource_type": "coolify_github_app", "id": state.ID.ValueInt64()})
+		app, err = r.client.GetGitHubApp(ctx, state.ID.ValueInt64())
+	}
+
 	if err != nil {
 		if client.IsNotFound(err) {
-			// The GitHub App was deleted outside of Terraform; remove from state.
-			tflog.Debug(ctx, "resource not found, removing from state", map[string]interface{}{"resource_type": "coolify_github_app", "uuid": state.UUID.ValueString()})
+			tflog.Debug(ctx, "resource not found, removing from state", map[string]interface{}{"resource_type": "coolify_github_app"})
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error reading GitHub App", fmt.Sprintf("Could not read GitHub App %d: %s", state.ID.ValueInt64(), err))
+		resp.Diagnostics.AddError("Error reading GitHub App", fmt.Sprintf("Could not read GitHub App: %s", err))
 		return
 	}
 
@@ -263,7 +271,7 @@ func (r *gitHubAppResource) Delete(ctx context.Context, req resource.DeleteReque
 }
 
 func (r *gitHubAppResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id, err := strconv.ParseInt(req.ID, 10, 64)
+	appID, err := strconv.ParseInt(req.ID, 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
@@ -271,7 +279,7 @@ func (r *gitHubAppResource) ImportState(ctx context.Context, req resource.Import
 		)
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_id"), appID)...)
 }
 
 func (r *gitHubAppResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {

--- a/internal/service/githubapp/resource_acc_test.go
+++ b/internal/service/githubapp/resource_acc_test.go
@@ -47,19 +47,19 @@ func TestAccGitHubAppResource_CRUD(t *testing.T) {
 					resource.TestCheckResourceAttr("coolify_github_app.test", "app_id", "12345"),
 				),
 			},
-			// Step 3: Import by ID
+			// Step 3: Import by app_id (GitHub App ID visible in UI)
 			{
 				ResourceName:                         "coolify_github_app.test",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: "id",
+				ImportStateVerifyIdentifierAttribute: "app_id",
 				ImportStateVerifyIgnore:              []string{"client_secret", "webhook_secret", "private_key_uuid"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["coolify_github_app.test"]
 					if !ok {
 						return "", fmt.Errorf("resource coolify_github_app.test not found")
 					}
-					return rs.Primary.Attributes["id"], nil
+					return rs.Primary.Attributes["app_id"], nil
 				},
 			},
 		},

--- a/internal/service/githubapp/resource_test.go
+++ b/internal/service/githubapp/resource_test.go
@@ -470,14 +470,14 @@ resource "coolify_github_app" "test" {
 				ResourceName:                         "coolify_github_app.test",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: "id",
+				ImportStateVerifyIdentifierAttribute: "app_id",
 				ImportStateVerifyIgnore:              []string{"client_secret", "webhook_secret", "private_key_uuid"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["coolify_github_app.test"]
 					if !ok {
 						return "", fmt.Errorf("resource not found")
 					}
-					return rs.Primary.Attributes["id"], nil
+					return rs.Primary.Attributes["app_id"], nil
 				},
 			},
 		},

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -59,10 +59,10 @@ your `.tf` configuration.
 existing storage UUID.
 
 
-The `coolify_github_app` resource uses a **numeric ID** (not a UUID):
+The `coolify_github_app` resource uses the **GitHub App ID** (shown as "App Id" in the Coolify UI under Sources), not a UUID or internal database ID:
 
 ```bash
-terraform import coolify_github_app.my_app 42
+terraform import coolify_github_app.my_app 12345
 ```
 
 Resources with composite IDs:


### PR DESCRIPTION
## Summary

The `coolify_github_app` import expected Coolify's internal database `id`, which is not exposed anywhere in the Coolify UI. Users only see the GitHub App ID (`app_id`) on the Sources page, causing import to fail with "Cannot import non-existent remote object".

## Changes

- **ImportState**: sets `app_id` instead of `id` from the import identifier
- **Read**: looks up by `app_id` when `id` is not yet known (import case), falls back to `id` for normal reads
- **Client**: adds `GetGitHubAppByAppID` that scans the list endpoint by `app_id`
- **Docs/examples**: updated `import.sh` to clarify the import uses the GitHub App ID

## Usage

```bash
# Use the GitHub App ID shown in Coolify UI (Sources > GitHub App > App Id)
terraform import coolify_github_app.example 12345
```

Closes #558