### PR TITLE
fix: compound import server validation for databases and services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-33 resources, 44 data sources, 970+ tests (unit + acceptance), 9 CI jobs.
+33 resources, 44 data sources, 980+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -218,7 +218,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 970+ tests (unit + acceptance)
+- 980+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 33 |
 | Data sources | 44 |
-| Tests | 970+ unit and acceptance tests |
+| Tests | 980+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -55,11 +55,11 @@ UUID format still works but may require you to set these fields manually in
 your `.tf` configuration.
 
 -> **Warning:** The `server_uuid` segment must be the server that actually hosts
-the resource. Coolify application GET responses do not return `server_uuid`, so
-a wrong value is not corrected on refresh. On replace, Terraform would recreate
-the resource on the wrong server. Application compound import validates that
-the application appears in `GET /servers/{server_uuid}/resources` and fails if
-it does not.
+the resource. Coolify GET responses often omit `server_uuid`, so a wrong value
+is not corrected on refresh. On replace, Terraform would recreate the resource
+on the wrong server. Compound import for applications, databases, and services
+validates membership via `GET /servers/{server_uuid}/resources` and fails if
+the resource is not listed on that server.
 
 ~> **Note:** Top-level S3 storages are managed in the Coolify web UI. When
 `coolify_database_backup` uses `save_s3 = true`, set `s3_storage_uuid` to an

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -129,6 +129,7 @@ if the API token lacks permissions, these fields will be empty in state.
 | `coolify_private_key` | `private_key` | Requires `root` or `read:sensitive` token |
 | `coolify_cloud_token` | `token` | Write-only, never returned by API |
 | `coolify_github_app` | `client_secret`, `webhook_secret`, `private_key_uuid` | Write-only. If `webhook_secret` was auto-generated on create, keep that generated value in your secret store or Terraform variables before import because Coolify will not return it later. |
+| Application resources (`coolify_application*`) | `manual_webhook_secret_*`, `http_basic_auth_password`, `dockerfile` (content) | Encrypted secrets are hidden without root / `read:sensitive`. Coolify auto-generates webhook secrets when omitted on create; the provider preserves configured values when GET returns empty. |
 | `coolify_environment_variable` | `value` | May be hidden without sensitive permissions |
 
 **After importing a resource with hidden fields:**

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2132,6 +2132,28 @@ func TestClient_ListServerResources(t *testing.T) {
 	assert.Equal(t, "database", got[1].Type)
 }
 
