### PR TITLE
fix: ValidateConfig unknown guards for backups and richer client errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-37 resources, 54 data sources, 1070+ tests (unit + acceptance), 9 CI jobs.
+37 resources, 54 data sources, 1080+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -219,7 +219,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1070+ tests (unit + acceptance)
+- 1080+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 37 |
 | Data sources | 44 |
-| Tests | 1070+ unit and acceptance tests |
+| Tests | 1080+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -304,7 +304,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1070+ tests, race detector enabled)
+make test                                       # Run unit tests (1080+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -298,14 +298,14 @@ func (c *Client) doCachedList(ctx context.Context, path string, result interface
 	tflog.Trace(ctx, "API request", map[string]interface{}{"method": "GET", "path": path})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return fmt.Errorf("creating request for GET %s: %w", path, err)
 	}
 	c.setCommonHeaders(req)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
+		return fmt.Errorf("executing request for GET %s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -358,7 +358,7 @@ func (c *Client) doWithStatus(ctx context.Context, method, path string, body int
 
 	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, reqBody)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return fmt.Errorf("creating request for %s %s: %w", method, path, err)
 	}
 	c.setCommonHeaders(req)
 	req.Header.Set("Accept", "application/json")
@@ -368,7 +368,7 @@ func (c *Client) doWithStatus(ctx context.Context, method, path string, body int
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
+		return fmt.Errorf("executing request for %s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/internal/service/database/backup/resource.go
+++ b/internal/service/database/backup/resource.go
@@ -190,14 +190,20 @@ func (r *databaseBackupResource) ValidateConfig(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !config.SaveS3.IsNull() && !config.SaveS3.IsUnknown() && config.SaveS3.ValueBool() {
-		if config.S3StorageUUID.IsNull() || config.S3StorageUUID.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("s3_storage_uuid"),
-				"Missing S3 Storage UUID",
-				"`s3_storage_uuid` must be set when `save_s3` is `true`.",
-			)
-		}
+	// Only enforce when save_s3 is known true. Unknown s3_storage_uuid
+	// (e.g. from a data source or resource reference) must not fail plan.
+	if config.SaveS3.IsNull() || config.SaveS3.IsUnknown() || !config.SaveS3.ValueBool() {
+		return
+	}
+	if config.S3StorageUUID.IsUnknown() {
+		return
+	}
+	if config.S3StorageUUID.IsNull() || config.S3StorageUUID.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("s3_storage_uuid"),
+			"Missing S3 Storage UUID",
+			"`s3_storage_uuid` must be set when `save_s3` is `true`.",
+		)
 	}
 }
 

