### PR TITLE
fix: bump Go 1.26.4 to 1.26.5 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coolify-terraform/terraform-provider-coolify
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8


### PR DESCRIPTION
Fixes govulncheck CI failure on main caused by GO-2026-5856 (Encrypted
Client Hello privacy leak in crypto/tls@go1.26.4, fixed in go1.26.5).

## Changes

- Bump `go` directive in `go.mod` from 1.26.4 to 1.26.5

## Validation

- `go build ./...` passes
- `govulncheck ./...`: 0 symbol-level vulnerabilities
- Local govulncheck confirms GO-2026-5856 is resolved