+func TestClient_ValidateResourceOnServer(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]ServerResource{
+			{UUID: "app-1", Name: "my-app", Type: "application"},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	require.NoError(t, c.ValidateResourceOnServer(context.Background(), "srv-1", "app-1", "application"))
+
+	err := c.ValidateResourceOnServer(context.Background(), "srv-1", "missing", "application")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not deployed on server")
+
+	err = (*Client)(nil).ValidateResourceOnServer(context.Background(), "srv-1", "app-1", "application")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider client is not configured")
+}
+
 func TestClient_ListServerDomains(t *testing.T) {
 	t.Parallel()
 	expected := []ServerDomain{

--- a/internal/client/servers.go
+++ b/internal/client/servers.go
@@ -144,6 +144,36 @@ func (c *Client) ListServerResources(ctx context.Context, uuid string) ([]Server
 	return r, nil
 }
 
+// ValidateResourceOnServer confirms resourceUUID is listed among resources on
+// serverUUID. Used for compound import so a wrong server_uuid cannot silently
+// survive until replace. kind is a human label for errors (e.g. "application").
+// Callers must not invoke this on a nil *Client (Go method receivers on nil
+// are allowed only when the method nil-checks first; we do that here).
+func (c *Client) ValidateResourceOnServer(ctx context.Context, serverUUID, resourceUUID, kind string) error {
+	if c == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	resources, err := c.ListServerResources(ctx, serverUUID)
+	if err != nil {
+		return fmt.Errorf(
+			"could not verify that %s %s is deployed on server %s: %w. "+
+				"Fix the server_uuid segment of the compound import ID, or import by %s UUID only",
+			kind, resourceUUID, serverUUID, err, kind,
+		)
+	}
+	for _, r := range resources {
+		if r.UUID == resourceUUID {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%s %s is not deployed on server %s. "+
+			"The compound import ID format is project_uuid:server_uuid:environment_name:%s_uuid; "+
+			"a wrong server_uuid is not corrected on Read and can recreate the resource on the wrong server on replace",
+		kind, resourceUUID, serverUUID, kind,
+	)
+}
+
 type ServerDomain struct {
 	Domain string `json:"domain"`
 	IP     string `json:"ip"`

--- a/internal/service/application/common_crud.go
+++ b/internal/service/application/common_crud.go
@@ -229,28 +229,7 @@ func importApplicationState(ctx context.Context, c *client.Client, req resource.
 // resources on the given server. Coolify GET application does not return
 // server_uuid, so compound import is the only chance to catch a wrong server.
 func validateApplicationOnServer(ctx context.Context, c *client.Client, serverUUID, appUUID string) error {
-	if c == nil {
-		return fmt.Errorf("provider client is not configured")
-	}
-	resources, err := c.ListServerResources(ctx, serverUUID)
-	if err != nil {
-		return fmt.Errorf(
-			"could not verify that application %s is deployed on server %s: %w. "+
-				"Fix the server_uuid segment of the compound import ID, or import by application UUID only",
-			appUUID, serverUUID, err,
-		)
-	}
-	for _, r := range resources {
-		if r.UUID == appUUID {
-			return nil
-		}
-	}
-	return fmt.Errorf(
-		"application %s is not deployed on server %s. "+
-			"The compound import ID format is project_uuid:server_uuid:environment_name:application_uuid; "+
-			"a wrong server_uuid is not corrected on Read and can recreate the app on the wrong server on replace",
-		appUUID, serverUUID,
-	)
+	return c.ValidateResourceOnServer(ctx, serverUUID, appUUID, "application")
 }
 
 // addApplicationImportSensitiveFieldsWarning explains why imported application

--- a/internal/service/database/clickhouse/resource.go
+++ b/internal/service/database/clickhouse/resource.go
@@ -157,7 +157,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_clickhouse", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/database/common.go
+++ b/internal/service/database/common.go
@@ -342,20 +342,25 @@ func AddCreateReadBackError(resp *resource.CreateResponse, label, identifier str
 	)
 }
 
-// ImportDatabaseState validates the import ID as a UUID and passes it through
-// as the "uuid" attribute.
-func ImportDatabaseState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+// ImportDatabaseState validates the import ID (simple UUID or compound) and
+// sets initial state. Compound import verifies the database is listed on the
+// given server so a wrong server_uuid cannot silently mis-target replace.
+func ImportDatabaseState(ctx context.Context, c *client.Client, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parsed, compound, err := validate.ParseCompoundImportID(req.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Import ID", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), parsed.UUID)...)
 	if compound {
+		if err := c.ValidateResourceOnServer(ctx, parsed.ServerUUID, parsed.UUID, "database"); err != nil {
+			resp.Diagnostics.AddError("Invalid compound import ID", err.Error())
+			return
+		}
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_uuid"), parsed.ProjectUUID)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("server_uuid"), parsed.ServerUUID)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_name"), parsed.EnvironmentName)...)
 	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), parsed.UUID)...)
 }
 
 // DatabaseExtendedPtrs groups pointers to extended database model fields

--- a/internal/service/database/dbtest/mock_server.go
+++ b/internal/service/database/dbtest/mock_server.go
@@ -162,26 +162,29 @@ func NewMockServer(dbType, name, image string, extraFields map[string]interface{
 			w.WriteHeader(http.StatusOK)
 
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/servers/") && strings.HasSuffix(r.URL.Path, "/resources"):
-			// Compound import validates server membership. Only the default
-			// test server UUID hosts this mock database.
-			const defaultServerUUID = "bbbb0001-0001-4000-8000-000000000001"
-			// Path: /api/v1/servers/{uuid}/resources
-			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-			serverUUID := ""
-			if len(parts) >= 4 {
-				serverUUID = parts[3]
-			}
-			if serverUUID == defaultServerUUID {
-				writeJSON(w, http.StatusOK, []map[string]string{
-					{"uuid": state.UUID, "name": state.Name, "type": "database"},
-				})
-			} else {
-				writeJSON(w, http.StatusOK, []map[string]string{})
-			}
+			writeServerResources(w, r.URL.Path, state)
 
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
 	})))
 	return srv, state