--- a/internal/service/database/backup/resource_validate_config_test.go
+++ b/internal/service/database/backup/resource_validate_config_test.go
@@ -1,0 +1,110 @@
+package backup
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func databaseBackupValidateConfig(t *testing.T, saveS3 types.Bool, s3UUID types.String) resource.ValidateConfigResponse {
+	t.Helper()
+	ctx := context.Background()
+	r := &databaseBackupResource{}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	state := tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+	}
+	for _, set := range []struct {
+		p path.Path
+		v any
+	}{
+		{path.Root("database_uuid"), types.StringValue("eeee0001-0001-4000-8000-000000000001")},
+		{path.Root("frequency"), types.StringValue("0 2 * * *")},
+		{path.Root("save_s3"), saveS3},
+		{path.Root("s3_storage_uuid"), s3UUID},
+	} {
+		diags := state.SetAttribute(ctx, set.p, set.v)
+		if diags.HasError() {
+			t.Fatalf("set %s: %v", set.p, diags.Errors())
+		}
+	}
+
+	resp := resource.ValidateConfigResponse{}
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{
+		Config: tfsdk.Config(state),
+	}, &resp)
+	return resp
+}
+
+func TestDatabaseBackupResource_ValidateConfig_UnknownS3UUID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		saveS3  types.Bool
+		s3UUID  types.String
+		wantErr *regexp.Regexp
+	}{
+		{
+			name:    "unknown s3 uuid with save_s3 true must not error",
+			saveS3:  types.BoolValue(true),
+			s3UUID:  types.StringUnknown(),
+			wantErr: nil,
+		},
+		{
+			name:    "unknown save_s3 must not error",
+			saveS3:  types.BoolUnknown(),
+			s3UUID:  types.StringNull(),
+			wantErr: nil,
+		},
+		{
+			name:    "known save_s3 true without uuid still errors",
+			saveS3:  types.BoolValue(true),
+			s3UUID:  types.StringNull(),
+			wantErr: regexp.MustCompile(`Missing S3 Storage UUID`),
+		},
+		{
+			name:    "valid pair ok",
+			saveS3:  types.BoolValue(true),
+			s3UUID:  types.StringValue("cccc0003-0003-4000-8000-000000000003"),
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := databaseBackupValidateConfig(t, tc.saveS3, tc.s3UUID)
+			hasErr := resp.Diagnostics.HasError()
+			if tc.wantErr == nil {
+				if hasErr {
+					t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+				}
+				return
+			}
+			if !hasErr {
+				t.Fatal("expected validation error, got none")
+			}
+			var joined string
+			for _, d := range resp.Diagnostics.Errors() {
+				joined += d.Detail() + " " + d.Summary()
+			}
+			if !tc.wantErr.MatchString(joined) {
+				t.Fatalf("error %q does not match %s", joined, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/service/volumebackup/resource.go
+++ b/internal/service/volumebackup/resource.go
@@ -212,14 +212,21 @@ func (r *storageBackupResource) ValidateConfig(ctx context.Context, req resource
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if cfg.DisableLocalBackup.ValueBool() && !cfg.SaveS3.ValueBool() {
+	// Unknown attributes (vars, references) must not be treated as false/empty.
+	// ValueBool() on unknown is false, which falsely triggers these checks.
+	if cfg.DisableLocalBackup.IsUnknown() || cfg.SaveS3.IsUnknown() || cfg.S3StorageUUID.IsUnknown() {
+		return
+	}
+	if !cfg.DisableLocalBackup.IsNull() && cfg.DisableLocalBackup.ValueBool() &&
+		(cfg.SaveS3.IsNull() || !cfg.SaveS3.ValueBool()) {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("disable_local_backup"),
 			"Invalid backup destinations",
 			"disable_local_backup requires save_s3 = true (Coolify rejects local-only disable).",
 		)
 	}
-	if cfg.SaveS3.ValueBool() && (cfg.S3StorageUUID.IsNull() || cfg.S3StorageUUID.ValueString() == "") {
+	if !cfg.SaveS3.IsNull() && cfg.SaveS3.ValueBool() &&
+		(cfg.S3StorageUUID.IsNull() || cfg.S3StorageUUID.ValueString() == "") {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("s3_storage_uuid"),
 			"Missing S3 storage",

--- a/internal/service/volumebackup/resource_validate_config_test.go
+++ b/internal/service/volumebackup/resource_validate_config_test.go
@@ -1,0 +1,128 @@
+package volumebackup
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func storageBackupValidateConfig(
+	t *testing.T,
+	saveS3, disableLocal types.Bool,
+	s3UUID types.String,
+) resource.ValidateConfigResponse {
+	t.Helper()
+	ctx := context.Background()
+	r := &storageBackupResource{}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	state := tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+	}
+	for _, set := range []struct {
+		p path.Path
+		v any
+	}{
+		{path.Root("application_uuid"), types.StringValue("aaaa0001-0001-4000-8000-000000000001")},
+		{path.Root("storage_uuid"), types.StringValue("bbbb0002-0002-4000-8000-000000000002")},
+		{path.Root("frequency"), types.StringValue("0 2 * * *")},
+		{path.Root("save_s3"), saveS3},
+		{path.Root("disable_local_backup"), disableLocal},
+		{path.Root("s3_storage_uuid"), s3UUID},
+	} {
+		diags := state.SetAttribute(ctx, set.p, set.v)
+		if diags.HasError() {
+			t.Fatalf("set %s: %v", set.p, diags.Errors())
+		}
+	}
+
+	resp := resource.ValidateConfigResponse{}
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{
+		Config: tfsdk.Config(state),
+	}, &resp)
+	return resp
+}
+
+func TestStorageBackupResource_ValidateConfig_UnknownAttrs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		saveS3       types.Bool
+		disableLocal types.Bool
+		s3UUID       types.String
+		wantErr      *regexp.Regexp
+	}{
+		{
+			name:         "unknown s3 uuid with save_s3 true must not error",
+			saveS3:       types.BoolValue(true),
+			disableLocal: types.BoolValue(false),
+			s3UUID:       types.StringUnknown(),
+			wantErr:      nil,
+		},
+		{
+			name:         "unknown save_s3 with disable_local true must not error",
+			saveS3:       types.BoolUnknown(),
+			disableLocal: types.BoolValue(true),
+			s3UUID:       types.StringNull(),
+			wantErr:      nil,
+		},
+		{
+			name:         "known save_s3 true without uuid still errors",
+			saveS3:       types.BoolValue(true),
+			disableLocal: types.BoolValue(false),
+			s3UUID:       types.StringNull(),
+			wantErr:      regexp.MustCompile(`s3_storage_uuid is required when save_s3 is true`),
+		},
+		{
+			name:         "known disable_local without save_s3 still errors",
+			saveS3:       types.BoolValue(false),
+			disableLocal: types.BoolValue(true),
+			s3UUID:       types.StringNull(),
+			wantErr:      regexp.MustCompile(`disable_local_backup requires save_s3`),
+		},
+		{
+			name:         "valid s3 pair ok",
+			saveS3:       types.BoolValue(true),
+			disableLocal: types.BoolValue(true),
+			s3UUID:       types.StringValue("cccc0003-0003-4000-8000-000000000003"),
+			wantErr:      nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := storageBackupValidateConfig(t, tc.saveS3, tc.disableLocal, tc.s3UUID)
+			hasErr := resp.Diagnostics.HasError()
+			if tc.wantErr == nil {
+				if hasErr {
+					t.Fatalf("unexpected errors: %v", resp.Diagnostics.Errors())
+				}
+				return
+			}
+			if !hasErr {
+				t.Fatal("expected validation error, got none")
+			}
+			var joined string
+			for _, d := range resp.Diagnostics.Errors() {
+				joined += d.Detail() + " " + d.Summary()
+			}
+			if !tc.wantErr.MatchString(joined) {
+				t.Fatalf("error %q does not match %s", joined, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

MPI cycle fixes for plan-time validation and client diagnostics.

## Changes

- **coolify_storage_backup** / **coolify_database_backup**: do not treat unknown attrs as false/empty in `ValidateConfig` (same class as service #616/#618). Plans that set `save_s3` / `s3_storage_uuid` / `disable_local_backup` via variables or references no longer fail incorrectly.
- Unit tests for known-error and unknown-skip ValidateConfig cases.
- **Client**: request create/execute errors include method and path.
- Docs: test count floor `1080+`.

## Related

- Ref #616 / #618 (service ValidateConfig pattern)
- Closes nothing for product backlog; filed #619 for application env advanced flags (`is_runtime`, etc.)

## Test plan

- [x] `make ci`
- [x] `go test -race ./internal/service/volumebackup/ ./internal/service/database/backup/ ./internal/client/`