### PR TITLE
docs: accurate Coolify version floor for storage_backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 | `coolify_database_backup` | Schedule automated database backups |
 | `coolify_scheduled_task` | Manage scheduled tasks on applications/services |
 | `coolify_storage` | Manage persistent storage volumes |
-| `coolify_storage_backup` | Schedule backups for storage volumes (Coolify tip/nightly after v4.2.0) |
+| `coolify_storage_backup` | Schedule backups for storage volumes (Coolify `v4.x` after [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946); not in tag `v4.2.0`) |
 | `coolify_cloud_token` | Manage cloud provider tokens (Hetzner, DigitalOcean, Vultr) |
 | `coolify_github_app` | Manage GitHub App integrations |
 | `coolify_envs_bulk` | Manage environment variables as a single atomic set |

--- a/docs/resources/storage_backup.md
+++ b/docs/resources/storage_backup.md
@@ -4,7 +4,7 @@ page_title: "coolify_storage_backup Resource - coolify"
 subcategory: ""
 description: |-
   Manages a Coolify scheduled backup for a persistent volume or directory storage attached to an application, database, or service.
-  Requires Coolify builds that include the volume backup API (PUT/DELETE .../storages/{storage_uuid}/backups), available on Coolify tip/nightly after v4.2.0.
+  Coolify version requirement: needs PUT/DELETE .../storages/{storage_uuid}/backups (VolumeBackupsController). That API landed on Coolify branch v4.x in coollabsio/coolify#10946 https://github.com/coollabsio/coolify/pull/10946 (merged 2026-07-20). It is not present in git tag v4.2.0 or stable CDN 4.1.2. There is no Coolify release tag yet that is known to include it; use a self-built or nightly image from v4.x after that merge. CDN nightly may still report version 4.2.0 even when tip commits are present, so do not treat the version string alone as proof.
   ~> API note: Coolify only exposes create/replace (PUT) and delete. There is no GET for the schedule. Read verifies the parent storage still exists via list and keeps schedule attributes from state. Out-of-band schedule edits may not appear until the next apply.
 ---
 
@@ -12,13 +12,15 @@ description: |-
 
 Manages a Coolify scheduled backup for a persistent volume or directory storage attached to an application, database, or service.
 
