### PR TITLE
fix: richer API error context and Coolify id troubleshooting

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -62,6 +62,15 @@ body excerpts are truncated to 500 characters.
 
 ## Common Issues
 
+### Invalid UUID / Coolify identifier
+
+Plan fails with `must be a valid UUID ... or Coolify identifier` when a
+`*_uuid` attribute is malformed. Coolify accepts RFC 4122 UUIDs, legacy
+7-character ids (older Cloud teams and upgraded instances), and modern
+20-36 character ids. See the [Common Errors](./common-errors) guide for
+examples. TRACE logs show the HTTP path that returned 404 when an id
+looks valid but the resource is missing.
+
 ### "Provider produced inconsistent result after apply"
 
 This usually means the provider's schema default doesn't match what the

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -320,10 +320,10 @@ func (c *Client) doCachedList(ctx context.Context, path string, result interface
 	})
 
 	if resp.StatusCode == http.StatusNotFound {
-		return &NotFoundError{Message: fmt.Sprintf("resource not found: %s", extractAPIMessage(respBody))}
+		return &NotFoundError{Message: fmt.Sprintf("resource not found (GET %s): %s", path, extractAPIMessage(respBody))}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, extractAPIMessage(respBody))
+		return fmt.Errorf("API returned status %d for GET %s: %s", resp.StatusCode, path, extractAPIMessage(respBody))
 	}
 
 	// Cache only after successful unmarshal to avoid storing malformed data.
@@ -385,13 +385,13 @@ func (c *Client) doWithStatus(ctx context.Context, method, path string, body int
 
 	// Check 404 first, regardless of expectedStatus.
 	if resp.StatusCode == http.StatusNotFound {
-		return &NotFoundError{Message: fmt.Sprintf("resource not found: %s", extractAPIMessage(respBody))}
+		return &NotFoundError{Message: fmt.Sprintf("resource not found (%s %s): %s", method, path, extractAPIMessage(respBody))}
 	}
 	if expectedStatus != 0 && resp.StatusCode != expectedStatus {
-		return fmt.Errorf("expected status %d, got %d: %s", expectedStatus, resp.StatusCode, extractAPIMessage(respBody))
+		return fmt.Errorf("expected status %d, got %d for %s %s: %s", expectedStatus, resp.StatusCode, method, path, extractAPIMessage(respBody))
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("api error (status %d): %s", resp.StatusCode, extractAPIMessage(respBody))
+		return fmt.Errorf("api error (status %d) for %s %s: %s", resp.StatusCode, method, path, extractAPIMessage(respBody))
 	}
 
 	if result != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2455,6 +2455,9 @@ func TestClient_CreateProject_WrongStatusCode(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected status 201")
 	assert.Contains(t, err.Error(), "got 200")
+	// Method and path help operators map failures to the Coolify endpoint.
+	assert.Contains(t, err.Error(), "POST")
+	assert.Contains(t, err.Error(), "/api/v1/projects")
 }
 
 // --- Malformed JSON response ---

--- a/internal/validate/uuid.go
+++ b/internal/validate/uuid.go
@@ -14,9 +14,9 @@ import (
 
 // uuidRegexp matches RFC 4122 UUIDs (e.g. "550e8400-e29b-41d4-a716-446655440000")
 // and Coolify identifiers. Coolify has generated ids of two lengths:
-// exactly 7 chars via Cuid2(7) up to v4.0.0-beta.3xx (still live on older
+// exactly 7 chars via Cuid2(7) through ~v4.0.0-beta.310 (still live on older
 // instances and Coolify Cloud teams from that era, e.g. "usoc080"), and
-// 24 chars via Cuid2 / Str::random(24) since v4.0.0-beta.400 (e.g.
+// 24 chars via default Cuid2 / new_public_id() since ~v4.0.0-beta.320 (e.g.
 // "deey8xhb2bm3fxpobcxyddfv"). The 20-36 branch keeps headroom around the
 // modern length; 8-19 char ids never existed and stay rejected.
 var uuidRegexp = regexp.MustCompile(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-zA-Z]{7}|[0-9a-zA-Z]{20,36})$`)

--- a/internal/validate/uuid_test.go
+++ b/internal/validate/uuid_test.go
@@ -27,7 +27,7 @@ func TestUUID_Valid(t *testing.T) {
 		"abcdefghij0123456789",                 // 20 chars
 		"abcdefghij0123456789ABCDEFGHIJ012345", // boundary: exactly 36 chars
 		"ABCDEFghij0123456789abcdef",           // mixed case (26 chars)
-		// Legacy Cuid2(7) Coolify identifiers (pre v4.0.0-beta.400)
+		// Legacy Cuid2(7) Coolify identifiers (pre ~v4.0.0-beta.320)
 		"usoc080", // real legacy id (7 chars)
 		"lk4cosc", // real legacy id (7 chars)
 	}

--- a/templates/guides/troubleshooting.md.tmpl
+++ b/templates/guides/troubleshooting.md.tmpl
@@ -62,6 +62,15 @@ body excerpts are truncated to 500 characters.
 
 ## Common Issues
 
+### Invalid UUID / Coolify identifier
+
+Plan fails with `must be a valid UUID ... or Coolify identifier` when a
+`*_uuid` attribute is malformed. Coolify accepts RFC 4122 UUIDs, legacy
+7-character ids (older Cloud teams and upgraded instances), and modern
+20-36 character ids. See the [Common Errors](./common-errors) guide for
+examples. TRACE logs show the HTTP path that returned 404 when an id
+looks valid but the resource is missing.
+
 ### "Provider produced inconsistent result after apply"
 
 This usually means the provider's schema default doesn't match what the


### PR DESCRIPTION
## Summary

MPI cycle 1 continuation (perspectives Ops through Observability).

## Changes

1. **Client errors** include HTTP method and path on status mismatches, API errors, and 404s (e.g. `expected status 201, got 200 for POST /api/v1/projects`). Unit test asserts path/method presence.
2. **Docs** correct Cuid2 era comments (~beta.310 / ~beta.320) and add a troubleshooting section for invalid Coolify identifiers (links to common-errors).

## Perspective outcomes

| Perspective | Result |
|-------------|--------|
| Ops/SRE | No-op (event-only workflows without `workflow_dispatch` are intentional) |
| Security | No-op (sensitive fields already marked) |
| Product Manager | No-op |
| Spec/Contract | Fixed inaccurate Coolify id era comments |
| Performance | No-op |
| Backward Compatibility | No-op (recent validator change is strictly more permissive) |
| Adversarial | No-op (7-char alnum still client-side only; API 404 remains) |
| Architecture | No-op |
| New Contributor | Troubleshooting UUID section + common-errors already updated in #615 |
| Observability | Fixed path/method on client API errors |

## Validation

- `go test -race ./internal/client/ ./internal/validate/`
- `make ci` green locally

## Note

Release PR #614 still open; not merged by this work.