### PR TITLE
test: full acceptance coverage for coolify_storage_backup

### DIFF
--- a/.github/actions/setup-coolify/action.yml
+++ b/.github/actions/setup-coolify/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: Root directory for Coolify data
     required: false
     default: /home/runner/coolify-data
+  coolify-image-tag:
+    description: >
+      Docker image tag for coollabsio/coolify (LATEST_IMAGE in compose).
+      Default edge is the multi-arch tip of Coolify v4.x and includes
+      VolumeBackupsController (coollabsio/coolify#10946). Stable latest / 4.2.0
+      do not. Override with a sha-... tag to pin, or latest for older API surface.
+    required: false
+    default: edge
 
 runs:
   using: composite
@@ -34,6 +42,7 @@ runs:
       shell: bash
       env:
         COOLIFY_DATA_DIR: ${{ inputs.coolify-data-dir }}
+        COOLIFY_IMAGE_TAG: ${{ inputs.coolify-image-tag }}
       run: |
         mkdir -p "$COOLIFY_DATA_DIR"/{source,ssh/{keys,mux},applications,databases,backups,services,proxy,webhooks-during-maintenance}
         mkdir -p "$COOLIFY_DATA_DIR/proxy/dynamic"
@@ -49,6 +58,14 @@ runs:
         sed -i "s|PUSHER_APP_ID=.*|PUSHER_APP_ID=$(openssl rand -hex 32)|g" .env
         sed -i "s|PUSHER_APP_KEY=.*|PUSHER_APP_KEY=$(openssl rand -hex 32)|g" .env
         sed -i "s|PUSHER_APP_SECRET=.*|PUSHER_APP_SECRET=$(openssl rand -hex 32)|g" .env
+        # Pin Coolify image tag (compose uses ${LATEST_IMAGE:-latest}).
+        # edge = v4.x tip with VolumeBackupsController (#10946); not in tag v4.2.0.
+        if grep -qE '^LATEST_IMAGE=' .env; then
+          sed -i "s|^LATEST_IMAGE=.*|LATEST_IMAGE=${COOLIFY_IMAGE_TAG}|" .env
+        else
+          echo "LATEST_IMAGE=${COOLIFY_IMAGE_TAG}" >> .env
+        fi
+        echo "Using Coolify image tag: ${COOLIFY_IMAGE_TAG}"
         ssh-keygen -t ed25519 -f "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal" -N "" -q
         cat "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub" >> ~/.ssh/authorized_keys
         sudo sh -c "cat $COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub >> /root/.ssh/authorized_keys"

--- a/TESTING.md
+++ b/TESTING.md
@@ -126,6 +126,8 @@ fixtures are still missing.
 | `COOLIFY_S3_STORAGE_UUID` | No | Required for S3 backup coverage if you are not using `make acc-bootstrap` |
 | `COOLIFY_GITHUB_APP_*` | No | Required for the GitHub App application acceptance test |
 
+`coolify_storage_backup` acceptance (`TestAccStorageBackupResource_CRUD`) needs a Coolify image with `VolumeBackupsController` (coollabsio/coolify#10946; not in tag `v4.2.0` or stable `latest`). CI sets `LATEST_IMAGE=edge` in [`.github/actions/setup-coolify`](.github/actions/setup-coolify/action.yml). Locally, add `LATEST_IMAGE=edge` to the Coolify compose `.env` before `docker compose up`. The test probes the API and skips with a clear reason if the route is missing; no extra secrets.
+
 #### Server validation for application tests
 
 Application-related tests require a validated server with SSH access.

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -515,6 +515,90 @@ func AccCheckResourceDisappears(resourceAddr, apiDeletePath string) resource.Tes
 	}
 }
 
