### PR TITLE
refactor: share cloud server helpers and harden CI runners

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
       scenarios: ${{ steps.filter.outputs.scenarios }}
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -74,6 +79,11 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -112,6 +122,11 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -173,6 +188,11 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -218,6 +238,11 @@ jobs:
         github.event_name == 'workflow_dispatch'
       )
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -321,6 +346,11 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -390,6 +420,11 @@ jobs:
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -516,6 +551,11 @@ jobs:
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -586,6 +626,11 @@ jobs:
     timeout-minutes: 2
     needs: [dco, test, lint, validate, scenario-tests, acceptance-tests]
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - name: Check results
         run: |
           results='${{ toJSON(needs.*.result) }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,11 @@ jobs:
           - language: actions
             build-mode: none
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/coolify-channels.yml
+++ b/.github/workflows/coolify-channels.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,6 +20,11 @@ jobs:
     timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -25,6 +25,11 @@ jobs:
         && github.actor != 'dependabot[bot]'
       )
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -38,6 +43,11 @@ jobs:
     timeout-minutes: 10
     needs: fossa
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - name: Add triage label for external authors
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -30,6 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,6 +22,11 @@ jobs:
     timeout-minutes: 5
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - name: Check PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       # Use a GitHub App token so that release-please PR pushes trigger
       # pull_request events (GITHUB_TOKEN suppresses them, which prevents
       # CI and auto-approve from running on the release PR).
@@ -69,6 +74,11 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.release-please.outputs.tag_name || github.event.inputs.tag || github.ref_name }}
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,6 +23,11 @@ jobs:
       security-events: write
       id-token: write
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           stale-issue-message: >

--- a/.github/workflows/test-cloud-bootstrap.yml
+++ b/.github/workflows/test-cloud-bootstrap.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden runner
+        if: runner.os == 'Linux'
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit

