### PR TITLE
test: cover legacy Coolify ids on helpers and fix docs floors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-37 resources, 54 data sources, 1060+ tests (unit + acceptance), 9 CI jobs.
+37 resources, 54 data sources, 1070+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -219,7 +219,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1060+ tests (unit + acceptance)
+- 1070+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 37 |
 | Data sources | 44 |
-| Tests | 1060+ unit and acceptance tests |
+| Tests | 1070+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -304,7 +304,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1060+ tests, race detector enabled)
+make test                                       # Run unit tests (1070+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -73,13 +73,21 @@ required fields that are not always obvious:
 ```
 Error: Invalid Attribute Value
 uuid must be a valid UUID (e.g. "550e8400-e29b-41d4-a716-446655440000")
+or Coolify identifier
 ```
 
 **Cause:** a UUID field received a malformed value.
 
-**Fix:** check that all UUID values use the standard format
-(`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Find UUIDs in the Coolify UI
-or with `terraform state show`.
+**Fix:** Coolify resource ids are either:
+
+- RFC 4122 UUIDs (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`), or
+- Coolify identifiers: **exactly 7** alphanumeric characters (legacy
+  `Cuid2(7)`, still present on older instances and some Coolify Cloud
+  teams) or **20-36** alphanumeric characters (modern NanoID/Cuid2).
+
+Copy the id from the Coolify UI URL or API (`GET /servers`, etc.), or
+from `terraform state show`. Values with dashes outside the RFC form,
+underscores, spaces, or lengths other than 7 and 20-36 are rejected.
 
 ### Cron syntax invalid
 