+}
+
+// writeServerResources answers GET /servers/{uuid}/resources for compound import.
+// Only the default test server UUID hosts the mock database.
+func writeServerResources(w http.ResponseWriter, path string, state *MockState) {
+	const defaultServerUUID = "bbbb0001-0001-4000-8000-000000000001"
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	serverUUID := ""
+	if len(parts) >= 4 {
+		serverUUID = parts[3]
+	}
+	if serverUUID != defaultServerUUID {
+		writeJSON(w, http.StatusOK, []map[string]string{})
+		return
+	}
+	writeJSON(w, http.StatusOK, []map[string]string{
+		{"uuid": state.UUID, "name": state.Name, "type": "database"},
+	})
 }

--- a/internal/service/database/dbtest/mock_server.go
+++ b/internal/service/database/dbtest/mock_server.go
@@ -161,6 +161,24 @@ func NewMockServer(dbType, name, image string, extraFields map[string]interface{
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/stop"):
 			w.WriteHeader(http.StatusOK)
 
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/servers/") && strings.HasSuffix(r.URL.Path, "/resources"):
+			// Compound import validates server membership. Only the default
+			// test server UUID hosts this mock database.
+			const defaultServerUUID = "bbbb0001-0001-4000-8000-000000000001"
+			// Path: /api/v1/servers/{uuid}/resources
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			serverUUID := ""
+			if len(parts) >= 4 {
+				serverUUID = parts[3]
+			}
+			if serverUUID == defaultServerUUID {
+				writeJSON(w, http.StatusOK, []map[string]string{
+					{"uuid": state.UUID, "name": state.Name, "type": "database"},
+				})
+			} else {
+				writeJSON(w, http.StatusOK, []map[string]string{})
+			}
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/service/database/dragonfly/resource.go
+++ b/internal/service/database/dragonfly/resource.go
@@ -146,7 +146,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_dragonfly", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/database/keydb/resource.go
+++ b/internal/service/database/keydb/resource.go
@@ -151,7 +151,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_keydb", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/database/mariadb/resource.go
+++ b/internal/service/database/mariadb/resource.go
@@ -168,7 +168,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_mariadb", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/database/mongodb/resource.go
+++ b/internal/service/database/mongodb/resource.go
@@ -163,7 +163,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_mongodb", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/database/mysql/resource.go
+++ b/internal/service/database/mysql/resource.go
@@ -182,7 +182,7 @@ func (r *mysqlDatabaseResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *mysqlDatabaseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 
 func flattenDatabase(db *client.Database, m *mysqlDatabaseResourceModel) {

--- a/internal/service/database/postgresql/resource.go
+++ b/internal/service/database/postgresql/resource.go
@@ -217,7 +217,7 @@ func (r *postgresqlDatabaseResource) Delete(ctx context.Context, req resource.De
 }
 
 func (r *postgresqlDatabaseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 
 func flattenDatabase(db *client.Database, m *postgresqlDatabaseResourceModel) {

--- a/internal/service/database/postgresql/resource_test.go
+++ b/internal/service/database/postgresql/resource_test.go
@@ -584,6 +584,42 @@ resource "coolify_database_postgresql" "test" {
 	})
 }
 
+func TestPostgresqlDatabaseResource_ImportCompoundWrongServer(t *testing.T) {
+	t.Parallel()
+	srv, state := dbtest.NewMockServer("postgresql", "pg-test-db", "postgres:16", map[string]interface{}{
+		"postgres_user":     "postgres",
+		"postgres_password": "secret123",
+		"postgres_db":       "defaultdb",
+	})
+	defer srv.Close()
+
+	const (
+		projUUID     = "aaaa0001-0001-4000-8000-000000000001"
+		wrongSrvUUID = "bbbb0002-0002-4000-8000-000000000002"
+		envName      = "production"
+	)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_database_postgresql" "test" {
+  project_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
+}
+`,
+			},
+			{
+				ResourceName:  "coolify_database_postgresql.test",
+				ImportState:   true,
+				ImportStateId: projUUID + ":" + wrongSrvUUID + ":" + envName + ":" + state.UUID,
+				ExpectError:   regexp.MustCompile(`is not deployed on server`),
+			},
+		},
+	})
+}
+
 // ---------------------------------------------------------------------------
 // TestPostgresqlDatabaseResource_ImportCompoundBadParts
 // ---------------------------------------------------------------------------

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -150,7 +150,7 @@ func (r *res) Delete(ctx context.Context, req resource.DeleteRequest, resp *reso
 	dbcommon.DeleteDatabaseState(ctx, r.client, "coolify_database_redis", s.UUID.ValueString(), resp)
 }
 func (r *res) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	dbcommon.ImportDatabaseState(ctx, req, resp)
+	dbcommon.ImportDatabaseState(ctx, r.client, req, resp)
 }
 func flattenDatabase(db *client.Database, m *model) {
 	dbcommon.FlattenDatabaseCommon(db, m.CommonPtrs())

--- a/internal/service/server/data_source_domains.go
+++ b/internal/service/server/data_source_domains.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
@@ -87,9 +88,11 @@ func (d *serverDomainsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_server_domains"})
 
-	domains, err := d.client.ListServerDomains(ctx, config.ServerUUID.ValueString())
+	serverUUID := config.ServerUUID.ValueString()
+	domains, err := d.client.ListServerDomains(ctx, serverUUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error listing server domains", err.Error())
+		resp.Diagnostics.AddError("Error listing server domains",
+			fmt.Sprintf("server %s: %s", serverUUID, err))
 		return
 	}
 

--- a/internal/service/server/data_source_resources.go
+++ b/internal/service/server/data_source_resources.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
@@ -92,9 +93,11 @@ func (d *serverResourcesDataSource) Read(ctx context.Context, req datasource.Rea
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_server_resources"})
 
-	resources, err := d.client.ListServerResources(ctx, config.ServerUUID.ValueString())
+	serverUUID := config.ServerUUID.ValueString()
+	resources, err := d.client.ListServerResources(ctx, serverUUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error listing server resources", err.Error())
+		resp.Diagnostics.AddError("Error listing server resources",
+			fmt.Sprintf("server %s: %s", serverUUID, err))
 		return
 	}
 

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -422,12 +422,16 @@ func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportSt
 		resp.Diagnostics.AddError("Invalid Import ID", err.Error())
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), parsed.UUID)...)
 	if compound {
+		if err := r.client.ValidateResourceOnServer(ctx, parsed.ServerUUID, parsed.UUID, "service"); err != nil {
+			resp.Diagnostics.AddError("Invalid compound import ID", err.Error())
+			return
+		}
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_uuid"), parsed.ProjectUUID)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("server_uuid"), parsed.ServerUUID)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_name"), parsed.EnvironmentName)...)
 	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), parsed.UUID)...)
 	resp.Diagnostics.AddWarning(
 		"Sensitive fields require token permissions",
 		"The Coolify API hides docker_compose and docker_compose_raw unless the API token has \"root\" or \"read:sensitive\" permission. "+

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -154,6 +154,21 @@ func newMockServiceServer() (*httptest.Server, *mockServiceState) {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/stop"):
 			w.WriteHeader(http.StatusOK)
 
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/servers/") && strings.HasSuffix(r.URL.Path, "/resources"):
+			const defaultServerUUID = "bbbb0001-0001-4000-8000-000000000001"
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			serverUUID := ""
+			if len(parts) >= 4 {
+				serverUUID = parts[3]
+			}
+			if serverUUID == defaultServerUUID {
+				json.NewEncoder(w).Encode([]map[string]string{
+					{"uuid": state.uuid, "name": state.name, "type": "service"},
+				})
+			} else {
+				json.NewEncoder(w).Encode([]map[string]string{})
+			}
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -679,6 +694,38 @@ func TestServiceResource_ImportCompound(t *testing.T) {
 					}
 					return nil
 				},
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestServiceResource_ImportCompoundWrongServer
+// ---------------------------------------------------------------------------
+
+func TestServiceResource_ImportCompoundWrongServer(t *testing.T) {
+	t.Parallel()
+	srv, _ := newMockServiceServer()
+	defer srv.Close()
+
+	const (
+		projUUID     = "aaaa0001-0001-4000-8000-000000000001"
+		wrongSrvUUID = "bbbb0002-0002-4000-8000-000000000002"
+		svcUUID      = "dddd0001-0001-4000-8000-000000000001"
+		envName      = "production"
+	)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: serviceConfig(srv.URL),
+			},
+			{
+				ResourceName:  "coolify_service.test",
+				ImportState:   true,
+				ImportStateId: projUUID + ":" + wrongSrvUUID + ":" + envName + ":" + svcUUID,
+				ExpectError:   regexp.MustCompile(`is not deployed on server`),
 			},
 		},
 	})

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -55,11 +55,11 @@ UUID format still works but may require you to set these fields manually in
 your `.tf` configuration.
 
 -> **Warning:** The `server_uuid` segment must be the server that actually hosts
-the resource. Coolify application GET responses do not return `server_uuid`, so
-a wrong value is not corrected on refresh. On replace, Terraform would recreate
-the resource on the wrong server. Application compound import validates that
-the application appears in `GET /servers/{server_uuid}/resources` and fails if
-it does not.
+the resource. Coolify GET responses often omit `server_uuid`, so a wrong value
+is not corrected on refresh. On replace, Terraform would recreate the resource
+on the wrong server. Compound import for applications, databases, and services
+validates membership via `GET /servers/{server_uuid}/resources` and fails if
+the resource is not listed on that server.
 
 ~> **Note:** Top-level S3 storages are managed in the Coolify web UI. When
 `coolify_database_backup` uses `save_s3 = true`, set `s3_storage_uuid` to an

--- a/templates/guides/secrets-management.md.tmpl
+++ b/templates/guides/secrets-management.md.tmpl
@@ -129,6 +129,7 @@ if the API token lacks permissions, these fields will be empty in state.
 | `coolify_private_key` | `private_key` | Requires `root` or `read:sensitive` token |
 | `coolify_cloud_token` | `token` | Write-only, never returned by API |
 | `coolify_github_app` | `client_secret`, `webhook_secret`, `private_key_uuid` | Write-only. If `webhook_secret` was auto-generated on create, keep that generated value in your secret store or Terraform variables before import because Coolify will not return it later. |
+| Application resources (`coolify_application*`) | `manual_webhook_secret_*`, `http_basic_auth_password`, `dockerfile` (content) | Encrypted secrets are hidden without root / `read:sensitive`. Coolify auto-generates webhook secrets when omitted on create; the provider preserves configured values when GET returns empty. |
 | `coolify_environment_variable` | `value` | May be hidden without sensitive permissions |
 
 **After importing a resource with hidden fields:**


### PR DESCRIPTION
## Summary

MPI cycle improvement: extend the application compound-import server safety check (#576) to databases and services, plus related docs and diagnostics.

## Changes

- Shared `client.ValidateResourceOnServer` used by applications, databases, and services on compound import
- Fail import when the resource is not listed on `GET /servers/{uuid}/resources`
- Mock servers return membership only for the default test server UUID
- Unit tests: wrong-server import for postgresql and service; ValidateResourceOnServer match/miss/nil
- Import guide: multi-resource compound import warning
- Secrets guide: application `manual_webhook_secret_*` hide/auto-gen behavior
- Server data sources: include server UUID in list error messages
- Documented test floor 980+

## Validation

- `make ci` (local)
- Package tests for client, application, database/*, service, server

## Note

Release PR #571 (v0.1.8) is open and was **not** merged (needs explicit approval).