### PR TITLE
fix: multi-perspective improvement rotation (client tests, doc fixes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,11 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 - Every resource needs `examples/resources/coolify_<type>/resource.tf` + `import.sh`
 - Every data source needs `examples/data-sources/coolify_<type>/data-source.tf`
 - Run `terraform fmt -recursive examples/` before committing HCL changes
+- **Scenario and resource counts live in 5+ files.** When adding a scenario, resource, or data source, grep for the old count across all docs before committing:
+  ```bash
+  grep -rn '16 ACME\|16 tested\|16 scenario' AGENTS.md README.md ROADMAP.md templates/ docs/
+  ```
+  Known locations for scenario counts: `AGENTS.md` (Project section), `README.md` (feature table + body text), `ROADMAP.md`, `templates/guides/architecture.md.tmpl` (ASCII diagram). Also check if a table row is missing in `README.md` for the new scenario.
 
 ### Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for release
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
 33 resources, 44 data sources, 960+ tests (unit + acceptance), 9 CI jobs.
-16 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
+17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
 - 960+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
-- Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, python-test, docs-check, api-coverage-check, counts-check, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
+- Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates
 - **Test counts use floor rounding**: `counts-check` rounds down to the nearest 10 (e.g., 857 tests -> "850+"). When updating test counts in AGENTS.md or README.md, use the floor value, not the exact count. Setting "855+" when the actual count is 857 will fail `make ci` because 855 > floor(857/10)*10 = 850.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-33 resources, 44 data sources, 960+ tests (unit + acceptance), 9 CI jobs.
+33 resources, 44 data sources, 970+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -213,7 +213,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 960+ tests (unit + acceptance)
+- 970+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,12 @@ From [GNUmakefile](GNUmakefile), `make ci` runs these local targets:
 - `lint`
 - `test`
 - `validate`
+- `actionlint-check`
 - `python-test`
 - `docs-check`
 - `api-coverage-check`
 - `counts-check`
+- `contract-compat`
 - `vulncheck`
 - `goreleaser-check`
 - `modverify`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 | Managed resources | 33 |
 | Data sources | 44 |
 | Tests | 960+ unit and acceptance tests |
-| Scenario examples | 16 ACME Corp setups |
+| Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
 ## Demo
@@ -169,7 +169,7 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 
 Deploy a full stack (app, database, backups, env vars) in a single `terraform apply`, or adopt the provider incrementally by importing your existing Coolify resources.
 
-**Real-world scenarios included** -- 16 tested ACME Corp examples cover common patterns:
+**Real-world scenarios included** -- 17 tested ACME Corp examples cover common patterns:
 
 | Scenario | What it deploys |
 |---|---|
@@ -189,6 +189,7 @@ Deploy a full stack (app, database, backups, env vars) in a single `terraform ap
 | [acme-compose-git](examples/scenarios/acme-compose-git) | Custom Docker Compose stack via docker_compose_raw |
 | [acme-env-scale](examples/scenarios/acme-env-scale) | Bulk env var management with shared + per-app patterns |
 | [acme-hetzner-infra](examples/scenarios/acme-hetzner-infra) | Hetzner Cloud server provisioning + build server |
+| [acme-import-existing](examples/scenarios/acme-import-existing) | Import pre-existing Coolify resources into Terraform state |
 
 Every scenario has `terraform test` integration tests that run against a real Coolify instance.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 33 |
 | Data sources | 44 |
-| Tests | 960+ unit and acceptance tests |
+| Tests | 970+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ The provider covers the core Coolify resource model:
 - 33 managed resources (projects, servers, applications, databases, services,
   backups, environment variables, deployments, and more)
 - 44 data sources for reading existing infrastructure
-- 16 ACME Corp scenario examples with integration tests
+- 17 ACME Corp scenario examples with integration tests
 - Full import support for adopting existing Coolify resources
 
 ## Near Term

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 16 ACME Corp scenarios                │
+│  - 17 ACME Corp scenarios                │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2520,6 +2520,77 @@ func TestClient_GetGitHubApp_EmptyList(t *testing.T) {
 	assert.True(t, IsNotFound(err))
 }
 
+// --- GetGitHubAppByAppID ---
+
+func TestClient_GetGitHubAppByAppID_Found(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]GitHubApp{
+			{ID: 10, Name: "other-app", AppID: 111},
+			{ID: 20, Name: "target-app", AppID: 222},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	app, err := c.GetGitHubAppByAppID(context.Background(), 222)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), app.ID)
+	assert.Equal(t, int64(222), app.AppID)
+	assert.Equal(t, "target-app", app.Name)
+}
+
+func TestClient_GetGitHubAppByAppID_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]GitHubApp{
+			{ID: 10, Name: "other-app", AppID: 111},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	_, err := c.GetGitHubAppByAppID(context.Background(), 999)
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+	assert.Contains(t, err.Error(), "999")
+}
+
+func TestClient_GetGitHubAppByAppID_SkipsBuiltInRecord(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// The built-in "Public GitHub" system record has ID=0 and AppID=0.
+		json.NewEncoder(w).Encode([]GitHubApp{
+			{ID: 0, Name: "Public GitHub", AppID: 0},
+			{ID: 5, Name: "real-app", AppID: 333},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	// Searching for AppID 0 should not match the built-in record (ID=0 is skipped).
+	_, err := c.GetGitHubAppByAppID(context.Background(), 0)
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_GetGitHubAppByAppID_EmptyList(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]GitHubApp{})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	_, err := c.GetGitHubAppByAppID(context.Background(), 42)
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
 // --- PollUntilDeleted ---
 
 func TestPollUntilDeleted_ImmediateNotFound(t *testing.T) {

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 16 ACME Corp scenarios                │
+│  - 17 ACME Corp scenarios                │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐


### PR DESCRIPTION
## Changes

Three commits from a multi-perspective improvement rotation:

1. **test: add client tests for GetGitHubAppByAppID** (QA perspective)
   - 4 new unit tests for the `GetGitHubAppByAppID` client method (found, not found, skips built-in record, empty list)
   - This method had zero test coverage after being added in PR #559

2. **docs: update scenario count to 17** (End User perspective)
   - `acme-import-existing` was added in PR #559 but the scenario count in AGENTS.md, README.md, ROADMAP.md, and the architecture guide template still said 16
   - Added the missing scenario to the README table

3. **docs: fix gate drift in make ci target list** (New Contributor perspective)
   - AGENTS.md and CONTRIBUTING.md listed 11 targets for `make ci` but the GNUmakefile runs 13
   - Missing `actionlint-check` and `contract-compat` added to both docs

## Verification

- `make ci` passes locally (all 13 targets)
- No grep matches remain for `16 ACME` in the codebase