+// AccTestSkipIfNoVolumeBackupAPI skips when Coolify lacks VolumeBackupsController
+// (PUT/DELETE .../storages/{uuid}/backups from coollabsio/coolify#10946).
+//
+// That API is on Coolify branch v4.x after the merge; it is not in git tag
+// v4.2.0 or stable CDN latest. CI boots coollabsio/coolify:edge (v4.x tip).
+// Locally set LATEST_IMAGE=edge (or a post-#10946 sha-... tag) before compose up.
+//
+// Probe strategy: PUT a schedule for non-existent parent/storage UUIDs.
+// Present controller returns 404 resource/storage, 422 validation, or 401/403.
+// Missing route returns Laravel "route ... could not be found" (or similar).
+func AccTestSkipIfNoVolumeBackupAPI(t *testing.T) {
+	t.Helper()
+	TestAccPreCheck(t)
+
+	endpoint := strings.TrimRight(os.Getenv("COOLIFY_ENDPOINT"), "/")
+	token := os.Getenv("COOLIFY_TOKEN")
+	// NanoID-shaped placeholders; do not need to exist.
+	path := endpoint + "/api/v1/applications/tfaccprobe000000000000001/storages/tfaccprobe000000000000002/backups"
+	req, err := http.NewRequest(http.MethodPut, path, strings.NewReader(`{"frequency":"daily"}`))
+	if err != nil {
+		t.Fatalf("building volume backup probe request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Skipf("volume backup API probe failed (cannot reach Coolify): %v", err)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	msg := strings.ToLower(string(body))
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// Route is registered; auth/middleware ran.
+		return
+	case http.StatusUnprocessableEntity:
+		// Validation ran on the volume backup controller.
+		return
+	case http.StatusNotFound:
+		// Controller-style 404s mean the route exists.
+		if strings.Contains(msg, "application not found") ||
+			strings.Contains(msg, "resource not found") ||
+			strings.Contains(msg, "storage not found") ||
+			strings.Contains(msg, "database not found") ||
+			strings.Contains(msg, "service not found") {
+			return
+		}
+		// Laravel unmatched route, Go net/http default 404, or HTML without
+		// controller message. Controller 404s always name the resource.
+		if strings.Contains(msg, "could not be found") ||
+			strings.Contains(msg, "route ") ||
+			strings.Contains(msg, "page not found") ||
+			strings.TrimSpace(msg) == "" ||
+			strings.Contains(msg, "<html") {
+			t.Skipf("Coolify instance has no VolumeBackupsController (HTTP %d). "+
+				"Need image tip after coollabsio/coolify#10946 (CI uses coollabsio/coolify:edge; "+
+				"local: set LATEST_IMAGE=edge in Coolify compose .env). Body: %s",
+				resp.StatusCode, truncateForSkip(string(body), 200))
+		}
+		// Unknown 404 body: treat as present (resource not found variants).
+		return
+	case http.StatusMethodNotAllowed:
+		t.Skipf("Coolify instance has no volume backup PUT route (HTTP 405). " +
+			"Need tip after coollabsio/coolify#10946 (coollabsio/coolify:edge)")
+	default:
+		// 200/201 should not happen for fake UUIDs; other codes still mean a handler ran.
+		if resp.StatusCode >= 500 {
+			t.Skipf("volume backup API probe returned HTTP %d (server error); skipping: %s",
+				resp.StatusCode, truncateForSkip(string(body), 200))
+		}
+	}
+}
+
+func truncateForSkip(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
 // AccTestS3StorageUUID returns the UUID of an S3 storage destination for
 // acceptance tests. Set COOLIFY_S3_STORAGE_UUID to the UUID of an S3
 // storage registered in Coolify. The test is skipped if not set.

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -97,3 +97,89 @@ func TestAccTestServerUUID_SkipsWhenOverrideIsNotVisible(t *testing.T) {
 		t.Fatal("expected AccTestServerUUID to skip when COOLIFY_SERVER_UUID is not visible")
 	}
 }
+
+func TestAccTestSkipIfNoVolumeBackupAPI_Present(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.2.0-edge"})
+	})
+	// Controller present: resource not found for fake UUIDs
+	mux.HandleFunc("PUT /api/v1/applications/{app}/storages/{stor}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Application not found."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, kv := range [][2]string{{"COOLIFY_ENDPOINT", srv.URL}, {"COOLIFY_TOKEN", "test-token"}} {
+		if err := os.Setenv(kv[0], kv[1]); err != nil {
+			t.Fatalf("setting %s: %v", kv[0], err)
+		}
+		defer os.Unsetenv(kv[0]) //nolint:errcheck
+	}
+
+	// Must not skip when controller is present
+	AccTestSkipIfNoVolumeBackupAPI(t)
+}
+
+func TestAccTestSkipIfNoVolumeBackupAPI_MissingRoute(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.2.0"})
+	})
+	// Unmatched PUT: Go ServeMux returns 404 with empty body (treated as missing route)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, kv := range [][2]string{{"COOLIFY_ENDPOINT", srv.URL}, {"COOLIFY_TOKEN", "test-token"}} {
+		if err := os.Setenv(kv[0], kv[1]); err != nil {
+			t.Fatalf("setting %s: %v", kv[0], err)
+		}
+		defer os.Unsetenv(kv[0]) //nolint:errcheck
+	}
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoVolumeBackupAPI(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoVolumeBackupAPI to skip when volume backup route is missing")
+	}
+}
+
+func TestAccTestSkipIfNoVolumeBackupAPI_ValidationPresent(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.2.0-edge"})
+	})
+	mux.HandleFunc("PUT /api/v1/applications/{app}/storages/{stor}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation failed."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, kv := range [][2]string{{"COOLIFY_ENDPOINT", srv.URL}, {"COOLIFY_TOKEN", "test-token"}} {
+		if err := os.Setenv(kv[0], kv[1]); err != nil {
+			t.Fatalf("setting %s: %v", kv[0], err)
+		}
+		defer os.Unsetenv(kv[0]) //nolint:errcheck
+	}
+
+	AccTestSkipIfNoVolumeBackupAPI(t)
+}

