### PR TITLE
fix: accept Coolify bare human cron schedules

### DIFF
--- a/docs/guides/migration-from-community.md
+++ b/docs/guides/migration-from-community.md
@@ -16,7 +16,7 @@ This guide helps you migrate from the
 This provider is a complete rewrite using the Terraform Plugin Framework
 (not the older SDK v2). It offers:
 
-- **36 resources** vs. ~10 in the community provider
+- **37 resources** vs. ~10 in the community provider
 - **44 data sources** with filtering support
 - **890+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Define your entire [Coolify](https://coolify.io/) infrastructure as code. Deploy
 
 Coolify gives you a self-hosted PaaS with a great UI. This provider adds what the UI cannot: reproducible environments, pull-request-based infrastructure reviews, disaster recovery from state, and CI/CD integration. Whether you run a single VPS or manage Coolify for a team, Terraform turns your infrastructure into a reviewable, testable, git-tracked configuration.
 
-**36 resources, 54 data sources, 99%+ Coolify API coverage.**
+**37 resources, 54 data sources, 99%+ Coolify API coverage.**
 
 ## Requirements
 

--- a/docs/resources/database_backup.md
+++ b/docs/resources/database_backup.md
@@ -35,7 +35,7 @@ resource "coolify_database_backup" "daily" {
 ### Required
 
 - `database_uuid` (String) The UUID of the database to back up. Changing this forces a new resource.
-- `frequency` (String) Cron expression for backup schedule (e.g., `0 2 * * *` for daily at 2 AM, or `@daily`, `@hourly`, `@weekly`).
+- `frequency` (String) Cron or Coolify human schedule (e.g., `0 2 * * *`, `daily`, `@daily`, `hourly`). Bare names without `@` match Coolify VALID_CRON_STRINGS.
 
 ### Optional
 

--- a/docs/resources/scheduled_task.md
+++ b/docs/resources/scheduled_task.md
@@ -40,7 +40,7 @@ resource "coolify_scheduled_task" "health_check" {
 ### Required
 
 - `command` (String) The command to execute.
-- `frequency` (String) The cron expression for the schedule (e.g., `*/5 * * * *`).
+- `frequency` (String) Cron or Coolify human schedule (e.g., `*/5 * * * *`, `daily`, `@daily`). Six-field cron is allowed for tasks.
 - `name` (String) The name of the scheduled task.
 
 ### Optional

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -57,7 +57,7 @@ resource "coolify_server" "example" {
 - `dynamic_timeout` (Number) Timeout in seconds for Docker operations (pull, build, health check) during deployment.
 - `is_build_server` (Boolean) Whether this server is used for building applications.
 - `port` (Number) The SSH port of the server.
-- `server_disk_usage_check_frequency` (String) Cron expression for how often disk usage is checked (e.g., `*/5 * * * *` or `@daily`).
+- `server_disk_usage_check_frequency` (String) Cron or Coolify human schedule for how often disk usage is checked (e.g., `*/5 * * * *`, `daily`, `@daily`).
 - `server_disk_usage_notification_threshold` (Number) Disk usage percentage at which a notification is sent.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user` (String) The SSH user for connecting to the server.

--- a/docs/resources/server_digitalocean.md
+++ b/docs/resources/server_digitalocean.md
@@ -66,7 +66,7 @@ variable "digitalocean_token" {
 - `is_build_server` (Boolean) Whether this server is used for building applications.
 - `monitoring` (Boolean) Whether to enable DigitalOcean monitoring on the droplet. Defaults to true to match Coolify.
 - `port` (Number) The SSH port of the server.
-- `server_disk_usage_check_frequency` (String) Cron expression for how often disk usage is checked (e.g., `*/5 * * * *` or `@daily`).
+- `server_disk_usage_check_frequency` (String) Cron or Coolify human schedule for how often disk usage is checked (e.g., `*/5 * * * *`, `daily`, `@daily`).
 - `server_disk_usage_notification_threshold` (Number) Disk usage percentage at which a notification is sent.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user` (String) The SSH user for connecting to the server.

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -67,7 +67,7 @@ resource "coolify_server_hetzner" "example" {
 - `instant_validate` (Boolean) Whether to validate server connectivity immediately after creation.
 - `is_build_server` (Boolean) Whether this server is used for building applications.
 - `port` (Number) The SSH port of the server.
-- `server_disk_usage_check_frequency` (String) Cron expression for how often disk usage is checked (e.g., `*/5 * * * *` or `@daily`).
+- `server_disk_usage_check_frequency` (String) Cron or Coolify human schedule for how often disk usage is checked (e.g., `*/5 * * * *`, `daily`, `@daily`).
 - `server_disk_usage_notification_threshold` (Number) Disk usage percentage at which a notification is sent.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user` (String) The SSH user for connecting to the server.

--- a/docs/resources/server_vultr.md
+++ b/docs/resources/server_vultr.md
@@ -65,7 +65,7 @@ variable "vultr_token" {
 - `instant_validate` (Boolean) Whether to validate server connectivity immediately after creation. Defaults to false to match Coolify.
 - `is_build_server` (Boolean) Whether this server is used for building applications.
 - `port` (Number) The SSH port of the server.
-- `server_disk_usage_check_frequency` (String) Cron expression for how often disk usage is checked (e.g., `*/5 * * * *` or `@daily`).
+- `server_disk_usage_check_frequency` (String) Cron or Coolify human schedule for how often disk usage is checked (e.g., `*/5 * * * *`, `daily`, `@daily`).
 - `server_disk_usage_notification_threshold` (Number) Disk usage percentage at which a notification is sent.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user` (String) The SSH user for connecting to the server.

--- a/docs/resources/storage_backup.md
+++ b/docs/resources/storage_backup.md
@@ -36,7 +36,7 @@ resource "coolify_storage_backup" "app_data" {
 
 ### Required
 
-- `frequency` (String) Cron or Coolify human expression for the schedule (e.g. `0 2 * * *`, `@daily`).
+- `frequency` (String) Cron or Coolify human expression for the schedule (e.g. `0 2 * * *`, `daily`, `@daily`, `hourly`). Coolify also accepts `every_minute`, `weekly`, `monthly`, and `yearly` without `@`.
 - `storage_uuid` (String) UUID of the persistent volume or directory storage to back up. Changing this forces a new resource.
 
 ### Optional

--- a/internal/service/database/backup/resource.go
+++ b/internal/service/database/backup/resource.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -90,14 +88,9 @@ func (r *databaseBackupResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Validators: []validator.String{validate.UUID()},
 			},
 			"frequency": schema.StringAttribute{
-				MarkdownDescription: "Cron expression for backup schedule (e.g., `0 2 * * *` for daily at 2 AM, or `@daily`, `@hourly`, `@weekly`).",
+				MarkdownDescription: "Cron or Coolify human schedule (e.g., `0 2 * * *`, `daily`, `@daily`, `hourly`). Bare names without `@` match Coolify VALID_CRON_STRINGS.",
 				Required:            true,
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^(\S+\s+){4}\S+$|^@(annually|yearly|monthly|weekly|daily|hourly)$`),
-						"must be a valid cron expression (e.g., \"0 2 * * *\" or \"@daily\")",
-					),
-				},
+				Validators:          []validator.String{validate.CoolifyFrequency()},
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the backup schedule is active.",

--- a/internal/service/scheduledtask/resource.go
+++ b/internal/service/scheduledtask/resource.go
@@ -3,7 +3,6 @@ package scheduledtask
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
@@ -95,14 +94,9 @@ func (r *scheduledTaskResource) Schema(_ context.Context, _ resource.SchemaReque
 				Required:            true,
 			},
 			"frequency": schema.StringAttribute{
-				MarkdownDescription: "The cron expression for the schedule (e.g., `*/5 * * * *`).",
+				MarkdownDescription: "Cron or Coolify human schedule (e.g., `*/5 * * * *`, `daily`, `@daily`). Six-field cron is allowed for tasks.",
 				Required:            true,
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^(\S+\s+){4,5}\S+$|^@(annually|yearly|monthly|weekly|daily|hourly)$`),
-						"must be a valid cron expression (e.g., \"*/5 * * * *\" or \"@daily\")",
-					),
-				},
+				Validators:          []validator.String{validate.CoolifyFrequencyAllowSeconds()},
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the scheduled task is enabled (defaults to `true`).",

--- a/internal/service/server/common.go
+++ b/internal/service/server/common.go
@@ -3,14 +3,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -137,16 +135,11 @@ func CommonServerAttrs(ctx context.Context, extra map[string]schema.Attribute) m
 			Validators:          []validator.Int64{int64validator.Between(1, 100)},
 		},
 		"server_disk_usage_check_frequency": schema.StringAttribute{
-			MarkdownDescription: "Cron expression for how often disk usage is checked (e.g., `*/5 * * * *` or `@daily`).",
+			MarkdownDescription: "Cron or Coolify human schedule for how often disk usage is checked (e.g., `*/5 * * * *`, `daily`, `@daily`).",
 			Optional:            true,
 			Computed:            true,
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-			Validators: []validator.String{
-				stringvalidator.RegexMatches(
-					regexp.MustCompile(`^(\S+\s+){4}\S+$|^@(annually|yearly|monthly|weekly|daily|hourly)$`),
-					"must be a valid cron expression (e.g., \"*/5 * * * *\" or \"@daily\")",
-				),
-			},
+			Validators:          []validator.String{validate.CoolifyFrequency()},
 		},
 	}
 	addExtendedSettingsAttrs(attrs)

--- a/internal/service/volumebackup/resource.go
+++ b/internal/service/volumebackup/resource.go
@@ -3,7 +3,6 @@ package volumebackup
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
@@ -117,14 +116,9 @@ func (r *storageBackupResource) Schema(_ context.Context, _ resource.SchemaReque
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"frequency": schema.StringAttribute{
-				MarkdownDescription: "Cron or Coolify human expression for the schedule (e.g. `0 2 * * *`, `@daily`).",
+				MarkdownDescription: "Cron or Coolify human expression for the schedule (e.g. `0 2 * * *`, `daily`, `@daily`, `hourly`). Coolify also accepts `every_minute`, `weekly`, `monthly`, and `yearly` without `@`.",
 				Required:            true,
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^(\S+\s+){4}\S+$|^@(annually|yearly|monthly|weekly|daily|hourly)$`),
-						"must be a valid cron expression (e.g. \"0 2 * * *\") or @daily/@hourly/@weekly/etc.",
-					),
-				},
+				Validators:          []validator.String{validate.CoolifyFrequency()},
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the schedule is enabled. Defaults to true.",

--- a/internal/service/volumebackup/resource_test.go
+++ b/internal/service/volumebackup/resource_test.go
@@ -2,6 +2,7 @@ package volumebackup_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/spectest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -20,13 +22,18 @@ const (
 	schedUUID = "cccc0003-0003-4000-8000-000000000003"
 )
 
-func newVolumeBackupMock(t *testing.T) *httptest.Server {
+type volumeBackupMock struct {
+	server   *httptest.Server
+	mu       sync.Mutex
+	schedule *client.VolumeBackupSchedule
+}
+
+func newVolumeBackupMock(t *testing.T) *volumeBackupMock {
 	t.Helper()
-	var mu sync.Mutex
-	var schedule *client.VolumeBackupSchedule
-	return httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		defer mu.Unlock()
+	m := &volumeBackupMock{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/applications/"+appUUID+"/storages/"+storUUID+"/backups":
@@ -40,7 +47,7 @@ func newVolumeBackupMock(t *testing.T) *httptest.Server {
 				http.Error(w, `{"message":"validation failed"}`, http.StatusUnprocessableEntity)
 				return
 			}
-			created := schedule == nil
+			created := m.schedule == nil
 			enabled := true
 			if input.Enabled != nil {
 				enabled = *input.Enabled
@@ -81,7 +88,7 @@ func newVolumeBackupMock(t *testing.T) *httptest.Server {
 			if input.StopDuringBackup != nil {
 				stopDuring = *input.StopDuringBackup
 			}
-			schedule = &client.VolumeBackupSchedule{
+			m.schedule = &client.VolumeBackupSchedule{
 				UUID: schedUUID, StorageUUID: storUUID, StorageType: "persistent",
 				Frequency: input.Frequency, Enabled: enabled, SaveS3: saveS3,
 				DisableLocalBackup: disableLocal, StopDuringBackup: stopDuring,
@@ -96,35 +103,56 @@ func newVolumeBackupMock(t *testing.T) *httptest.Server {
 			} else {
 				w.WriteHeader(http.StatusOK)
 			}
-			_ = json.NewEncoder(w).Encode(schedule)
+			_ = json.NewEncoder(w).Encode(m.schedule)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/applications/"+appUUID+"/storages":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"persistent_storages": []client.Storage{{UUID: storUUID, Name: "data", MountPath: "/data"}},
 				"file_storages":       []client.Storage{},
 			})
 		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/applications/"+appUUID+"/storages/"+storUUID+"/backups":
-			if schedule == nil {
+			if m.schedule == nil {
 				http.Error(w, `{"message":"Storage backup schedule not found."}`, http.StatusNotFound)
 				return
 			}
-			schedule = nil
+			m.schedule = nil
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
 		default:
 			http.Error(w, `{}`, http.StatusNotFound)
 		}
-	})))
+	})
+	m.server = httptest.NewServer(spectest.WithSpecAudit(t, "coolify-v4",
+		acctest.WithVersionEndpoint(handler)))
+	return m
+}
+
+func (m *volumeBackupMock) Close() { m.server.Close() }
+
+func (m *volumeBackupMock) URL() string { return m.server.URL }
+
+// checkVolumeBackupDestroy fails if the mock still holds a schedule after destroy.
+// Coolify has no GET for schedules; mock state is the only signal.
+func (m *volumeBackupMock) checkDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.schedule != nil {
+			return fmt.Errorf("volume backup schedule still present after destroy (uuid=%s)", m.schedule.UUID)
+		}
+		return nil
+	}
 }
 
 func TestStorageBackupResource_CreateUpdateDelete(t *testing.T) {
 	t.Parallel()
-	srv := newVolumeBackupMock(t)
-	defer srv.Close()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             mock.checkDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderBlockForURL(srv.URL) + `
+				Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid = "` + appUUID + `"
   storage_uuid     = "` + storUUID + `"
@@ -137,10 +165,11 @@ resource "coolify_storage_backup" "test" {
 					resource.TestCheckResourceAttr("coolify_storage_backup.test", "storage_type", "persistent"),
 					resource.TestCheckResourceAttr("coolify_storage_backup.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("coolify_storage_backup.test", "timeout", "3600"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "retention_amount_locally", "7"),
 				),
 			},
 			{
-				Config: acctest.ProviderBlockForURL(srv.URL) + `
+				Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid = "` + appUUID + `"
   storage_uuid     = "` + storUUID + `"
@@ -155,7 +184,7 @@ resource "coolify_storage_backup" "test" {
 				),
 			},
 			{
-				Config: acctest.ProviderBlockForURL(srv.URL) + `
+				Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid = "` + appUUID + `"
   storage_uuid     = "` + storUUID + `"
@@ -194,12 +223,12 @@ resource "coolify_storage_backup" "test" {
 
 func TestStorageBackupResource_InvalidFrequency(t *testing.T) {
 	t.Parallel()
-	srv := newVolumeBackupMock(t)
-	defer srv.Close()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{{
-			Config: acctest.ProviderBlockForURL(srv.URL) + `
+			Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid = "` + appUUID + `"
   storage_uuid     = "` + storUUID + `"
@@ -210,14 +239,37 @@ resource "coolify_storage_backup" "test" {
 	})
 }
 
+func TestStorageBackupResource_HumanFrequencyDaily(t *testing.T) {
+	t.Parallel()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
+	// Coolify VALID_CRON_STRINGS accepts "daily" without "@".
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             mock.checkDestroy(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(mock.URL()) + `
+resource "coolify_storage_backup" "test" {
+  application_uuid = "` + appUUID + `"
+  storage_uuid     = "` + storUUID + `"
+  frequency        = "daily"
+}`,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_storage_backup.test", "frequency", "daily"),
+				resource.TestCheckResourceAttr("coolify_storage_backup.test", "uuid", schedUUID),
+			),
+		}},
+	})
+}
+
 func TestStorageBackupResource_DisableLocalWithoutS3(t *testing.T) {
 	t.Parallel()
-	srv := newVolumeBackupMock(t)
-	defer srv.Close()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{{
-			Config: acctest.ProviderBlockForURL(srv.URL) + `
+			Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid     = "` + appUUID + `"
   storage_uuid         = "` + storUUID + `"
@@ -230,15 +282,35 @@ resource "coolify_storage_backup" "test" {
 	})
 }
 
-func TestStorageBackupResource_Import(t *testing.T) {
+func TestStorageBackupResource_SaveS3WithoutUUID(t *testing.T) {
 	t.Parallel()
-	srv := newVolumeBackupMock(t)
-	defer srv.Close()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(mock.URL()) + `
+resource "coolify_storage_backup" "test" {
+  application_uuid = "` + appUUID + `"
+  storage_uuid     = "` + storUUID + `"
+  frequency        = "0 2 * * *"
+  save_s3          = true
+}`,
+			ExpectError: regexp.MustCompile(`s3_storage_uuid is required when save_s3 is true`),
+		}},
+	})
+}
+
+func TestStorageBackupResource_Import(t *testing.T) {
+	t.Parallel()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             mock.checkDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderBlockForURL(srv.URL) + `
+				Config: acctest.ProviderBlockForURL(mock.URL()) + `
 resource "coolify_storage_backup" "test" {
   application_uuid = "` + appUUID + `"
   storage_uuid     = "` + storUUID + `"
@@ -260,6 +332,75 @@ resource "coolify_storage_backup" "test" {
 				},
 			},
 		},
+	})
+}
+
+func TestStorageBackupResource_ImportInvalidID(t *testing.T) {
+	t.Parallel()
+	mock := newVolumeBackupMock(t)
+	defer mock.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(mock.URL()) + `
+resource "coolify_storage_backup" "test" {
+  application_uuid = "` + appUUID + `"
+  storage_uuid     = "` + storUUID + `"
+  frequency        = "0 2 * * *"
+}`,
+			},
+			{
+				ResourceName:  "coolify_storage_backup.test",
+				ImportState:   true,
+				ImportStateId: "not-enough-parts",
+				ExpectError:   regexp.MustCompile(`Invalid import ID format`),
+			},
+			{
+				ResourceName:  "coolify_storage_backup.test",
+				ImportState:   true,
+				ImportStateId: "widget:" + appUUID + ":" + storUUID,
+				ExpectError:   regexp.MustCompile(`must be application, service, or database`),
+			},
+		},
+	})
+}
+
+func TestStorageBackupResource_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/applications/"+appUUID+"/storages/"+storUUID+"/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(client.VolumeBackupSchedule{
+			UUID: schedUUID, StorageUUID: storUUID, StorageType: "persistent",
+			Frequency: "0 2 * * *", Enabled: true, Timeout: 3600,
+			RetentionAmountLocally: 7, RetentionAmountS3: 7,
+		})
+	})
+	mux.HandleFunc("GET /api/v1/applications/"+appUUID+"/storages", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"persistent_storages": []client.Storage{{UUID: storUUID, Name: "data", MountPath: "/data"}},
+			"file_storages":       []client.Storage{},
+		})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/"+appUUID+"/storages/"+storUUID+"/backups", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Storage backup schedule not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_storage_backup" "test" {
+  application_uuid = "` + appUUID + `"
+  storage_uuid     = "` + storUUID + `"
+  frequency        = "0 2 * * *"
+}`,
+			// Destroy runs after step; DELETE 404 must be treated as success.
+		}},
 	})
 }
 

--- a/internal/validate/cron.go
+++ b/internal/validate/cron.go
@@ -1,0 +1,40 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// coolifyFrequencyPattern matches Coolify schedule frequencies:
+// standard 5-field cron, optional 6-field when allowSixFields is true, and
+// human strings from Coolify VALID_CRON_STRINGS (bootstrap/helpers/constants.php):
+// every_minute, hourly, daily, weekly, monthly, yearly, and @hourly/@daily/etc.
+//
+// Bare names without "@" are accepted by Coolify; rejecting them causes  plan-time
+// false failures for valid API values.
+const (
+	coolifyHuman = `(?:every_minute|hourly|daily|weekly|monthly|yearly|@(?:annually|yearly|monthly|weekly|daily|hourly))`
+	// 5-field cron: five tokens separated by spaces
+	coolifyCron5 = `(?:\S+\s+){4}\S+`
+	// 5- or 6-field cron (scheduled tasks)
+	coolifyCron5or6 = `(?:\S+\s+){4,5}\S+`
+)
+
+var (
+	coolifyFrequency5Regexp    = regexp.MustCompile(`^(?:` + coolifyCron5 + `|` + coolifyHuman + `)$`)
+	coolifyFrequency5or6Regexp = regexp.MustCompile(`^(?:` + coolifyCron5or6 + `|` + coolifyHuman + `)$`)
+)
+
+// CoolifyFrequency validates cron / Coolify human schedule strings (5-field cron).
+func CoolifyFrequency() validator.String {
+	return stringvalidator.RegexMatches(coolifyFrequency5Regexp,
+		`must be a valid cron expression (e.g. "0 2 * * *") or Coolify human schedule (daily, hourly, @daily, every_minute, …)`)
+}
+
+// CoolifyFrequencyAllowSeconds validates 5- or 6-field cron plus Coolify human schedules.
+func CoolifyFrequencyAllowSeconds() validator.String {
+	return stringvalidator.RegexMatches(coolifyFrequency5or6Regexp,
+		`must be a valid cron expression (e.g. "*/5 * * * *" or six-field) or Coolify human schedule (daily, @daily, …)`)
+}

--- a/internal/validate/cron_test.go
+++ b/internal/validate/cron_test.go
@@ -1,0 +1,52 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCoolifyFrequency(t *testing.T) {
+	t.Parallel()
+	v := validate.CoolifyFrequency()
+	valid := []string{
+		"0 2 * * *",
+		"*/5 * * * *",
+		"@daily",
+		"@hourly",
+		"daily",
+		"hourly",
+		"weekly",
+		"monthly",
+		"yearly",
+		"every_minute",
+	}
+	for _, s := range valid {
+		s := s
+		t.Run("ok_"+s, func(t *testing.T) {
+			t.Parallel()
+			req := validator.StringRequest{ConfigValue: types.StringValue(s)}
+			var resp validator.StringResponse
+			v.ValidateString(context.Background(), req, &resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("%q should be valid: %v", s, resp.Diagnostics)
+			}
+		})
+	}
+	invalid := []string{"not-a-cron", "@secondly", "every minute"}
+	for _, s := range invalid {
+		s := s
+		t.Run("bad_"+s, func(t *testing.T) {
+			t.Parallel()
+			req := validator.StringRequest{ConfigValue: types.StringValue(s)}
+			var resp validator.StringResponse
+			v.ValidateString(context.Background(), req, &resp)
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("%q should be invalid", s)
+			}
+		})
+	}
+}

--- a/templates/guides/migration-from-community.md.tmpl
+++ b/templates/guides/migration-from-community.md.tmpl
@@ -16,7 +16,7 @@ This guide helps you migrate from the
 This provider is a complete rewrite using the Terraform Plugin Framework
 (not the older SDK v2). It offers:
 
-- **36 resources** vs. ~10 in the community provider
+- **37 resources** vs. ~10 in the community provider
 - **44 data sources** with filtering support
 - **890+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,7 +11,7 @@ Define your entire [Coolify](https://coolify.io/) infrastructure as code. Deploy
 
 Coolify gives you a self-hosted PaaS with a great UI. This provider adds what the UI cannot: reproducible environments, pull-request-based infrastructure reviews, disaster recovery from state, and CI/CD integration. Whether you run a single VPS or manage Coolify for a team, Terraform turns your infrastructure into a reviewable, testable, git-tracked configuration.
 
-**36 resources, 54 data sources, 99%+ Coolify API coverage.**
+**37 resources, 54 data sources, 99%+ Coolify API coverage.**
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

MPI cycle on main after storage_backup version accuracy (#602).

### Findings fixed

1. **Coolify human cron without `@`** (high): Coolify `VALID_CRON_STRINGS` accepts `daily`, `hourly`, `weekly`, `monthly`, `yearly`, and `every_minute` without a leading `@`. Provider validators only allowed `@daily`-style tokens, so valid schedules failed at plan time. Shared `validate.CoolifyFrequency` / `CoolifyFrequencyAllowSeconds` now match Coolify constants plus standard cron; used for `coolify_storage_backup`, `coolify_database_backup`, `coolify_scheduled_task`, and server disk-check frequency.

2. **storage_backup test depth**: SpecAudit on CRUD mock, CheckDestroy via mock schedule state, SaveS3 without UUID, invalid import IDs, delete 404, and bare `daily` schedule.

3. **Docs**: resource count 36 → 37 after `coolify_storage_backup`.

### Not fixed (blocked / intentional)

- Release PR #588 (v0.1.9): needs explicit user merge approval
- #591 coolify-channel promotion watch
- #445 actionlint `code-quality` (upstream still open)
- #393 / #394 blocked-upstream (no Coolify API)
- #475 community promotion (large, non-code)

## Test plan

- [x] `make ci`
- [x] `go test -race` for validate, volumebackup, database/backup, scheduledtask, server, hetzner, digitalocean, vultr