-Requires Coolify builds that include the volume backup API (`PUT/DELETE .../storages/{storage_uuid}/backups`), available on Coolify tip/nightly after v4.2.0.
+**Coolify version requirement:** needs `PUT/DELETE .../storages/{storage_uuid}/backups` (VolumeBackupsController). That API landed on Coolify branch `v4.x` in [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946) (merged 2026-07-20). It is **not** present in git tag `v4.2.0` or stable CDN `4.1.2`. There is no Coolify release tag yet that is known to include it; use a self-built or nightly image from `v4.x` after that merge. CDN nightly may still report version `4.2.0` even when tip commits are present, so do not treat the version string alone as proof.
 
 ~> **API note:** Coolify only exposes create/replace (PUT) and delete. There is no GET for the schedule. Read verifies the parent storage still exists via list and keeps schedule attributes from state. Out-of-band schedule edits may not appear until the next apply.
 
 ## Example Usage
 
 ```terraform
+# Requires Coolify v4.x with volume backup API (coollabsio/coolify#10946+).
+# Not available on git tag v4.2.0 or stable CDN 4.1.2.
 resource "coolify_storage_backup" "app_data" {
   application_uuid = coolify_application.api.uuid
   storage_uuid     = coolify_storage.data.uuid

--- a/examples/resources/coolify_storage_backup/resource.tf
+++ b/examples/resources/coolify_storage_backup/resource.tf
@@ -1,3 +1,5 @@
+# Requires Coolify v4.x with volume backup API (coollabsio/coolify#10946+).
+# Not available on git tag v4.2.0 or stable CDN 4.1.2.
 resource "coolify_storage_backup" "app_data" {
   application_uuid = coolify_application.api.uuid
   storage_uuid     = coolify_storage.data.uuid

--- a/internal/client/volume_backups.go
+++ b/internal/client/volume_backups.go
@@ -8,8 +8,11 @@ import (
 )
 
 // VolumeBackupSchedule is a Coolify scheduled backup for a persistent volume
-// or directory storage. API requires Coolify builds that include
-// VolumeBackupsController (tip / nightly after v4.2.0).
+// or directory storage.
+//
+// API requires VolumeBackupsController (PUT/DELETE .../storages/{uuid}/backups),
+// which landed on Coolify v4.x in coollabsio/coolify#10946 (2026-07-20). Not in
+// git tag v4.2.0 or stable 4.1.2; no later release tag is known to include it yet.
 type VolumeBackupSchedule struct {
 	UUID                     string  `json:"uuid"`
 	Message                  string  `json:"message,omitempty"`

--- a/internal/service/volumebackup/resource.go
+++ b/internal/service/volumebackup/resource.go
@@ -68,8 +68,13 @@ func (r *storageBackupResource) Schema(_ context.Context, _ resource.SchemaReque
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a Coolify scheduled backup for a persistent volume or directory storage " +
 			"attached to an application, database, or service.\n\n" +
-			"Requires Coolify builds that include the volume backup API " +
-			"(`PUT/DELETE .../storages/{storage_uuid}/backups`), available on Coolify tip/nightly after v4.2.0.\n\n" +
+			"**Coolify version requirement:** needs `PUT/DELETE .../storages/{storage_uuid}/backups` " +
+			"(VolumeBackupsController). That API landed on Coolify branch `v4.x` in " +
+			"[coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946) (merged 2026-07-20). " +
+			"It is **not** present in git tag `v4.2.0` or stable CDN `4.1.2`. " +
+			"There is no Coolify release tag yet that is known to include it; use a self-built or " +
+			"nightly image from `v4.x` after that merge. CDN nightly may still report version `4.2.0` " +
+			"even when tip commits are present, so do not treat the version string alone as proof.\n\n" +
 			"~> **API note:** Coolify only exposes create/replace (PUT) and delete. There is no GET for the schedule. " +
 			"Read verifies the parent storage still exists via list and keeps schedule attributes from state. " +
 			"Out-of-band schedule edits may not appear until the next apply.",

--- a/internal/service/volumebackup/resource_acc_test.go
+++ b/internal/service/volumebackup/resource_acc_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 // TestAccStorageBackupResource_CRUD exercises "coolify_storage_backup" against a real Coolify
-// instance that exposes PUT/DELETE .../storages/{uuid}/backups (tip/nightly after v4.2.0).
+// instance with VolumeBackupsController (Coolify v4.x after coollabsio/coolify#10946; not in tag v4.2.0).
 func TestAccStorageBackupResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	// Requires tip Coolify + an existing storage volume UUID. Wire full env when ready.
-	t.Skip("coolify_storage_backup acceptance needs Coolify tip volume-backup routes and a test storage UUID")
+	// Needs Coolify v4.x including #10946 + a disposable storage UUID. Unit tests cover the resource.
+	t.Skip("coolify_storage_backup acceptance needs Coolify v4.x with volume-backup routes (#10946+) and a test storage UUID")
 
 	appUUID := "00000000-0000-4000-8000-000000000001"
 	storUUID := "00000000-0000-4000-8000-000000000002"

--- a/testdata/contracts/coolify-v4.2.0.json
+++ b/testdata/contracts/coolify-v4.2.0.json
@@ -7158,40 +7158,6 @@
         "network",
         "type"
       ]
-    },
-    "VolumeBackupsController::validateUpsertRequest": {
-      "allowed_fields": [
-        "frequency",
-        "enabled",
-        "save_s3",
-        "disable_local_backup",
-        "stop_during_backup",
-        "s3_storage_uuid",
-        "retention_amount_locally",
-        "retention_days_locally",
-        "retention_max_storage_locally",
-        "retention_amount_s3",
-        "retention_days_s3",
-        "retention_max_storage_s3",
-        "timeout"
-      ]
-    },
-    "VolumeBackupsController::upsert": {
-      "allowed_fields": [
-        "frequency",
-        "enabled",
-        "save_s3",
-        "disable_local_backup",
-        "stop_during_backup",
-        "s3_storage_uuid",
-        "retention_amount_locally",
-        "retention_days_locally",
-        "retention_max_storage_locally",
-        "retention_amount_s3",
-        "retention_days_s3",
-        "retention_max_storage_s3",
-        "timeout"
-      ]
     }
   },
   "enums": {
@@ -7597,20 +7563,6 @@
       ]
     },
     {
-      "method": "DELETE",
-      "path": "/applications/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "destroy",
-      "middleware": []
-    },
-    {
-      "method": "PUT",
-      "path": "/applications/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "upsert",
-      "middleware": []
-    },
-    {
       "method": "GET",
       "path": "/applications/{uuid}/tags",
       "controller": "ApplicationsController",
@@ -8005,20 +7957,6 @@
       "middleware": [
         "api.ability:write"
       ]
-    },
-    {
-      "method": "DELETE",
-      "path": "/databases/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "destroy",
-      "middleware": []
-    },
-    {
-      "method": "PUT",
-      "path": "/databases/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "upsert",
-      "middleware": []
     },
     {
       "method": "GET",
@@ -9007,20 +8945,6 @@
       "middleware": [
         "api.ability:write"
       ]
-    },
-    {
-      "method": "DELETE",
-      "path": "/services/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "destroy",
-      "middleware": []
-    },
-    {
-      "method": "PUT",
-      "path": "/services/{uuid}/storages/{storage_uuid}/backups",
-      "controller": "VolumeBackupsController",
-      "action": "upsert",
-      "middleware": []
     },
     {
       "method": "GET",

--- a/testdata/contracts/coolify-v4.json
+++ b/testdata/contracts/coolify-v4.json
@@ -1,6 +1,6 @@
 {
   "version": "v4.2.0",
-  "extracted_from": "coollabsio/coolify@v4.2.0",
+  "extracted_from": "coollabsio/coolify@v4.2.0 plus v4.x volume-backup routes (PR #10946+)",
   "extracted_at": "2026-07-25T11:12:30.470822+00:00",
   "models": {
     "Application": {
@@ -9148,5 +9148,6 @@
         "api.ability:read"
       ]
     }
-  ]
+  ],
+  "notes": "Pin is based on v4.2.0 extract. Volume backup PUT/DELETE .../storages/{storage_uuid}/backups routes are from Coolify v4.x after PR coollabsio/coolify#10946 (merged 2026-07-20). They are NOT present in git tag v4.2.0. Nightly CDN may report version 4.2.0 while including tip commits."
 }


### PR DESCRIPTION
## Summary

We did not have a reliable Coolify semver for volume backup APIs. This corrects the docs and contracts.

### Findings (verified against coollabsio/coolify)
- API landed on `v4.x` via [#10946](https://github.com/coollabsio/coolify/pull/10946) (2026-07-20)
- **Not** in git tag `v4.2.0` (controller missing)
- **Not** on stable CDN `4.1.2`
- No later release tag known to include it; nightly CDN may still say `4.2.0`

### Changes
- Resource schema, client godoc, README, example comments, generated docs
- Remove volume-backup routes from `coolify-v4.2.0.json` (tag fidelity)
- Annotate pin `coolify-v4.json` provenance (v4.2.0 base + tip routes)