--- a/internal/service/volumebackup/resource_acc_test.go
+++ b/internal/service/volumebackup/resource_acc_test.go
@@ -2,6 +2,9 @@ package volumebackup_test
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
@@ -9,42 +12,60 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// TestAccStorageBackupResource_CRUD exercises "coolify_storage_backup" against a real Coolify
-// instance with VolumeBackupsController (Coolify v4.x after coollabsio/coolify#10946; not in tag v4.2.0).
+// TestAccStorageBackupResource_CRUD exercises coolify_storage_backup against a
+// real Coolify instance with VolumeBackupsController (v4.x tip after
+// coollabsio/coolify#10946; not in tag v4.2.0). CI boots coollabsio/coolify:edge.
 func TestAccStorageBackupResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	// Needs Coolify v4.x including #10946 + a disposable storage UUID. Unit tests cover the resource.
-	t.Skip("coolify_storage_backup acceptance needs Coolify v4.x with volume-backup routes (#10946+) and a test storage UUID")
+	acctest.AccTestSkipIfNoVolumeBackupAPI(t)
 
-	appUUID := "00000000-0000-4000-8000-000000000001"
-	storUUID := "00000000-0000-4000-8000-000000000002"
+	serverUUID := acctest.AccTestServerUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-volbkp")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             testAccStorageBackupDestroy,
 		Steps: []resource.TestStep{
+			// Create schedule on a disposable application storage
 			{
-				Config: testAccStorageBackupConfig(appUUID, storUUID, "0 2 * * *"),
+				Config: testAccStorageBackupConfig(name, serverUUID, "0 2 * * *"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_storage_backup.test", "uuid"),
+					resource.TestCheckResourceAttrSet("coolify_storage_backup.test", "storage_uuid"),
+					resource.TestCheckResourceAttrSet("coolify_storage_backup.test", "application_uuid"),
 					resource.TestCheckResourceAttr("coolify_storage_backup.test", "frequency", "0 2 * * *"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "storage_type", "persistent"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "retention_amount_locally", "7"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "timeout", "3600"),
 				),
 			},
+			// Idempotency
 			{
-				Config: testAccStorageBackupConfig(appUUID, storUUID, "0 3 * * *"),
+				Config:             testAccStorageBackupConfig(name, serverUUID, "0 2 * * *"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update frequency
+			{
+				Config: testAccStorageBackupConfig(name, serverUUID, "0 3 * * *"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_storage_backup.test", "frequency", "0 3 * * *"),
+					resource.TestCheckResourceAttrSet("coolify_storage_backup.test", "uuid"),
 				),
 			},
+			// Import (schedule fields are state-only; no GET on Coolify)
 			{
 				ResourceName:                         "coolify_storage_backup.test",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "storage_uuid",
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return "application:" + appUUID + ":" + storUUID, nil
-				},
+				ImportStateIdFunc: testAccStorageBackupImportStateIdFunc(
+					"coolify_application_dockerfile.test",
+					"coolify_storage.test",
+				),
 				ImportStateVerifyIgnore: []string{
 					"uuid", "frequency", "enabled", "save_s3", "disable_local_backup",
 					"stop_during_backup", "s3_storage_uuid", "storage_type",
@@ -56,12 +77,108 @@ func TestAccStorageBackupResource_CRUD(t *testing.T) {
 	})
 }
 
-func testAccStorageBackupConfig(appUUID, storUUID, frequency string) string {
+func testAccStorageBackupConfig(name, serverUUID, frequency string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
-resource "coolify_storage_backup" "test" {
-  application_uuid = %q
-  storage_uuid     = %q
-  frequency        = %q
+resource "coolify_project" "test" {
+  name = %[1]q
 }
-`, appUUID, storUUID, frequency)
+
+resource "coolify_application_dockerfile" "test" {
+  project_uuid        = coolify_project.test.uuid
+  server_uuid         = %[2]q
+  dockerfile_location = base64encode(<<-DOCKERFILE
+    FROM nginx:alpine
+    EXPOSE 80
+  DOCKERFILE
+  )
+  ports_exposes = "80"
+}
+
+resource "coolify_storage" "test" {
+  application_uuid = coolify_application_dockerfile.test.uuid
+  name             = %[1]q
+  mount_path       = "/data"
+}
+
+resource "coolify_storage_backup" "test" {
+  application_uuid = coolify_application_dockerfile.test.uuid
+  storage_uuid     = coolify_storage.test.uuid
+  frequency        = %[3]q
+  enabled          = true
+}
+`, name, serverUUID, frequency)
+}
+
+func testAccStorageBackupImportStateIdFunc(appResourceName, storageResourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		appRS, ok := s.RootModule().Resources[appResourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found in state", appResourceName)
+		}
+		storageRS, ok := s.RootModule().Resources[storageResourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found in state", storageResourceName)
+		}
+		appUUID := appRS.Primary.Attributes["uuid"]
+		storageUUID := storageRS.Primary.Attributes["uuid"]
+		return fmt.Sprintf("application:%s:%s", appUUID, storageUUID), nil
+	}
+}
+
+// testAccStorageBackupDestroy confirms the schedule is gone. Coolify has no GET
+// for volume backup schedules; DELETE returns 404 when missing (or when the
+// parent resource/storage is already removed during full destroy).
+func testAccStorageBackupDestroy(s *terraform.State) error {
+	endpoint := strings.TrimRight(os.Getenv("COOLIFY_ENDPOINT"), "/")
+	token := os.Getenv("COOLIFY_TOKEN")
+	if endpoint == "" || token == "" {
+		return fmt.Errorf("COOLIFY_ENDPOINT and COOLIFY_TOKEN required for CheckDestroy")
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "coolify_storage_backup" {
+			continue
+		}
+		appUUID := rs.Primary.Attributes["application_uuid"]
+		svcUUID := rs.Primary.Attributes["service_uuid"]
+		dbUUID := rs.Primary.Attributes["database_uuid"]
+		storUUID := rs.Primary.Attributes["storage_uuid"]
+		if storUUID == "" {
+			continue
+		}
+
+		var path string
+		switch {
+		case appUUID != "":
+			path = fmt.Sprintf("%s/api/v1/applications/%s/storages/%s/backups", endpoint, appUUID, storUUID)
+		case svcUUID != "":
+			path = fmt.Sprintf("%s/api/v1/services/%s/storages/%s/backups", endpoint, svcUUID, storUUID)
+		case dbUUID != "":
+			path = fmt.Sprintf("%s/api/v1/databases/%s/storages/%s/backups", endpoint, dbUUID, storUUID)
+		default:
+			return fmt.Errorf("coolify_storage_backup %s has no parent uuid", rs.Primary.ID)
+		}
+
+		req, err := http.NewRequest(http.MethodDelete, path, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("DELETE volume backup for %s: %w", storUUID, err)
+		}
+		_ = resp.Body.Close()
+
+		// 404 = already gone (desired). 200 = delete succeeded late. 409 = in progress.
+		switch resp.StatusCode {
+		case http.StatusNotFound, http.StatusOK:
+			// destroyed
+		default:
+			return fmt.Errorf("volume backup schedule for storage %s still present (HTTP %d on DELETE)",
+				storUUID, resp.StatusCode)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Implements full acceptance coverage for `coolify_storage_backup` against real Coolify with `VolumeBackupsController` (coollabsio/coolify#10946).

Closes #608.

### Changes

- **CI bootstrap** (`.github/actions/setup-coolify`): default `LATEST_IMAGE=edge` so acceptance runners boot Coolify v4.x tip, which includes volume backup routes. Stable `latest` / tag `v4.2.0` do not. Override via input `coolify-image-tag` (for example `sha-...` or `latest`).
- **Acc test** (`TestAccStorageBackupResource_CRUD`): creates project + dockerfile app + storage + `coolify_storage_backup`, updates frequency, imports (state-only schedule fields ignored), destroys with CheckDestroy via DELETE 404.
- **Probe helper** (`AccTestSkipIfNoVolumeBackupAPI`): skips with a clear reason only when the PUT route is missing; unit-tested for present / missing / 422 cases.
- **Docs**: `TESTING.md` + coolify-test-instance skill (edge image, no new secrets).

### Acceptance criteria

- [x] CI Coolify bootstrap runs an image with VolumeBackupsController (`:edge`)
- [x] Acc test creates parent storage + schedule, updates frequency, imports, destroys
- [x] Skip only when image lacks the API (clear skip reason)
- [x] Documented in coolify-test-instance skill / TESTING.md (no new secrets)

### Test plan

- [x] `go test ./internal/acctest/ ./internal/service/volumebackup/`
- [ ] CI Acceptance Tests job green (exercises real Coolify `:edge`)
- [ ] Confirm acc log runs `TestAccStorageBackupResource_CRUD` (not skip)