### PR TITLE
ci: stop cancel races leaving PR Title checks cancelled

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,9 +4,13 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+# Do not cancel in-progress runs. This job is a few seconds long, and
+# cancel-in-progress races (opened + synchronize, or force-push from
+# release-please) leave a CANCELLED Conventional Commit check on the
+# PR head SHA, which marks the PR unstable even when the title is valid.
 concurrency:
-  group: pr-title-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: pr-title-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: false
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary

- PR Title workflow concurrency used `cancel-in-progress: true` per PR number only
- Release-please force-pushes (and similar dual events) could cancel the Conventional Commit check for the current head SHA
- That left [release PR #571](https://github.com/coolify-terraform/terraform-provider-coolify/pull/571) `UNSTABLE` even though the title matches Conventional Commits
- Scope the concurrency group by head SHA and set `cancel-in-progress: false` (the job is a few seconds long)

## Test plan

- [x] Re-ran the cancelled Conventional Commit job on #571; PR is now `CLEAN` / mergeable
- [ ] Confirm this PR's own Conventional Commit check stays green after any synchronize events