### PR TITLE
test: storage_backup S3 acc, preflight probe, and edge pin docs

### DIFF
--- a/.github/actions/setup-coolify/action.yml
+++ b/.github/actions/setup-coolify/action.yml
@@ -15,7 +15,9 @@ inputs:
       Docker image tag for coollabsio/coolify (LATEST_IMAGE in compose).
       Default edge is the multi-arch tip of Coolify v4.x and includes
       VolumeBackupsController (coollabsio/coolify#10946). Stable latest / 4.2.0
-      do not. Override with a sha-... tag to pin, or latest for older API surface.
+      do not. If edge is flaky, pin a multi-arch SHA from Coolify's
+      coolify-sha-build (e.g. sha-<full-git-sha> on docker.io/ghcr.io).
+      Use latest only when you intentionally want the older stable API surface.
     required: false
     default: edge
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,7 +39,26 @@ acc-preflight: ## Check required env, API reachability, and common acceptance fi
 	else echo "INFO: COOLIFY_SERVER_UUID not set. Acceptance helpers will auto-discover the first visible server."; fi; \
 	if [ -z "$$COOLIFY_HETZNER_TOKEN" ]; then echo "WARNING: COOLIFY_HETZNER_TOKEN not set. Hetzner and cloud token acceptance packages will skip."; else echo "Hetzner fixture OK: COOLIFY_HETZNER_TOKEN is set."; fi; \
 	if [ -z "$$COOLIFY_S3_STORAGE_UUID" ]; then echo "WARNING: COOLIFY_S3_STORAGE_UUID not set. S3 backup acceptance tests will skip."; else echo "S3 fixture OK: COOLIFY_S3_STORAGE_UUID is set."; fi; \
-	if [ -n "$$COOLIFY_GITHUB_APP_APP_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_INSTALLATION_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_CLIENT_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_CLIENT_SECRET" ] && [ -n "$$COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE" ] && [ -n "$$COOLIFY_GITHUB_APP_REPOSITORY" ]; then echo "GitHub App fixtures OK: COOLIFY_GITHUB_APP_* is configured."; else echo "WARNING: COOLIFY_GITHUB_APP_* fixtures are incomplete. GitHub App application acceptance will skip."; fi
+	if [ -n "$$COOLIFY_GITHUB_APP_APP_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_INSTALLATION_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_CLIENT_ID" ] && [ -n "$$COOLIFY_GITHUB_APP_CLIENT_SECRET" ] && [ -n "$$COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE" ] && [ -n "$$COOLIFY_GITHUB_APP_REPOSITORY" ]; then echo "GitHub App fixtures OK: COOLIFY_GITHUB_APP_* is configured."; else echo "WARNING: COOLIFY_GITHUB_APP_* fixtures are incomplete. GitHub App application acceptance will skip."; fi; \
+	endpoint=$$(printf '%s' "$$COOLIFY_ENDPOINT" | sed 's|/*$$||'); \
+	vb_code=$$(curl -sS -o /tmp/acc-preflight-vb.body -w '%{http_code}' \
+	  -X PUT \
+	  -H "Authorization: Bearer $$COOLIFY_TOKEN" \
+	  -H "Content-Type: application/json" \
+	  -H "Accept: application/json" \
+	  -d '{"frequency":"daily"}' \
+	  "$$endpoint/api/v1/applications/tfaccprobe000000000000001/storages/tfaccprobe000000000000002/backups" 2>/dev/null || echo "000"); \
+	vb_body=$$(tr '[:upper:]' '[:lower:]' < /tmp/acc-preflight-vb.body 2>/dev/null || true); \
+	rm -f /tmp/acc-preflight-vb.body; \
+	if [ "$$vb_code" = "401" ] || [ "$$vb_code" = "403" ] || [ "$$vb_code" = "422" ]; then \
+	  echo "Volume backup API OK: HTTP $$vb_code (VolumeBackupsController present)."; \
+	elif [ "$$vb_code" = "404" ] && printf '%s' "$$vb_body" | grep -qE 'application not found|resource not found|storage not found|database not found|service not found'; then \
+	  echo "Volume backup API OK: HTTP 404 resource/storage (VolumeBackupsController present)."; \
+	elif [ "$$vb_code" = "404" ] || [ "$$vb_code" = "405" ] || [ "$$vb_code" = "000" ]; then \
+	  echo "WARNING: Volume backup routes missing (HTTP $$vb_code). coolify_storage_backup acc tests will skip. Use coollabsio/coolify:edge (CI default) or pin LATEST_IMAGE=sha-<git-sha> after coollabsio/coolify#10946."; \
+	else \
+	  echo "Volume backup API OK: HTTP $$vb_code (handler responded)."; \
+	fi
 
 check-pkg: ## Verify PKG is set for package-scoped test targets
 	@test -n "$(PKG)" || (echo "ERROR: PKG is required, example: make test-pkg PKG=./internal/service/project/"; exit 1)

--- a/TESTING.md
+++ b/TESTING.md
@@ -409,7 +409,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 33/33 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 105
+- **Total acceptance test functions**: 106
 
 ### Testing strategies for edge cases
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -123,10 +123,24 @@ fixtures are still missing.
 | `COOLIFY_TOKEN` | Yes | API bearer token |
 | `COOLIFY_SERVER_UUID` | No | Override server auto-discovery for acceptance helpers. `make acc-preflight` verifies that the UUID is visible to the current API token. |
 | `COOLIFY_HETZNER_TOKEN` | No | Required only for `cloudtoken` and Hetzner-related acceptance packages |
-| `COOLIFY_S3_STORAGE_UUID` | No | Required for S3 backup coverage if you are not using `make acc-bootstrap` |
+| `COOLIFY_S3_STORAGE_UUID` | No | Required for S3 backup coverage (`coolify_database_backup` and `coolify_storage_backup` S3 paths) if you are not using `make acc-bootstrap` |
 | `COOLIFY_GITHUB_APP_*` | No | Required for the GitHub App application acceptance test |
 
-`coolify_storage_backup` acceptance (`TestAccStorageBackupResource_CRUD`) needs a Coolify image with `VolumeBackupsController` (coollabsio/coolify#10946; not in tag `v4.2.0` or stable `latest`). CI sets `LATEST_IMAGE=edge` in [`.github/actions/setup-coolify`](.github/actions/setup-coolify/action.yml). Locally, add `LATEST_IMAGE=edge` to the Coolify compose `.env` before `docker compose up`. The test probes the API and skips with a clear reason if the route is missing; no extra secrets.
+`coolify_storage_backup` acceptance (`TestAccStorageBackupResource_CRUD` and `_S3`) needs a Coolify image with `VolumeBackupsController` (coollabsio/coolify#10946; not in tag `v4.2.0` or stable `latest`). CI sets `LATEST_IMAGE=edge` in [`.github/actions/setup-coolify`](.github/actions/setup-coolify/action.yml). Locally, add `LATEST_IMAGE=edge` to the Coolify compose `.env` before `docker compose up`. `make acc-preflight` warns when the volume-backup routes are missing; the tests also probe and skip with a clear reason. No extra secrets for the local schedule path; the S3 path needs `COOLIFY_S3_STORAGE_UUID` (same MinIO fixture as database backup S3 tests).
+
+**Pinning the Coolify image (when `:edge` is flaky):** compose uses `${LATEST_IMAGE:-latest}`. Prefer a known-good multi-arch SHA tag from Coolify's `coolify-sha-build` workflow (tags look like `sha-<full-git-sha>` on Docker Hub / GHCR):
+
+```bash
+# Local compose .env
+LATEST_IMAGE=sha-2180a5e7effdf8a994eaeb871d0ac77fa0be8fea
+
+# CI setup-coolify composite action
+# uses: ./.github/actions/setup-coolify
+# with:
+#   coolify-image-tag: sha-2180a5e7effdf8a994eaeb871d0ac77fa0be8fea
+```
+
+Confirm the SHA includes #10946+ (or that `VolumeBackupsController.php` is in the image). `edge` tracks tip and can move day-to-day.
 
 #### Server validation for application tests
 

--- a/internal/service/volumebackup/resource_acc_test.go
+++ b/internal/service/volumebackup/resource_acc_test.go
@@ -77,6 +77,57 @@ func TestAccStorageBackupResource_CRUD(t *testing.T) {
 	})
 }
 
+// TestAccStorageBackupResource_S3 exercises save_s3 + s3_storage_uuid against
+// real Coolify MinIO (COOLIFY_S3_STORAGE_UUID). Requires VolumeBackupsController.
+func TestAccStorageBackupResource_S3(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	acctest.AccTestSkipIfNoVolumeBackupAPI(t)
+
+	serverUUID := acctest.AccTestServerUUID(t)
+	s3UUID := acctest.AccTestS3StorageUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-volbkp-s3")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             testAccStorageBackupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBackupS3Config(name, serverUUID, s3UUID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coolify_storage_backup.test", "uuid"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "save_s3", "true"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "s3_storage_uuid", s3UUID),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "frequency", "0 3 * * *"),
+					resource.TestCheckResourceAttr("coolify_storage_backup.test", "storage_type", "persistent"),
+				),
+			},
+			{
+				Config:             testAccStorageBackupS3Config(name, serverUUID, s3UUID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:                         "coolify_storage_backup.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "storage_uuid",
+				ImportStateIdFunc: testAccStorageBackupImportStateIdFunc(
+					"coolify_application_dockerfile.test",
+					"coolify_storage.test",
+				),
+				ImportStateVerifyIgnore: []string{
+					"uuid", "frequency", "enabled", "save_s3", "disable_local_backup",
+					"stop_during_backup", "s3_storage_uuid", "storage_type",
+					"retention_amount_locally", "retention_days_locally", "retention_max_storage_locally",
+					"retention_amount_s3", "retention_days_s3", "retention_max_storage_s3", "timeout",
+				},
+			},
+		},
+	})
+}
+
 func testAccStorageBackupConfig(name, serverUUID, frequency string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {
@@ -107,6 +158,40 @@ resource "coolify_storage_backup" "test" {
   enabled          = true
 }
 `, name, serverUUID, frequency)
+}
+
+func testAccStorageBackupS3Config(name, serverUUID, s3UUID string) string {
+	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
+resource "coolify_project" "test" {
+  name = %[1]q
+}
+
+resource "coolify_application_dockerfile" "test" {
+  project_uuid        = coolify_project.test.uuid
+  server_uuid         = %[2]q
+  dockerfile_location = base64encode(<<-DOCKERFILE
+    FROM nginx:alpine
+    EXPOSE 80
+  DOCKERFILE
+  )
+  ports_exposes = "80"
+}
+
+resource "coolify_storage" "test" {
+  application_uuid = coolify_application_dockerfile.test.uuid
+  name             = %[1]q
+  mount_path       = "/data"
+}
+
+resource "coolify_storage_backup" "test" {
+  application_uuid = coolify_application_dockerfile.test.uuid
+  storage_uuid     = coolify_storage.test.uuid
+  frequency        = "0 3 * * *"
+  enabled          = true
+  save_s3          = true
+  s3_storage_uuid  = %[3]q
+}
+`, name, serverUUID, s3UUID)
 }
 
 func testAccStorageBackupImportStateIdFunc(appResourceName, storageResourceName string) resource.ImportStateIdFunc {


### PR DESCRIPTION
## Summary

Developer-testing follow-ups for `coolify_storage_backup` after #609.

1. **`make acc-preflight`** probes `PUT .../storages/{uuid}/backups` with fake UUIDs and warns when the volume-backup routes are missing (same signal as the acc skip helper).
2. **`TestAccStorageBackupResource_S3`** creates parent storage + schedule with `save_s3` / `s3_storage_uuid` (skips without `COOLIFY_S3_STORAGE_UUID` or without VolumeBackupsController).
3. **Pin docs** for flaky `:edge`: set `LATEST_IMAGE=sha-<git-sha>` locally or `coolify-image-tag` on setup-coolify.

## Test plan

- [x] `go test ./internal/service/volumebackup/ ./internal/acctest/`
- [ ] CI Acceptance Tests: CRUD still runs; S3 runs when MinIO fixture present
- [ ] `make acc-preflight` against edge shows volume backup OK; against old image warns