--- a/internal/service/digitalocean/resource.go
+++ b/internal/service/digitalocean/resource.go
@@ -208,21 +208,7 @@ func (r *digitalOceanServerResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
-	if plan.Description.IsUnknown() {
-		plan.Description = types.StringNull()
-	}
-	if plan.IP.IsUnknown() {
-		plan.IP = types.StringNull()
-	}
-	if plan.IsReachable.IsUnknown() {
-		plan.IsReachable = types.BoolNull()
-	}
-	if plan.IsUsable.IsUnknown() {
-		plan.IsUsable = types.BoolNull()
-	}
-	if plan.ServerDiskUsageCheckFrequency.IsUnknown() {
-		plan.ServerDiskUsageCheckFrequency = types.StringNull()
-	}
+	server.NormalizeUnknownCloudServerPlanFields(plan.commonPtrs())
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -230,21 +216,11 @@ func (r *digitalOceanServerResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	// The DigitalOcean create endpoint only accepts DigitalOcean-specific fields.
-	// General server fields (description, port, user, is_build_server)
-	// and settings must be applied via a follow-up PATCH.
-	if hasNonDefaultDigitalOceanSettings(plan) {
-		settingsUpdate := server.BuildPostCreateSettingsInput(plan.commonPtrs())
-		// DigitalOcean Create doesn't accept these core fields; add them to the PATCH.
-		settingsUpdate.Description = flex.StringValueOrNull(plan.Description)
-		settingsUpdate.Port = flex.IntIfNonDefault(plan.Port, 22)
-		settingsUpdate.User = flex.StringValueOrNull(plan.User)
-		settingsUpdate.IsBuildServer = flex.BoolValueOrNull(plan.IsBuildServer)
-		if _, err := r.client.UpdateServer(ctx, created.UUID, settingsUpdate); err != nil {
-			resp.Diagnostics.AddError("Error setting DigitalOcean server settings",
-				fmt.Sprintf("server %s: %s", created.UUID, err))
-			return
-		}
+	// Cloud create endpoints only accept provider-specific fields; shared
+	// settings/core fields need a follow-up PATCH when non-default.
+	if err := server.ApplyPostCreateCloudProviderSettings(ctx, r.client, created.UUID, plan.commonPtrs()); err != nil {
+		resp.Diagnostics.AddError("Error setting DigitalOcean server settings", err.Error())
+		return
 	}
 
 	// Read back for full state.
@@ -343,14 +319,6 @@ func (r *digitalOceanServerResource) ImportState(ctx context.Context, req resour
 		return
 	}
 	resource.ImportStatePassthroughID(ctx, path.Root("uuid"), req, resp)
-}
-
-func hasNonDefaultDigitalOceanSettings(plan digitalOceanServerResourceModel) bool {
-	return flex.StringValueNonDefault(plan.Description, "") ||
-		flex.Int64ValueNonDefault(plan.Port, 22) ||
-		flex.StringValueNonDefault(plan.User, "root") ||
-		flex.BoolValueNonDefault(plan.IsBuildServer, false) ||
-		server.HasNonDefaultSettings(plan.commonPtrs())
 }
 
 func (m *digitalOceanServerResourceModel) commonPtrs() server.ServerCommonPtrs {

--- a/internal/service/hetzner/hasnondefault_test.go
+++ b/internal/service/hetzner/hasnondefault_test.go
@@ -3,6 +3,7 @@ package hetzner
 import (
 	"testing"
 
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/server"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -21,14 +22,15 @@ func defaultHetznerPlan() hetznerServerResourceModel {
 	}
 }
 
-func TestHasNonDefaultHetznerSettings_AllDefaults(t *testing.T) {
+func TestHasNonDefaultCloudProviderSettings_ViaHetznerModel(t *testing.T) {
 	t.Parallel()
-	if hasNonDefaultHetznerSettings(defaultHetznerPlan()) {
+	m := defaultHetznerPlan()
+	if server.HasNonDefaultCloudProviderSettings(m.commonPtrs()) {
 		t.Error("expected false when all fields are at their defaults")
 	}
 }
 
-func TestHasNonDefaultHetznerSettings_EachField(t *testing.T) {
+func TestHasNonDefaultCloudProviderSettings_EachHetznerField(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name   string
@@ -54,17 +56,17 @@ func TestHasNonDefaultHetznerSettings_EachField(t *testing.T) {
 			t.Parallel()
 			m := defaultHetznerPlan()
 			tc.mutate(&m)
-			if !hasNonDefaultHetznerSettings(m) {
+			if !server.HasNonDefaultCloudProviderSettings(m.commonPtrs()) {
 				t.Errorf("expected true when %s is non-default", tc.name)
 			}
 		})
 	}
 }
 
-func TestHasNonDefaultHetznerSettings_NullFields(t *testing.T) {
+func TestHasNonDefaultCloudProviderSettings_NullHetznerFields(t *testing.T) {
 	t.Parallel()
 	plan := hetznerServerResourceModel{}
-	if hasNonDefaultHetznerSettings(plan) {
+	if server.HasNonDefaultCloudProviderSettings((&plan).commonPtrs()) {
 		t.Error("expected false when all fields are null/zero-value")
 	}
 }

--- a/internal/service/hetzner/resource.go
+++ b/internal/service/hetzner/resource.go
@@ -201,21 +201,7 @@ func (r *hetznerServerResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
-	if plan.Description.IsUnknown() {
-		plan.Description = types.StringNull()
-	}
-	if plan.IP.IsUnknown() {
-		plan.IP = types.StringNull()
-	}
-	if plan.IsReachable.IsUnknown() {
-		plan.IsReachable = types.BoolNull()
-	}
-	if plan.IsUsable.IsUnknown() {
-		plan.IsUsable = types.BoolNull()
-	}
-	if plan.ServerDiskUsageCheckFrequency.IsUnknown() {
-		plan.ServerDiskUsageCheckFrequency = types.StringNull()
-	}
+	server.NormalizeUnknownCloudServerPlanFields(plan.commonPtrs())
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -223,21 +209,11 @@ func (r *hetznerServerResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	// The Hetzner create endpoint only accepts Hetzner-specific fields.
-	// General server fields (description, port, user, is_build_server)
-	// and settings must be applied via a follow-up PATCH.
-	if hasNonDefaultHetznerSettings(plan) {
-		settingsUpdate := server.BuildPostCreateSettingsInput(plan.commonPtrs())
-		// Hetzner Create doesn't accept these core fields; add them to the PATCH.
-		settingsUpdate.Description = flex.StringValueOrNull(plan.Description)
-		settingsUpdate.Port = flex.IntIfNonDefault(plan.Port, 22)
-		settingsUpdate.User = flex.StringValueOrNull(plan.User)
-		settingsUpdate.IsBuildServer = flex.BoolValueOrNull(plan.IsBuildServer)
-		if _, err := r.client.UpdateServer(ctx, created.UUID, settingsUpdate); err != nil {
-			resp.Diagnostics.AddError("Error setting Hetzner server settings",
-				fmt.Sprintf("server %s: %s", created.UUID, err))
-			return
-		}
+	// Cloud create endpoints only accept provider-specific fields; shared
+	// settings/core fields need a follow-up PATCH when non-default.
+	if err := server.ApplyPostCreateCloudProviderSettings(ctx, r.client, created.UUID, plan.commonPtrs()); err != nil {
+		resp.Diagnostics.AddError("Error setting Hetzner server settings", err.Error())
+		return
 	}
 
 	// Read back for full state.
@@ -336,14 +312,6 @@ func (r *hetznerServerResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 	resource.ImportStatePassthroughID(ctx, path.Root("uuid"), req, resp)
-}
-
-func hasNonDefaultHetznerSettings(plan hetznerServerResourceModel) bool {
-	return flex.StringValueNonDefault(plan.Description, "") ||
-		flex.Int64ValueNonDefault(plan.Port, 22) ||
-		flex.StringValueNonDefault(plan.User, "root") ||
-		flex.BoolValueNonDefault(plan.IsBuildServer, false) ||
-		server.HasNonDefaultSettings(plan.commonPtrs())
 }
 
 func (m *hetznerServerResourceModel) commonPtrs() server.ServerCommonPtrs {

--- a/internal/service/server/common.go
+++ b/internal/service/server/common.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
@@ -296,6 +297,63 @@ func BuildPostCreateSettingsInput(p ServerCommonPtrs) client.UpdateServerInput {
 		ServerDiskUsageNotificationThreshold: flex.IntIfNonDefault(*p.ServerDiskUsageNotificationThreshold, 80),
 		ServerDiskUsageCheckFrequency:        flex.StringValueOrNull(*p.ServerDiskUsageCheckFrequency),
 	}
+}
+
+// HasNonDefaultCloudProviderSettings reports whether a cloud-provisioned
+// server (Hetzner/DigitalOcean/Vultr) needs a post-create PATCH. Cloud create
+// endpoints only accept provider-specific fields, so description/port/user/
+// is_build_server and extended settings must be applied afterward when non-default.
+func HasNonDefaultCloudProviderSettings(p ServerCommonPtrs) bool {
+	return flex.StringValueNonDefault(*p.Description, "") ||
+		flex.Int64ValueNonDefault(*p.Port, 22) ||
+		flex.StringValueNonDefault(*p.User, "root") ||
+		flex.BoolValueNonDefault(*p.IsBuildServer, false) ||
+		HasNonDefaultSettings(p)
+}
+
+// BuildPostCreateCloudProviderInput builds the follow-up PATCH body for
+// Hetzner/DigitalOcean/Vultr servers after provider-specific create.
+func BuildPostCreateCloudProviderInput(p ServerCommonPtrs) client.UpdateServerInput {
+	input := BuildPostCreateSettingsInput(p)
+	// Core fields the cloud create endpoints do not accept.
+	input.Description = flex.StringValueOrNull(*p.Description)
+	input.Port = flex.IntIfNonDefault(*p.Port, 22)
+	input.User = flex.StringValueOrNull(*p.User)
+	input.IsBuildServer = flex.BoolValueOrNull(*p.IsBuildServer)
+	return input
+}
+
+// NormalizeUnknownCloudServerPlanFields resolves Optional+Computed fields
+// that remain unknown after create so partial state is valid before
+// read-back (cloud providers often leave IP/reachability unknown at create).
+func NormalizeUnknownCloudServerPlanFields(p ServerCommonPtrs) {
+	if p.Description != nil && p.Description.IsUnknown() {
+		*p.Description = types.StringNull()
+	}
+	if p.IP != nil && p.IP.IsUnknown() {
+		*p.IP = types.StringNull()
+	}
+	if p.IsReachable != nil && p.IsReachable.IsUnknown() {
+		*p.IsReachable = types.BoolNull()
+	}
+	if p.IsUsable != nil && p.IsUsable.IsUnknown() {
+		*p.IsUsable = types.BoolNull()
+	}
+	if p.ServerDiskUsageCheckFrequency != nil && p.ServerDiskUsageCheckFrequency.IsUnknown() {
+		*p.ServerDiskUsageCheckFrequency = types.StringNull()
+	}
+}
+
+// ApplyPostCreateCloudProviderSettings sends the shared post-create PATCH
+// when HasNonDefaultCloudProviderSettings is true. No-op when all defaults.
+func ApplyPostCreateCloudProviderSettings(ctx context.Context, c *client.Client, uuid string, p ServerCommonPtrs) error {
+	if !HasNonDefaultCloudProviderSettings(p) {
+		return nil
+	}
+	if _, err := c.UpdateServer(ctx, uuid, BuildPostCreateCloudProviderInput(p)); err != nil {
+		return fmt.Errorf("server %s: %w", uuid, err)
+	}
+	return nil
 }
 
 // BuildServerUpdateInput constructs an UpdateServerInput from the diff

--- a/internal/service/server/common_test.go
+++ b/internal/service/server/common_test.go
@@ -636,6 +636,124 @@ func TestHasNonDefaultSettings_ViaCommonPtrs(t *testing.T) {
 	}
 }
 
+func cloudProviderDefaultPtrs() (ServerCommonPtrs, *testModel) {
+	ptrs, m := newTestPtrs()
+	m.Description = types.StringValue("")
+	m.Port = types.Int64Value(22)
+	m.User = types.StringValue("root")
+	m.IsBuildServer = types.BoolValue(false)
+	m.ConcurrentBuilds = types.Int64Value(2)
+	m.DynamicTimeout = types.Int64Value(3600)
+	m.DeploymentQueueLimit = types.Int64Value(25)
+	m.ConnectionTimeout = types.Int64Value(10)
+	m.ServerDiskUsageNotificationThreshold = types.Int64Value(80)
+	m.ServerDiskUsageCheckFrequency = types.StringNull()
+	return ptrs, m
+}
+
+func TestHasNonDefaultCloudProviderSettings_AllDefaults(t *testing.T) {
+	t.Parallel()
+	ptrs, _ := cloudProviderDefaultPtrs()
+	if HasNonDefaultCloudProviderSettings(ptrs) {
+		t.Error("expected false when core fields and settings are at defaults")
+	}
+}
+
+func TestHasNonDefaultCloudProviderSettings_CoreFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(*testModel)
+	}{
+		{"Description", func(m *testModel) { m.Description = types.StringValue("prod") }},
+		{"Port", func(m *testModel) { m.Port = types.Int64Value(2222) }},
+		{"User", func(m *testModel) { m.User = types.StringValue("deploy") }},
+		{"IsBuildServer", func(m *testModel) { m.IsBuildServer = types.BoolValue(true) }},
+		{"ConcurrentBuilds", func(m *testModel) { m.ConcurrentBuilds = types.Int64Value(8) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ptrs, m := cloudProviderDefaultPtrs()
+			tc.mutate(m)
+			if !HasNonDefaultCloudProviderSettings(ptrs) {
+				t.Errorf("expected true when %s is non-default", tc.name)
+			}
+		})
+	}
+}
+
+func TestBuildPostCreateCloudProviderInput(t *testing.T) {
+	t.Parallel()
+	ptrs, m := cloudProviderDefaultPtrs()
+	m.Description = types.StringValue("edge node")
+	m.Port = types.Int64Value(2222)
+	m.User = types.StringValue("deploy")
+	m.IsBuildServer = types.BoolValue(true)
+	m.ConcurrentBuilds = types.Int64Value(4)
+
+	input := BuildPostCreateCloudProviderInput(ptrs)
+	if input.Description == nil || *input.Description != "edge node" {
+		t.Fatalf("Description = %v, want edge node", input.Description)
+	}
+	if input.Port == nil || *input.Port != 2222 {
+		t.Fatalf("Port = %v, want 2222", input.Port)
+	}
+	if input.User == nil || *input.User != "deploy" {
+		t.Fatalf("User = %v, want deploy", input.User)
+	}
+	if input.IsBuildServer == nil || !*input.IsBuildServer {
+		t.Fatalf("IsBuildServer = %v, want true", input.IsBuildServer)
+	}
+	if input.ConcurrentBuilds == nil || *input.ConcurrentBuilds != 4 {
+		t.Fatalf("ConcurrentBuilds = %v, want 4", input.ConcurrentBuilds)
+	}
+	// Provider-specific create owns Name/IP; post-create PATCH must not resend them.
+	if input.Name != nil {
+		t.Errorf("Name should be nil, got %v", *input.Name)
+	}
+	if input.IP != nil {
+		t.Errorf("IP should be nil, got %v", *input.IP)
+	}
+}
+
+func TestNormalizeUnknownCloudServerPlanFields(t *testing.T) {
+	t.Parallel()
+	ptrs, m := newTestPtrs()
+	m.Description = types.StringUnknown()
+	m.IP = types.StringUnknown()
+	m.IsReachable = types.BoolUnknown()
+	m.IsUsable = types.BoolUnknown()
+	m.ServerDiskUsageCheckFrequency = types.StringUnknown()
+
+	NormalizeUnknownCloudServerPlanFields(ptrs)
+
+	if !m.Description.IsNull() {
+		t.Errorf("Description = %v, want null", m.Description)
+	}
+	if !m.IP.IsNull() {
+		t.Errorf("IP = %v, want null", m.IP)
+	}
+	if !m.IsReachable.IsNull() {
+		t.Errorf("IsReachable = %v, want null", m.IsReachable)
+	}
+	if !m.IsUsable.IsNull() {
+		t.Errorf("IsUsable = %v, want null", m.IsUsable)
+	}
+	if !m.ServerDiskUsageCheckFrequency.IsNull() {
+		t.Errorf("ServerDiskUsageCheckFrequency = %v, want null", m.ServerDiskUsageCheckFrequency)
+	}
+}
+
+func TestApplyPostCreateCloudProviderSettings_SkipsDefaults(t *testing.T) {
+	t.Parallel()
+	// No HTTP client needed when all defaults: helper must no-op without calling Update.
+	ptrs, _ := cloudProviderDefaultPtrs()
+	if err := ApplyPostCreateCloudProviderSettings(context.Background(), nil, "uuid", ptrs); err != nil {
+		t.Fatalf("expected nil error on defaults, got %v", err)
+	}
+}
+
 func TestHasNonDefaultSettings_AllDefaults(t *testing.T) {
 	t.Parallel()
 	plan := serverResourceModel{

--- a/internal/service/vultr/resource.go
+++ b/internal/service/vultr/resource.go
@@ -210,21 +210,7 @@ func (r *vultrServerResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	plan.UUID = types.StringValue(created.UUID)
-	if plan.Description.IsUnknown() {
-		plan.Description = types.StringNull()
-	}
-	if plan.IP.IsUnknown() {
-		plan.IP = types.StringNull()
-	}
-	if plan.IsReachable.IsUnknown() {
-		plan.IsReachable = types.BoolNull()
-	}
-	if plan.IsUsable.IsUnknown() {
-		plan.IsUsable = types.BoolNull()
-	}
-	if plan.ServerDiskUsageCheckFrequency.IsUnknown() {
-		plan.ServerDiskUsageCheckFrequency = types.StringNull()
-	}
+	server.NormalizeUnknownCloudServerPlanFields(plan.commonPtrs())
 
 	// Save partial state so the resource is tracked even if the read-back fails.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -232,21 +218,11 @@ func (r *vultrServerResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	// The Vultr create endpoint only accepts Vultr-specific fields.
-	// General server fields (description, port, user, is_build_server)
-	// and settings must be applied via a follow-up PATCH.
-	if hasNonDefaultVultrSettings(plan) {
-		settingsUpdate := server.BuildPostCreateSettingsInput(plan.commonPtrs())
-		// Vultr Create doesn't accept these core fields; add them to the PATCH.
-		settingsUpdate.Description = flex.StringValueOrNull(plan.Description)
-		settingsUpdate.Port = flex.IntIfNonDefault(plan.Port, 22)
-		settingsUpdate.User = flex.StringValueOrNull(plan.User)
-		settingsUpdate.IsBuildServer = flex.BoolValueOrNull(plan.IsBuildServer)
-		if _, err := r.client.UpdateServer(ctx, created.UUID, settingsUpdate); err != nil {
-			resp.Diagnostics.AddError("Error setting Vultr server settings",
-				fmt.Sprintf("server %s: %s", created.UUID, err))
-			return
-		}
+	// Cloud create endpoints only accept provider-specific fields; shared
+	// settings/core fields need a follow-up PATCH when non-default.
+	if err := server.ApplyPostCreateCloudProviderSettings(ctx, r.client, created.UUID, plan.commonPtrs()); err != nil {
+		resp.Diagnostics.AddError("Error setting Vultr server settings", err.Error())
+		return
 	}
 
 	// Read back for full state.
@@ -345,14 +321,6 @@ func (r *vultrServerResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 	resource.ImportStatePassthroughID(ctx, path.Root("uuid"), req, resp)
-}
-
-func hasNonDefaultVultrSettings(plan vultrServerResourceModel) bool {
-	return flex.StringValueNonDefault(plan.Description, "") ||
-		flex.Int64ValueNonDefault(plan.Port, 22) ||
-		flex.StringValueNonDefault(plan.User, "root") ||
-		flex.BoolValueNonDefault(plan.IsBuildServer, false) ||
-		server.HasNonDefaultSettings(plan.commonPtrs())
 }
 
 func (m *vultrServerResourceModel) commonPtrs() server.ServerCommonPtrs {


### PR DESCRIPTION
## Summary

- **#596:** Extract shared post-create helpers for Hetzner/DigitalOcean/Vultr servers into `internal/service/server` so the three Create paths no longer duplicate the settings PATCH, unknown-field normalize, and non-default guards.
- **#597:** Add pinned `step-security/harden-runner@v2.20.0` as the first step of every workflow job (Linux-only via `runner.os == 'Linux'`, `egress-policy: audit`).

## Changes

### Cloud server consolidation
- `HasNonDefaultCloudProviderSettings`
- `BuildPostCreateCloudProviderInput`
- `NormalizeUnknownCloudServerPlanFields`
- `ApplyPostCreateCloudProviderSettings`
- Unit tests for the helpers; Hetzner model tests now call the shared API

Provider-specific create inputs stay in each package (location/server_type, region/size, plan/os_id).

### CI harden-runner
All 15 workflow files with jobs now start with harden-runner (including normalizing the existing social-preview step).

## Test plan
- [x] `go test ./internal/service/server/ ./internal/service/hetzner/ ./internal/service/digitalocean/ ./internal/service/vultr/`
- [x] `golangci-lint run` on those packages
- [x] `make actionlint-check`

Closes #596
Closes #597