--- a/internal/validate/uuid_test.go
+++ b/internal/validate/uuid_test.go
@@ -97,27 +97,41 @@ func TestUUID_NullAndUnknown(t *testing.T) {
 
 func TestIsUUID(t *testing.T) {
 	t.Parallel()
-	if !validate.IsUUID("550e8400-e29b-41d4-a716-446655440000") {
-		t.Error("expected valid UUID to return true")
+	valid := []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"deey8xhb2bm3fxpobcxyddfv", // modern NanoID/Cuid2 (24)
+		"usoc080",                  // legacy Cuid2(7)
+		"lk4cosc",                  // legacy Cuid2(7)
 	}
-	if !validate.IsUUID("deey8xhb2bm3fxpobcxyddfv") {
-		t.Error("expected valid NanoID to return true")
+	for _, s := range valid {
+		if !validate.IsUUID(s) {
+			t.Errorf("IsUUID(%q) should be true", s)
+		}
 	}
-	if validate.IsUUID("not-a-uuid") {
-		t.Error("expected invalid string to return false")
+	invalid := []string{
+		"not-a-uuid",
+		"../../admin",
+		"",
+		"abc123",  // 6 chars (legacy min - 1)
+		"abc12345", // 8 chars (legacy + 1)
 	}
-	if validate.IsUUID("../../admin") {
-		t.Error("expected path traversal to return false")
-	}
-	if validate.IsUUID("") {
-		t.Error("expected empty string to return false")
+	for _, s := range invalid {
+		if validate.IsUUID(s) {
+			t.Errorf("IsUUID(%q) should be false", s)
+		}
 	}
 }
 
 func TestImportUUID_Valid(t *testing.T) {
 	t.Parallel()
-	if err := validate.ImportUUID("550e8400-e29b-41d4-a716-446655440000"); err != nil {
-		t.Errorf("expected nil error for valid UUID, got: %v", err)
+	for _, id := range []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"usoc080",
+		"deey8xhb2bm3fxpobcxyddfv",
+	} {
+		if err := validate.ImportUUID(id); err != nil {
+			t.Errorf("ImportUUID(%q) expected nil, got: %v", id, err)
+		}
 	}
 }
 
@@ -130,19 +144,24 @@ func TestImportUUID_Invalid(t *testing.T) {
 	if !strings.Contains(err.Error(), "../../admin") {
 		t.Errorf("error should contain the bad ID, got: %v", err)
 	}
+	if err := validate.ImportUUID("abc123"); err == nil {
+		t.Error("expected error for 6-char id")
+	}
 }
 
 func TestParseCompoundImportID_SimpleUUID(t *testing.T) {
 	t.Parallel()
-	parsed, compound, err := validate.ParseCompoundImportID("deey8xhb2bm3fxpobcxyddfv")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if compound {
-		t.Error("expected compound=false for simple UUID")
-	}
-	if parsed.UUID != "deey8xhb2bm3fxpobcxyddfv" {
-		t.Errorf("expected UUID=%q, got %q", "deey8xhb2bm3fxpobcxyddfv", parsed.UUID)
+	for _, id := range []string{"deey8xhb2bm3fxpobcxyddfv", "usoc080"} {
+		parsed, compound, err := validate.ParseCompoundImportID(id)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", id, err)
+		}
+		if compound {
+			t.Errorf("expected compound=false for simple id %q", id)
+		}
+		if parsed.UUID != id {
+			t.Errorf("expected UUID=%q, got %q", id, parsed.UUID)
+		}
 	}
 }
 
@@ -224,35 +243,51 @@ func newImportStateResponse(s schema.Schema) *resource.ImportStateResponse {
 
 func TestImportParentChild_Valid(t *testing.T) {
 	t.Parallel()
-	parentUUID := "550e8400-e29b-41d4-a716-446655440000"
-	childUUID := "aaaa0001-0001-4000-8000-000000000001"
+	cases := []struct {
+		name       string
+		parentUUID string
+		childUUID  string
+	}{
+		{
+			name:       "rfc-uuid",
+			parentUUID: "550e8400-e29b-41d4-a716-446655440000",
+			childUUID:  "aaaa0001-0001-4000-8000-000000000001",
+		},
+		{
+			name:       "legacy-cuid2-7",
+			parentUUID: "usoc080",
+			childUUID:  "lk4cosc",
+		},
+	}
 	allowedTypes := []string{"application", "service", "database"}
 
-	for _, typ := range allowedTypes {
-		t.Run(typ, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			s := importParentChildSchema(allowedTypes)
-			resp := newImportStateResponse(s)
-			req := resource.ImportStateRequest{ID: typ + ":" + parentUUID + ":" + childUUID}
+	for _, tc := range cases {
+		for _, typ := range allowedTypes {
+			t.Run(tc.name+"/"+typ, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				s := importParentChildSchema(allowedTypes)
+				resp := newImportStateResponse(s)
+				req := resource.ImportStateRequest{ID: typ + ":" + tc.parentUUID + ":" + tc.childUUID}
 
-			validate.ImportParentChild(ctx, req, resp, allowedTypes, "storage")
+				validate.ImportParentChild(ctx, req, resp, allowedTypes, "storage")
 
-			if resp.Diagnostics.HasError() {
-				t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
-			}
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+				}
 
-			var gotParent, gotChild types.String
-			resp.State.GetAttribute(ctx, path.Root(typ+"_uuid"), &gotParent)
-			resp.State.GetAttribute(ctx, path.Root("uuid"), &gotChild)
+				var gotParent, gotChild types.String
+				resp.State.GetAttribute(ctx, path.Root(typ+"_uuid"), &gotParent)
+				resp.State.GetAttribute(ctx, path.Root("uuid"), &gotChild)
 
-			if gotParent.ValueString() != parentUUID {
-				t.Errorf("expected %s_uuid=%s, got %s", typ, parentUUID, gotParent.ValueString())
-			}
-			if gotChild.ValueString() != childUUID {
-				t.Errorf("expected uuid=%s, got %s", childUUID, gotChild.ValueString())
-			}
-		})
+				if gotParent.ValueString() != tc.parentUUID {
+					t.Errorf("expected %s_uuid=%s, got %s", typ, tc.parentUUID, gotParent.ValueString())
+				}
+				if gotChild.ValueString() != tc.childUUID {
+					t.Errorf("expected uuid=%s, got %s", tc.childUUID, gotChild.ValueString())
+				}
+			})
+		}
 	}
 }
 

--- a/internal/validate/uuid_test.go
+++ b/internal/validate/uuid_test.go
@@ -112,7 +112,7 @@ func TestIsUUID(t *testing.T) {
 		"not-a-uuid",
 		"../../admin",
 		"",
-		"abc123",  // 6 chars (legacy min - 1)
+		"abc123",   // 6 chars (legacy min - 1)
 		"abc12345", // 8 chars (legacy + 1)
 	}
 	for _, s := range invalid {

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -73,13 +73,21 @@ required fields that are not always obvious:
 ```
 Error: Invalid Attribute Value
 uuid must be a valid UUID (e.g. "550e8400-e29b-41d4-a716-446655440000")
+or Coolify identifier
 ```
 
 **Cause:** a UUID field received a malformed value.
 
-**Fix:** check that all UUID values use the standard format
-(`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Find UUIDs in the Coolify UI
-or with `terraform state show`.
+**Fix:** Coolify resource ids are either:
+
+- RFC 4122 UUIDs (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`), or
+- Coolify identifiers: **exactly 7** alphanumeric characters (legacy
+  `Cuid2(7)`, still present on older instances and some Coolify Cloud
+  teams) or **20-36** alphanumeric characters (modern NanoID/Cuid2).
+
+Copy the id from the Coolify UI URL or API (`GET /servers`, etc.), or
+from `terraform state show`. Values with dashes outside the RFC form,
+underscores, spaces, or lengths other than 7 and 20-36 are rejected.
 
 ### Cron syntax invalid
 


### PR DESCRIPTION
## Summary

Follow-up MPI batch after the Cuid2(7) validator change (#611) and process fixes (#612, #613).

## Changes

1. **Tests** (`internal/validate`): exercise legacy 7-char ids on `IsUUID`, `ImportUUID`, simple compound import, and `ImportParentChild` (not only schema validator tables). Invalid 6/8-char bounds covered on helpers.
2. **Docs** (`common-errors` guide): document that Coolify accepts RFC UUIDs, exactly 7-char legacy ids, and 20-36 modern identifiers.
3. **Counts**: bump documented test floor from 1060+ to 1070+ (actual 1077).

## Validation

- `go test -race ./internal/validate/`
- `make ci` green locally

## Pre-rotation gate notes

- Main CI green after #611
- Open **release PR #614** (`chore(main): release 0.1.10`) left unmerged (needs explicit approval)
- Open issues #393/#394/#445 `blocked-upstream`; #591 coolify-channel tracking; #475 community promo (not code)