### PR TITLE
fix(ci): skip Auto Approve on fork PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,10 +14,19 @@ permissions:
 jobs:
   approve:
     name: Auto Approve
+    # Same-repo heads only. Fork PRs get a read-only GITHUB_TOKEN on
+    # pull_request, so createReview(APPROVE) fails with "Resource not
+    # accessible by integration". Also require a trusted actor so random
+    # same-repo collaborators are not auto-approved. Check head.repo, not
+    # only github.actor: a maintainer re-run on an external PR would make
+    # actor trusted and previously entered this job and failed red.
     if: >-
-      github.actor == 'SebTardif' ||
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'coolify-terraform-auto-approve[bot]'
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        github.actor == 'SebTardif' ||
+        github.actor == 'dependabot[bot]' ||
+        github.actor == 'coolify-terraform-auto-approve[bot]'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:


### PR DESCRIPTION
## Summary

Stop Auto Approve from running (and failing red) on external fork PRs when a maintainer re-runs workflows.

## Problem

On PR #611 (first-time contributor), Auto Approve failed with:

```text
HttpError: Resource not accessible by integration
```

Root cause:

1. The job `if` only checked `github.actor` (SebTardif, dependabot, auto-approve bot).
2. A maintainer re-run / workflow approval sets `actor` to the maintainer, so the job entered on a fork PR.
3. Fork `pull_request` events get a read-only `GITHUB_TOKEN`, so `createReview(APPROVE)` cannot succeed.

## Change

Require `github.event.pull_request.head.repo.full_name == github.repository` in addition to the trusted-actor list. Fork PRs always skip (green skip), never fail.

Same-repo maintainer and Dependabot PRs are unchanged.

## Validation

- Workflow condition re-read; matches GitHub fork-token behavior
- No runtime code changes

## Ref

Seen on https://github.com/coolify-terraform/terraform-provider-coolify/actions/runs/30533885243/job/90842406778?pr=611