### PR TITLE
fix: accept unknown docker_compose_raw/type in service ValidateConfig

### DIFF
--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -214,8 +214,17 @@ func (r *serviceResource) ValidateConfig(ctx context.Context, req resource.Valid
 		return
 	}
 
-	hasType := !model.Type.IsNull() && !model.Type.IsUnknown()
-	hasCompose := !model.DockerComposeRaw.IsNull() && !model.DockerComposeRaw.IsUnknown()
+	// Values that come from variables, data sources or other resources are
+	// still unknown when ValidateConfig runs. Treat unknown as "set": the
+	// attribute is present in the config, only its value is not resolved yet.
+	// Without this, a config like docker_compose_raw = var.compose fails
+	// validation with "One of type or docker_compose_raw must be set".
+	if model.Type.IsUnknown() || model.DockerComposeRaw.IsUnknown() {
+		return
+	}
+
+	hasType := !model.Type.IsNull()
+	hasCompose := !model.DockerComposeRaw.IsNull()
 
 	if hasType && hasCompose {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -202,11 +202,14 @@ func (r *serviceResource) Configure(_ context.Context, req resource.ConfigureReq
 	r.client = flex.ConfigureClient(req, &resp.Diagnostics)
 }
 
-// ValidateConfig checks that type and docker_compose_raw are not both set.
+// ValidateConfig checks that exactly one of type or docker_compose_raw is set.
 // We use ValidateConfig instead of stringvalidator.ExactlyOneOf because type
 // is Optional+Computed with UseStateForUnknown. ExactlyOneOf operates at the
 // attribute level and would misfire when the computed value is populated from
 // state, incorrectly rejecting configs that only set docker_compose_raw.
+//
+// Unknown values (from variables, data sources, or other resources) must not
+// be treated as absent: ValidateConfig runs before those values are resolved.
 func (r *serviceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var model serviceResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)

--- a/internal/service/service/resource_validate_config_test.go
+++ b/internal/service/service/resource_validate_config_test.go
@@ -48,7 +48,7 @@ func serviceValidateConfig(t *testing.T, typeVal, composeVal types.String) resou
 
 	resp := resource.ValidateConfigResponse{}
 	r.ValidateConfig(ctx, resource.ValidateConfigRequest{
-		Config: tfsdk.Config{Schema: state.Schema, Raw: state.Raw},
+		Config: tfsdk.Config(state),
 	}, &resp)
 	return resp
 }

--- a/internal/service/service/resource_validate_config_test.go
+++ b/internal/service/service/resource_validate_config_test.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// serviceValidateConfig runs ValidateConfig with the given type and
+// docker_compose_raw values (other attributes left null).
+func serviceValidateConfig(t *testing.T, typeVal, composeVal types.String) resource.ValidateConfigResponse {
+	t.Helper()
+	ctx := context.Background()
+	r := &serviceResource{}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	state := tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+	}
+	// Required-looking ids so Config.Get is realistic; validation only
+	// inspects type and docker_compose_raw.
+	for _, set := range []struct {
+		p path.Path
+		v types.String
+	}{
+		{path.Root("project_uuid"), types.StringValue("aaaa0001-0001-4000-8000-000000000001")},
+		{path.Root("server_uuid"), types.StringValue("bbbb0001-0001-4000-8000-000000000001")},
+		{path.Root("type"), typeVal},
+		{path.Root("docker_compose_raw"), composeVal},
+	} {
+		diags := state.SetAttribute(ctx, set.p, set.v)
+		if diags.HasError() {
+			t.Fatalf("set %s: %v", set.p, diags.Errors())
+		}
+	}
+
+	resp := resource.ValidateConfigResponse{}
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{
+		Config: tfsdk.Config{Schema: state.Schema, Raw: state.Raw},
+	}, &resp)
+	return resp
+}
+
+func TestServiceResource_ValidateConfig_UnknownComposeOrType(t *testing.T) {
+	t.Parallel()
+
+	compose := types.StringValue("version: '3'\nservices:\n  web:\n    image: nginx\n")
+	catalog := types.StringValue("plausible")
+
+	cases := []struct {
+		name    string
+		typ     types.String
+		compose types.String
+		wantErr *regexp.Regexp
+	}{
+		{
+			name:    "unknown compose only (var/data source pattern)",
+			typ:     types.StringNull(),
+			compose: types.StringUnknown(),
+			wantErr: nil,
+		},
+		{
+			name:    "unknown type only",
+			typ:     types.StringUnknown(),
+			compose: types.StringNull(),
+			wantErr: nil,
+		},
+		{
+			name:    "both unknown",
+			typ:     types.StringUnknown(),
+			compose: types.StringUnknown(),
+			wantErr: nil,
+		},
+		{
+			name:    "known compose only",
+			typ:     types.StringNull(),
+			compose: compose,
+			wantErr: nil,
+		},
+		{
+			name:    "known type only",
+			typ:     catalog,
+			compose: types.StringNull(),
+			wantErr: nil,
+		},
+		{
+			name:    "neither set",
+			typ:     types.StringNull(),
+			compose: types.StringNull(),
+			wantErr: regexp.MustCompile(`(?i)must be set|missing required`),
+		},
+		{
+			name:    "both known set",
+			typ:     catalog,
+			compose: compose,
+			wantErr: regexp.MustCompile(`(?i)mutually exclusive|conflicting`),
+		},
+		// Conflict is deferred while either side is still unknown.
+		{
+			name:    "known type and unknown compose",
+			typ:     catalog,
+			compose: types.StringUnknown(),
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := serviceValidateConfig(t, tc.typ, tc.compose)
+			if tc.wantErr == nil {
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+				}
+				return
+			}
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("expected validation error, got none")
+			}
+			var details string
+			for _, d := range resp.Diagnostics.Errors() {
+				details += d.Summary() + " " + d.Detail() + "\n"
+			}
+			if !tc.wantErr.MatchString(details) {
+				t.Fatalf("error %q does not match %s", details, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Same fix as #616 (by @oter), plus regression tests. Could not push to the fork (`maintainer_can_modify` is true but the API only grants pull on `oter/terraform-provider-coolify`), so this branch carries the original author commit plus tests.

## Problem

`ValidateConfig` treated unknown values as absent, so configs like:

```hcl
docker_compose_raw = var.workers_compose
```

failed with `One of "type" or "docker_compose_raw" must be set` even though the attribute is set (value not resolved yet).

## Fix

Return early when either attribute is unknown; null/both-set checks still run when values are known.

## Tests

Table-driven `ValidateConfig` coverage:

- unknown compose / type / both → no error
- known compose only / type only → no error
- neither set → missing error
- both known set → conflict error
- known type + unknown compose → no error (conflict deferred)

## Credits

Primary fix: @oter (`cff1fda` cherry-picked with original author and DCO).

## Ref

Supersedes #616