### PR TITLE
fix: preserve raw custom_nginx_configuration on read

### DIFF
--- a/internal/service/application/common_flatten.go
+++ b/internal/service/application/common_flatten.go
@@ -121,13 +121,16 @@ func flattenExtendedFields(app *client.Application, f commonAppFields) {
 	// null state (import) but do not force "/" onto omitted create plans (#577).
 	flex.SetStringSeedIfConfigured(f.BaseDirectory, app.BaseDirectory, "/")
 	flex.SetStringIfConfigured(f.GitCommitSha, app.GitCommitSha)
-	// custom_labels: the API requires base64 input, stores base64, and returns
-	// base64 on GET (with read:sensitive permission). Since the provider auto-
-	// encodes via EnsureBase64, users write raw content. ResolveBase64Field
+	// custom_labels and custom_nginx_configuration: API requires base64 input,
+	// stores base64, and returns base64 on GET (with read:sensitive). Users write
+	// raw content; provider auto-encodes via EnsureBase64. ResolveBase64Field
 	// preserves the user's raw value when it matches the API's base64, avoiding
 	// perpetual diffs. Also handles pre-encoded input for backward compatibility.
 	if f.CustomLabels != nil {
 		*f.CustomLabels = flex.ResolveBase64Field(*f.CustomLabels, app.CustomLabels)
+	}
+	if f.CustomNginxConfiguration != nil {
+		*f.CustomNginxConfiguration = flex.ResolveBase64Field(*f.CustomNginxConfiguration, app.CustomNginxConfiguration)
 	}
 	// Nullable fields — seed null state from API (import) and clear when the
 	// API returns empty for configured values (UI drift).
@@ -138,7 +141,6 @@ func flattenExtendedFields(app *client.Application, f commonAppFields) {
 	flex.SetStringSeedOrClear(f.WatchPaths, app.WatchPaths)
 	flex.SetStringOrClear(f.CustomDockerRunOptions, app.CustomDockerRunOptions)
 	flex.SetStringOrClear(f.CustomNetworkAliases, app.CustomNetworkAliases)
-	flex.SetStringOrClear(f.CustomNginxConfiguration, app.CustomNginxConfiguration)
 	flex.SetStringOrClear(f.PortsMappings, app.PortsMappings)
 	flex.SetStringIfConfigured(f.HTTPBasicAuthUsername, app.HTTPBasicAuthUsername)
 	flex.SetStringIfConfigured(f.HTTPBasicAuthPassword, app.HTTPBasicAuthPassword)

--- a/internal/service/application/common_flatten_test.go
+++ b/internal/service/application/common_flatten_test.go
@@ -897,6 +897,55 @@ func TestFlattenExtendedFields_CustomLabelsEmptyAPIPreservesState(t *testing.T) 
 	}
 }
 
+func TestFlattenExtendedFields_CustomNginxRawPreserved(t *testing.T) {
+	t.Parallel()
+	raw := "server { listen 80; location / { return 200; } }"
+	apiBase64 := base64.StdEncoding.EncodeToString([]byte(raw))
+
+	nginx := types.StringValue(raw)
+	f, _ := newDefaultFields()
+	f.CustomNginxConfiguration = &nginx
+
+	app := &client.Application{CustomNginxConfiguration: apiBase64}
+	flattenExtendedFields(app, f)
+
+	if f.CustomNginxConfiguration.ValueString() != raw {
+		t.Errorf("CustomNginxConfiguration = %q, want user's raw value %q", f.CustomNginxConfiguration.ValueString(), raw)
+	}
+}
+
+func TestFlattenExtendedFields_CustomNginxExternalChange(t *testing.T) {
+	t.Parallel()
+	userRaw := "server { listen 80; }"
+	externalRaw := "server { listen 443; }"
+	apiBase64 := base64.StdEncoding.EncodeToString([]byte(externalRaw))
+
+	nginx := types.StringValue(userRaw)
+	f, _ := newDefaultFields()
+	f.CustomNginxConfiguration = &nginx
+
+	app := &client.Application{CustomNginxConfiguration: apiBase64}
+	flattenExtendedFields(app, f)
+
+	if f.CustomNginxConfiguration.ValueString() != externalRaw {
+		t.Errorf("CustomNginxConfiguration = %q, want decoded external value %q", f.CustomNginxConfiguration.ValueString(), externalRaw)
+	}
+}
+
+func TestFlattenExtendedFields_CustomNginxEmptyAPIPreservesState(t *testing.T) {
+	t.Parallel()
+	nginx := types.StringValue("server {}")
+	f, _ := newDefaultFields()
+	f.CustomNginxConfiguration = &nginx
+
+	app := &client.Application{CustomNginxConfiguration: ""}
+	flattenExtendedFields(app, f)
+
+	if f.CustomNginxConfiguration.ValueString() != "server {}" {
+		t.Errorf("CustomNginxConfiguration = %q, want preserved state value %q", f.CustomNginxConfiguration.ValueString(), "server {}")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // custom_labels + custom_nginx_configuration: update input encoding
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Triage of [AI Code Quality findings](https://github.com/coolify-terraform/terraform-provider-coolify/security/quality/ai-findings) found **one true positive**:

`custom_nginx_configuration` is base64-encoded on Create/Update (same as `custom_labels`) but Read flattened with `SetStringOrClear`, so state became API base64 while config stayed raw → perpetual diffs.

### Fix

Use `flex.ResolveBase64Field` for nginx config, matching labels. Tests cover raw preserve, external change, and empty API (sensitive hide).

### Other AI findings (false positives / noise)

| Finding | Verdict |
|---------|---------|
| CHANGELOG Go 1.26.x "does not exist" | FP — project uses Go 1.26.5 (`go.mod`) |
| `dbtest.NewMockServer` "ignored error" | FP — second return is `*MockState`, not `error` |
| Multi-line switch case in keydb mock | Style only |
| MySQL `ExpectError` regex specificity | Cosmetic; existing regex is already specific enough |
| Architecture diagram `ver.` / `scen.` | Intentional ASCII box truncation |

## Test plan

- [x] `go test -race ./internal/service/application/ -run Flatten|CustomNginx|CustomLabels`