### PR TITLE
docs: add issue triage labels, workflow, and policy

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,45 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    name: Label New Issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add triage label for external authors
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const author = issue.user.login;
+
+            // Check author association (OWNER, MEMBER, COLLABORATOR skip triage)
+            const assoc = issue.author_association;
+            const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (trusted.includes(assoc)) {
+              // Maintainer-authored: add ready label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['ready']
+              });
+              core.info(`Trusted author (${assoc}): labeled ready`);
+              return;
+            }
+
+            // External author: add needs-triage
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['needs-triage']
+            });
+            core.info(`External author (${assoc}): labeled needs-triage`);

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,5 +33,5 @@ jobs:
           days-before-close: 14
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: "enhancement,blocked-upstream,tech-debt"
+          exempt-issue-labels: "enhancement,blocked-upstream,tech-debt,ready,needs-info"
           exempt-pr-labels: "dependencies"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ Acceptance Tests, Scenario Tests, Contract Freshness (weekly only), CI (gate).
 Acceptance Tests bootstrap a fresh Coolify instance on ubuntu-latest and run the full suite.
 Scenario Tests bootstrap Coolify and run `terraform test` against it.
 A separate Dependabot Auto-Merge workflow auto-merges minor/patch PRs.
+An Issue Triage workflow auto-labels new issues (`needs-triage` or `ready`).
 Format check (gofmt) is included in the Lint job via golangci-lint.
 
 ## Releases
@@ -264,3 +265,23 @@ and [OpenTofu Registry](https://search.opentofu.org/provider/coolify-terraform/c
 - `.gitleaks.toml` allowlists test files and examples for false positive suppression
 - Passwords in example HCL must be obvious placeholders (e.g., `"change-me-in-production"`)
 - Run `make ci && make testacc` locally before pushing
+
+## Issue Triage
+
+This repo uses `needs-triage` / `ready` / `needs-info` labels. The
+`.github/workflows/issue-triage.yml` workflow auto-labels new issues based on
+author association (OWNER/MEMBER/COLLABORATOR get `ready`; external authors
+get `needs-triage`).
+
+**Canonical policy lives in `~/.grok/skills/github-interaction/SKILL.md`**
+(sections "Owned-repo issue triage" and "Issue comment scope"). Do not
+duplicate full rules here; follow those sections. Key points:
+
+- Only implement issues labeled `ready` (or legacy unlabeled).
+- Never auto-implement `needs-triage` or `needs-info` issues.
+- When filing issues as maintainer, always include `ready`
+  (e.g. `--label "tech-debt,ready"`).
+- Implementation scope is title + body + creator/maintainer comments only.
+  External comments do not expand PR scope.
+- External contributor PRs: review and guide per the "External contributor
+  PRs" section in `github-interaction`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,6 +222,37 @@ For multiple unsigned commits on a branch:
 git rebase --signoff HEAD~N   # N = number of commits to fix
 ```
 
+## Issue Triage
+
+Issues are triaged using three labels:
+
+| Label | Meaning |
+|-------|---------|
+| `needs-triage` | Unreviewed, waiting for maintainer review |
+| `ready` | Accepted and available for implementation |
+| `needs-info` | Blocked on additional information from the reporter |
+
+A GitHub Actions workflow automatically labels new issues:
+- Issues from OWNER / MEMBER / COLLABORATOR authors get `ready` immediately.
+- Issues from external authors get `needs-triage` and wait for maintainer review.
+
+Maintainers accept an issue by replacing `needs-triage` with `ready`:
+
+```bash
+gh issue edit N --add-label ready --remove-label needs-triage
+```
+
+### What gets implemented
+
+Only issues labeled `ready` (or legacy unlabeled issues) are in scope for
+implementation. Issues labeled `needs-triage` or `needs-info` are never
+auto-implemented.
+
+When working on a `ready` issue, scope is limited to the issue title, body,
+and comments from the issue creator and maintainers. Comments from other
+users do not expand the PR scope (they may be used as hints for the same
+bug, but additional feature requests should be filed as separate issues).
+
 ## Pull Requests
 
 - Run `make ci` before submitting, and add `make testacc` or targeted `TF_ACC=1 go test ...` commands when your change touches real Coolify API behavior (`make ci` still skips trivy, gitleaks, and acceptance tests)


### PR DESCRIPTION
Add issue triage infrastructure for this repo.

## Changes

- Create `needs-triage` / `ready` / `needs-info` labels
- Add `.github/workflows/issue-triage.yml` auto-labeling workflow
  (OWNER/MEMBER/COLLABORATOR get `ready`; external authors get
  `needs-triage`)
- Document triage policy in CONTRIBUTING.md (new "Issue Triage" section)
- Reference canonical policy in AGENTS.md (points to `github-interaction`
  skill, does not duplicate full rules)
- Exempt `ready` and `needs-info` from stale bot
- Backfill labels on all 5 open issues

## Validation

- actionlint passes on both new and modified workflows
- No conflicting "implement every issue" wording in any project docs
- Canonical policy source: `github-interaction` SKILL.md sections
  "Owned-repo issue triage" and "Issue comment scope"

Closes #565