### PR TITLE
feat: expose env is_runtime, is_literal, is_multiline, and comment

### DIFF
--- a/docs/data-sources/environment_variable.md
+++ b/docs/data-sources/environment_variable.md
@@ -44,7 +44,11 @@ output "env_var_value" {
 
 ### Read-Only
 
-- `is_build` (Boolean) Whether available at build time.
+- `comment` (String) Optional comment.
+- `is_build` (Boolean) Whether available at build time (applications).
+- `is_literal` (Boolean) Whether the value is literal.
+- `is_multiline` (Boolean) Whether the value is multiline.
 - `is_preview` (Boolean) Whether available in preview deployments.
+- `is_runtime` (Boolean) Whether available at runtime (applications).
 - `key` (String) The variable name.
 - `value` (String, Sensitive) The variable value.

--- a/docs/data-sources/environment_variables.md
+++ b/docs/data-sources/environment_variables.md
@@ -60,8 +60,12 @@ Required:
 
 Read-Only:
 
-- `is_build` (Boolean) Whether available at build time.
+- `comment` (String) Optional comment.
+- `is_build` (Boolean) Whether available at build time (applications).
+- `is_literal` (Boolean) Whether the value is literal.
+- `is_multiline` (Boolean) Whether the value is multiline.
 - `is_preview` (Boolean) Whether available in preview deployments.
+- `is_runtime` (Boolean) Whether available at runtime (applications).
 - `key` (String) The variable name.
 - `uuid` (String) The UUID of the environment variable.
 - `value` (String, Sensitive) The variable value.

--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Manages an environment variable on a Coolify application, service, or database.
   ~> Note: Each instance requires a List API call to read because the Coolify API does not provide a singular GET endpoint for environment variables. Large numbers of these resources on a single parent resource may cause slower plan/apply times due to this API limitation.
+  is_build and is_runtime are application-only (Coolify is_buildtime / is_runtime). is_literal, is_multiline, and comment are supported for applications, services, and databases.
 ---
 
 # coolify_environment_variable (Resource)
@@ -12,6 +13,8 @@ description: |-
 Manages an environment variable on a Coolify application, service, or database.
 
 ~> **Note:** Each instance requires a List API call to read because the Coolify API does not provide a singular GET endpoint for environment variables. Large numbers of these resources on a single parent resource may cause slower plan/apply times due to this API limitation.
+
+`is_build` and `is_runtime` are **application-only** (Coolify `is_buildtime` / `is_runtime`). `is_literal`, `is_multiline`, and `comment` are supported for applications, services, and databases.
 
 ## Example Usage
 
@@ -22,17 +25,32 @@ resource "coolify_environment_variable" "database_url" {
   key              = "DATABASE_URL"
   value            = "postgresql://user:pass@db:5432/myapp"
   is_build         = false
+  is_runtime       = true
   is_preview       = false
+  is_literal       = false
+  comment          = "Primary database DSN"
+}
+
+# Build-time only secret (not injected at runtime)
+resource "coolify_environment_variable" "npm_token" {
+  application_uuid = coolify_application.example.uuid
+  key              = "NPM_TOKEN"
+  value            = "change-me-in-production"
+  is_build         = true
+  is_runtime       = false
+  is_literal       = true
 }
 
 # Set a custom environment variable on a database
 # Note: do not duplicate built-in credential fields (e.g. POSTGRES_PASSWORD)
 # that are already managed by the database resource's own attributes.
-# `is_build` is application-only; omit it for database/service variables.
+# is_build / is_runtime are application-only; omit them for database/service variables.
 resource "coolify_environment_variable" "db_log_level" {
   database_uuid = coolify_database_postgresql.example.uuid
   key           = "POSTGRES_LOG_MIN_MESSAGES"
   value         = "warning"
+  is_literal    = true
+  comment       = "Quiet Postgres logs"
 }
 ```
 
@@ -47,9 +65,13 @@ resource "coolify_environment_variable" "db_log_level" {
 ### Optional
 
 - `application_uuid` (String) The UUID of the application to set the variable on. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. Changing this forces a new resource.
+- `comment` (String) Optional human-readable comment for the environment variable (max 256 characters on Coolify).
 - `database_uuid` (String) The UUID of the database to set the variable on. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. Changing this forces a new resource.
-- `is_build` (Boolean) Whether this variable is available at build time. Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.
+- `is_build` (Boolean) Whether this variable is available at build time (Coolify `is_buildtime`). Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.
+- `is_literal` (Boolean) Whether the value is treated as a literal (no Coolify escaping/expansion). Defaults to `false` when omitted on create.
+- `is_multiline` (Boolean) Whether the value is multiline. Defaults to `false` when omitted on create.
 - `is_preview` (Boolean) Whether this variable is available in preview deployments. Set it explicitly when you need preview-scoped behavior.
+- `is_runtime` (Boolean) Whether this variable is available at container runtime (Coolify `is_runtime`). Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.
 - `service_uuid` (String) The UUID of the service to set the variable on. Exactly one of `application_uuid`, `service_uuid`, or `database_uuid` must be provided. Changing this forces a new resource.
 
 ### Read-Only

--- a/examples/resources/coolify_environment_variable/resource.tf
+++ b/examples/resources/coolify_environment_variable/resource.tf
@@ -4,15 +4,30 @@ resource "coolify_environment_variable" "database_url" {
   key              = "DATABASE_URL"
   value            = "postgresql://user:pass@db:5432/myapp"
   is_build         = false
+  is_runtime       = true
   is_preview       = false
+  is_literal       = false
+  comment          = "Primary database DSN"
+}
+
+# Build-time only secret (not injected at runtime)
+resource "coolify_environment_variable" "npm_token" {
+  application_uuid = coolify_application.example.uuid
+  key              = "NPM_TOKEN"
+  value            = "change-me-in-production"
+  is_build         = true
+  is_runtime       = false
+  is_literal       = true
 }
 
 # Set a custom environment variable on a database
 # Note: do not duplicate built-in credential fields (e.g. POSTGRES_PASSWORD)
 # that are already managed by the database resource's own attributes.
-# `is_build` is application-only; omit it for database/service variables.
+# is_build / is_runtime are application-only; omit them for database/service variables.
 resource "coolify_environment_variable" "db_log_level" {
   database_uuid = coolify_database_postgresql.example.uuid
   key           = "POSTGRES_LOG_MIN_MESSAGES"
   value         = "warning"
+  is_literal    = true
+  comment       = "Quiet Postgres logs"
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -998,7 +998,7 @@ func TestClient_CreateEnvVar_Application(t *testing.T) {
 		Key:     "DATABASE_URL",
 		Value:   "postgres://localhost/db",
 		IsBuild: true,
-	}, &createIsBuild)
+	}, &EnvVarWriteOpts{IsBuild: &createIsBuild})
 	require.NoError(t, err)
 	assert.Equal(t, "env-new", resp.UUID)
 }
@@ -1662,11 +1662,12 @@ func TestClient_UpdateEnvVar_Application(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "test-token")
+	isBuild := false
 	err := c.UpdateEnvVar(context.Background(), "applications", "app-env-1", EnvironmentVariable{
 		Key:     "DATABASE_URL",
 		Value:   "postgres://new-host/db",
 		IsBuild: false,
-	})
+	}, &EnvVarWriteOpts{IsBuild: &isBuild})
 	require.NoError(t, err)
 }
 
@@ -1786,7 +1787,7 @@ func TestClient_UpdateEnvVar_Service(t *testing.T) {
 	err := c.UpdateEnvVar(context.Background(), "services", "svc-env-1", EnvironmentVariable{
 		Key:   "REDIS_URL",
 		Value: "redis://new-host:6379",
-	})
+	}, nil)
 	require.NoError(t, err)
 }
 
@@ -4162,8 +4163,73 @@ func TestClient_UpdateEnvVar_Database(t *testing.T) {
 	err := c.UpdateEnvVar(context.Background(), "databases", "db-env-1", EnvironmentVariable{
 		Key:   "DB_HOST",
 		Value: "new-host",
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestClient_CreateEnvVar_Application_ExtendedFlags(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var bodyMap map[string]any
+		require.NoError(t, json.Unmarshal(body, &bodyMap))
+		assert.Equal(t, "APP_SECRET", bodyMap["key"])
+		assert.Equal(t, false, bodyMap["is_runtime"])
+		assert.Equal(t, true, bodyMap["is_buildtime"])
+		assert.Equal(t, true, bodyMap["is_literal"])
+		assert.Equal(t, true, bodyMap["is_multiline"])
+		assert.Equal(t, "build only", bodyMap["comment"])
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(CreateEnvVarResponse{UUID: "env-ext"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	isBuild, isRuntime, isLiteral, isMulti := true, false, true, true
+	comment := "build only"
+	resp, err := c.CreateEnvVar(context.Background(), "applications", "app-1", EnvironmentVariable{
+		Key:   "APP_SECRET",
+		Value: "secret",
+	}, &EnvVarWriteOpts{
+		IsBuild:     &isBuild,
+		IsRuntime:   &isRuntime,
+		IsLiteral:   &isLiteral,
+		IsMultiline: &isMulti,
+		Comment:     &comment,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, "env-ext", resp.UUID)
+}
+
+func TestClient_CreateEnvVar_Service_LiteralComment(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var bodyMap map[string]any
+		require.NoError(t, json.Unmarshal(body, &bodyMap))
+		assert.Equal(t, true, bodyMap["is_literal"])
+		assert.Equal(t, "note", bodyMap["comment"])
+		assert.NotContains(t, bodyMap, "is_buildtime")
+		assert.NotContains(t, bodyMap, "is_runtime")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(CreateEnvVarResponse{UUID: "svc-ext"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	isLiteral := true
+	comment := "note"
+	resp, err := c.CreateEnvVar(context.Background(), "services", "svc-1", EnvironmentVariable{
+		Key:   "FLAG",
+		Value: "1",
+	}, &EnvVarWriteOpts{IsLiteral: &isLiteral, Comment: &comment})
+	require.NoError(t, err)
+	assert.Equal(t, "svc-ext", resp.UUID)
 }
 
 func TestClient_DeleteEnvVar_Database(t *testing.T) {

--- a/internal/client/environment_variables.go
+++ b/internal/client/environment_variables.go
@@ -9,11 +9,26 @@ import (
 
 // EnvironmentVariable represents a single environment variable from the Coolify API.
 type EnvironmentVariable struct {
-	UUID      string `json:"uuid,omitempty"`
-	Key       string `json:"key"`
-	Value     string `json:"value"`
-	IsPreview bool   `json:"is_preview"`
-	IsBuild   bool   `json:"is_buildtime"`
+	UUID        string `json:"uuid,omitempty"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	IsPreview   bool   `json:"is_preview"`
+	IsBuild     bool   `json:"is_buildtime"`
+	IsRuntime   bool   `json:"is_runtime"`
+	IsLiteral   bool   `json:"is_literal"`
+	IsMultiline bool   `json:"is_multiline"`
+	Comment     string `json:"comment,omitempty"`
+}
+
+// EnvVarWriteOpts holds optional fields for create/update payloads.
+// A nil pointer omits the JSON key so Coolify can apply its default.
+// Application-only: IsBuild, IsRuntime. All parents: IsLiteral, IsMultiline, Comment.
+type EnvVarWriteOpts struct {
+	IsBuild     *bool
+	IsRuntime   *bool
+	IsLiteral   *bool
+	IsMultiline *bool
+	Comment     *string
 }
 
 // PreferNonPreviewEnvVarsByKey collapses duplicate preview and non-preview rows
@@ -50,19 +65,28 @@ func FindEnvVarByUUID(envs []EnvironmentVariable, uuid string) (EnvironmentVaria
 	return EnvironmentVariable{}, false
 }
 
-// applicationEnvVarInput includes is_buildtime (only valid for applications).
+// applicationEnvVarInput is the write payload for application envs.
+// Coolify accepts is_runtime and is_buildtime only on applications.
 type applicationEnvVarInput struct {
-	Key       string `json:"key"`
-	Value     string `json:"value"`
-	IsPreview bool   `json:"is_preview"`
-	IsBuild   *bool  `json:"is_buildtime,omitempty"`
+	Key         string  `json:"key"`
+	Value       string  `json:"value"`
+	IsPreview   bool    `json:"is_preview"`
+	IsBuild     *bool   `json:"is_buildtime,omitempty"`
+	IsRuntime   *bool   `json:"is_runtime,omitempty"`
+	IsLiteral   *bool   `json:"is_literal,omitempty"`
+	IsMultiline *bool   `json:"is_multiline,omitempty"`
+	Comment     *string `json:"comment,omitempty"`
 }
 
-// envVarInput is the payload for service/database env var mutations.
+// envVarInput is the write payload for service/database envs.
+// Coolify does not accept is_buildtime / is_runtime on these parents.
 type envVarInput struct {
-	Key       string `json:"key"`
-	Value     string `json:"value"`
-	IsPreview bool   `json:"is_preview"`
+	Key         string  `json:"key"`
+	Value       string  `json:"value"`
+	IsPreview   bool    `json:"is_preview"`
+	IsLiteral   *bool   `json:"is_literal,omitempty"`
+	IsMultiline *bool   `json:"is_multiline,omitempty"`
+	Comment     *string `json:"comment,omitempty"`
 }
 
 // CreateEnvVarResponse is the response from creating an environment variable.
@@ -90,18 +114,39 @@ func envPath(parentType, parentUUID string) string {
 	return fmt.Sprintf("/api/v1/%s/%s/envs", parentType, url.PathEscape(parentUUID))
 }
 
+func buildEnvWriteInput(parentType string, key, value string, isPreview bool, opts *EnvVarWriteOpts) interface{} {
+	if opts == nil {
+		opts = &EnvVarWriteOpts{}
+	}
+	if parentType == "applications" {
+		return applicationEnvVarInput{
+			Key:         key,
+			Value:       value,
+			IsPreview:   isPreview,
+			IsBuild:     opts.IsBuild,
+			IsRuntime:   opts.IsRuntime,
+			IsLiteral:   opts.IsLiteral,
+			IsMultiline: opts.IsMultiline,
+			Comment:     opts.Comment,
+		}
+	}
+	return envVarInput{
+		Key:         key,
+		Value:       value,
+		IsPreview:   isPreview,
+		IsLiteral:   opts.IsLiteral,
+		IsMultiline: opts.IsMultiline,
+		Comment:     opts.Comment,
+	}
+}
+
 // CreateEnvVar creates an environment variable on a parent resource.
-// createIsBuild is only sent for applications (pass nil for services/databases).
-func (c *Client) CreateEnvVar(ctx context.Context, parentType, parentUUID string, ev EnvironmentVariable, createIsBuild *bool) (*CreateEnvVarResponse, error) {
+// Pass opts for optional flags; nil pointers are omitted from the JSON body.
+func (c *Client) CreateEnvVar(ctx context.Context, parentType, parentUUID string, ev EnvironmentVariable, opts *EnvVarWriteOpts) (*CreateEnvVarResponse, error) {
 	if err := validateParentType(parentType); err != nil {
 		return nil, err
 	}
-	var input interface{}
-	if parentType == "applications" {
-		input = applicationEnvVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview, IsBuild: createIsBuild}
-	} else {
-		input = envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
-	}
+	input := buildEnvWriteInput(parentType, ev.Key, ev.Value, ev.IsPreview, opts)
 	var r CreateEnvVarResponse
 	path := envPath(parentType, parentUUID)
 	if err := c.doWithStatus(ctx, http.MethodPost, path, input, &r, http.StatusCreated); err != nil {
@@ -125,17 +170,17 @@ func (c *Client) ListEnvVars(ctx context.Context, parentType, parentUUID string)
 }
 
 // UpdateEnvVar updates an environment variable on a parent resource.
-// For applications, is_buildtime is included in the payload.
-func (c *Client) UpdateEnvVar(ctx context.Context, parentType, parentUUID string, ev EnvironmentVariable) error {
+// opts should carry the flags to send; application paths may include IsBuild/IsRuntime.
+func (c *Client) UpdateEnvVar(ctx context.Context, parentType, parentUUID string, ev EnvironmentVariable, opts *EnvVarWriteOpts) error {
 	if err := validateParentType(parentType); err != nil {
 		return err
 	}
-	var input interface{}
-	if parentType == "applications" {
-		input = applicationEnvVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview, IsBuild: &ev.IsBuild}
-	} else {
-		input = envVarInput{Key: ev.Key, Value: ev.Value, IsPreview: ev.IsPreview}
+	if opts == nil {
+		// Back-compat: send build from entity for applications.
+		b := ev.IsBuild
+		opts = &EnvVarWriteOpts{IsBuild: &b}
 	}
+	input := buildEnvWriteInput(parentType, ev.Key, ev.Value, ev.IsPreview, opts)
 	path := envPath(parentType, parentUUID)
 	if err := c.do(ctx, http.MethodPatch, path, input, nil); err != nil {
 		return fmt.Errorf("updating %s env var %s: %w", parentType, parentUUID, err)

--- a/internal/client/environment_variables.go
+++ b/internal/client/environment_variables.go
@@ -176,9 +176,17 @@ func (c *Client) UpdateEnvVar(ctx context.Context, parentType, parentUUID string
 		return err
 	}
 	if opts == nil {
-		// Back-compat: send build from entity for applications.
-		b := ev.IsBuild
-		opts = &EnvVarWriteOpts{IsBuild: &b}
+		// Back-compat: populate write opts from the full entity so application
+		// omit-as-false fields (is_literal) are not silently cleared.
+		b, r, l, m := ev.IsBuild, ev.IsRuntime, ev.IsLiteral, ev.IsMultiline
+		c := ev.Comment
+		opts = &EnvVarWriteOpts{
+			IsBuild:     &b,
+			IsRuntime:   &r,
+			IsLiteral:   &l,
+			IsMultiline: &m,
+			Comment:     &c,
+		}
 	}
 	input := buildEnvWriteInput(parentType, ev.Key, ev.Value, ev.IsPreview, opts)
 	path := envPath(parentType, parentUUID)

--- a/internal/service/environmentvariable/data_source.go
+++ b/internal/service/environmentvariable/data_source.go
@@ -34,11 +34,15 @@ type envVarListModel struct {
 }
 
 type envVarItemModel struct {
-	UUID      types.String `tfsdk:"uuid"`
-	Key       types.String `tfsdk:"key"`
-	Value     types.String `tfsdk:"value"`
-	IsPreview types.Bool   `tfsdk:"is_preview"`
-	IsBuild   types.Bool   `tfsdk:"is_build"`
+	UUID        types.String `tfsdk:"uuid"`
+	Key         types.String `tfsdk:"key"`
+	Value       types.String `tfsdk:"value"`
+	IsPreview   types.Bool   `tfsdk:"is_preview"`
+	IsBuild     types.Bool   `tfsdk:"is_build"`
+	IsRuntime   types.Bool   `tfsdk:"is_runtime"`
+	IsLiteral   types.Bool   `tfsdk:"is_literal"`
+	IsMultiline types.Bool   `tfsdk:"is_multiline"`
+	Comment     types.String `tfsdk:"comment"`
 }
 
 // dsParentTypeAndUUID resolves which parent UUID attribute is set and returns
@@ -92,11 +96,15 @@ func (d *envVarListDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"uuid":       schema.StringAttribute{MarkdownDescription: "The UUID of the environment variable.", Computed: true},
-						"key":        schema.StringAttribute{MarkdownDescription: "The variable name.", Computed: true},
-						"value":      schema.StringAttribute{MarkdownDescription: "The variable value.", Computed: true, Sensitive: true},
-						"is_preview": schema.BoolAttribute{MarkdownDescription: "Whether available in preview deployments.", Computed: true},
-						"is_build":   schema.BoolAttribute{MarkdownDescription: "Whether available at build time.", Computed: true},
+						"uuid":         schema.StringAttribute{MarkdownDescription: "The UUID of the environment variable.", Computed: true},
+						"key":          schema.StringAttribute{MarkdownDescription: "The variable name.", Computed: true},
+						"value":        schema.StringAttribute{MarkdownDescription: "The variable value.", Computed: true, Sensitive: true},
+						"is_preview":   schema.BoolAttribute{MarkdownDescription: "Whether available in preview deployments.", Computed: true},
+						"is_build":     schema.BoolAttribute{MarkdownDescription: "Whether available at build time (applications).", Computed: true},
+						"is_runtime":   schema.BoolAttribute{MarkdownDescription: "Whether available at runtime (applications).", Computed: true},
+						"is_literal":   schema.BoolAttribute{MarkdownDescription: "Whether the value is literal.", Computed: true},
+						"is_multiline": schema.BoolAttribute{MarkdownDescription: "Whether the value is multiline.", Computed: true},
+						"comment":      schema.StringAttribute{MarkdownDescription: "Optional comment.", Computed: true},
 					},
 				},
 			},
@@ -144,6 +152,14 @@ func (d *envVarListDataSource) Read(ctx context.Context, req datasource.ReadRequ
 			return filter.BoolToString(ev.IsPreview), true
 		case "is_build":
 			return filter.BoolToString(ev.IsBuild), true
+		case "is_runtime":
+			return filter.BoolToString(ev.IsRuntime), true
+		case "is_literal":
+			return filter.BoolToString(ev.IsLiteral), true
+		case "is_multiline":
+			return filter.BoolToString(ev.IsMultiline), true
+		case "comment":
+			return ev.Comment, true
 		default:
 			return "", false
 		}
@@ -152,11 +168,15 @@ func (d *envVarListDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	items := make([]envVarItemModel, len(envVars))
 	for i, ev := range envVars {
 		items[i] = envVarItemModel{
-			UUID:      types.StringValue(ev.UUID),
-			Key:       types.StringValue(ev.Key),
-			Value:     types.StringValue(ev.Value),
-			IsPreview: types.BoolValue(ev.IsPreview),
-			IsBuild:   types.BoolValue(ev.IsBuild),
+			UUID:        types.StringValue(ev.UUID),
+			Key:         types.StringValue(ev.Key),
+			Value:       types.StringValue(ev.Value),
+			IsPreview:   types.BoolValue(ev.IsPreview),
+			IsBuild:     types.BoolValue(ev.IsBuild),
+			IsRuntime:   types.BoolValue(ev.IsRuntime),
+			IsLiteral:   types.BoolValue(ev.IsLiteral),
+			IsMultiline: types.BoolValue(ev.IsMultiline),
+			Comment:     types.StringValue(ev.Comment),
 		}
 	}
 	config.EnvironmentVariables = items

--- a/internal/service/environmentvariable/data_source_singular.go
+++ b/internal/service/environmentvariable/data_source_singular.go
@@ -34,6 +34,10 @@ type envVarDataSourceModel struct {
 	Value           types.String `tfsdk:"value"`
 	IsPreview       types.Bool   `tfsdk:"is_preview"`
 	IsBuild         types.Bool   `tfsdk:"is_build"`
+	IsRuntime       types.Bool   `tfsdk:"is_runtime"`
+	IsLiteral       types.Bool   `tfsdk:"is_literal"`
+	IsMultiline     types.Bool   `tfsdk:"is_multiline"`
+	Comment         types.String `tfsdk:"comment"`
 }
 
 // NewDataSource returns a new singular environment variable data source.
@@ -87,7 +91,23 @@ func (d *envVarDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed:            true,
 			},
 			"is_build": schema.BoolAttribute{
-				MarkdownDescription: "Whether available at build time.",
+				MarkdownDescription: "Whether available at build time (applications).",
+				Computed:            true,
+			},
+			"is_runtime": schema.BoolAttribute{
+				MarkdownDescription: "Whether available at runtime (applications).",
+				Computed:            true,
+			},
+			"is_literal": schema.BoolAttribute{
+				MarkdownDescription: "Whether the value is literal.",
+				Computed:            true,
+			},
+			"is_multiline": schema.BoolAttribute{
+				MarkdownDescription: "Whether the value is multiline.",
+				Computed:            true,
+			},
+			"comment": schema.StringAttribute{
+				MarkdownDescription: "Optional comment.",
 				Computed:            true,
 			},
 		},
@@ -131,5 +151,9 @@ func (d *envVarDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	config.Value = types.StringValue(ev.Value)
 	config.IsPreview = types.BoolValue(ev.IsPreview)
 	config.IsBuild = types.BoolValue(ev.IsBuild)
+	config.IsRuntime = types.BoolValue(ev.IsRuntime)
+	config.IsLiteral = types.BoolValue(ev.IsLiteral)
+	config.IsMultiline = types.BoolValue(ev.IsMultiline)
+	config.Comment = types.StringValue(ev.Comment)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/internal/service/environmentvariable/resource.go
+++ b/internal/service/environmentvariable/resource.go
@@ -155,6 +155,7 @@ func (r *environmentVariableResource) Schema(_ context.Context, _ resource.Schem
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Validators:          []validator.String{stringvalidator.LengthAtMost(256)},
 			},
 		},
 	}
@@ -241,6 +242,14 @@ func boolPtrIfKnown(v types.Bool) *bool {
 	return &b
 }
 
+func boolPtrKnownOrDefault(v types.Bool, def bool) *bool {
+	if v.IsNull() || v.IsUnknown() {
+		return &def
+	}
+	b := v.ValueBool()
+	return &b
+}
+
 func stringPtrIfKnown(v types.String) *string {
 	if v.IsNull() || v.IsUnknown() {
 		return nil
@@ -251,11 +260,19 @@ func stringPtrIfKnown(v types.String) *string {
 
 // writeOptsFromPlan builds create/update opts. Application-only flags are
 // only set for applications. Shared flags apply to all parents.
-func writeOptsFromPlan(parentType string, plan *environmentVariableResourceModel) *client.EnvVarWriteOpts {
+// forUpdate must be true on PATCH: Coolify application update uses
+// is_literal ?? false and assigns is_multiline without has(), so omitting
+// those keys would clear them.
+func writeOptsFromPlan(parentType string, plan *environmentVariableResourceModel, forUpdate bool) *client.EnvVarWriteOpts {
 	opts := &client.EnvVarWriteOpts{
-		IsLiteral:   boolPtrIfKnown(plan.IsLiteral),
-		IsMultiline: boolPtrIfKnown(plan.IsMultiline),
-		Comment:     stringPtrIfKnown(plan.Comment),
+		Comment: stringPtrIfKnown(plan.Comment),
+	}
+	if forUpdate && parentType == "applications" {
+		opts.IsLiteral = boolPtrKnownOrDefault(plan.IsLiteral, false)
+		opts.IsMultiline = boolPtrKnownOrDefault(plan.IsMultiline, false)
+	} else {
+		opts.IsLiteral = boolPtrIfKnown(plan.IsLiteral)
+		opts.IsMultiline = boolPtrIfKnown(plan.IsMultiline)
 	}
 	if parentType == "applications" {
 		opts.IsBuild = boolPtrIfKnown(plan.IsBuild)
@@ -278,7 +295,9 @@ func applyCreateDefaults(parentType string, plan *environmentVariableResourceMod
 			plan.IsRuntime = types.BoolValue(true)
 		}
 	} else {
-		// Not meaningful for service/database; store false so state is known.
+		// App-only attributes are not managed for service/database.
+		// Coolify model defaults both to true, but the provider surface
+		// treats them as false (ValidateConfig rejects user sets).
 		plan.IsBuild = types.BoolValue(false)
 		plan.IsRuntime = types.BoolValue(false)
 	}
@@ -293,7 +312,7 @@ func applyCreateDefaults(parentType string, plan *environmentVariableResourceMod
 	}
 }
 
-func flattenEnvToModel(ev client.EnvironmentVariable, state *environmentVariableResourceModel) {
+func flattenEnvToModel(parentType string, ev client.EnvironmentVariable, state *environmentVariableResourceModel) {
 	priorValue := ""
 	if !state.Value.IsNull() && !state.Value.IsUnknown() {
 		priorValue = state.Value.ValueString()
@@ -301,8 +320,14 @@ func flattenEnvToModel(ev client.EnvironmentVariable, state *environmentVariable
 	state.Key = types.StringValue(ev.Key)
 	state.Value = types.StringValue(client.PreserveEnvVarValue(ev.Value, priorValue))
 	state.IsPreview = types.BoolValue(ev.IsPreview)
-	state.IsBuild = types.BoolValue(ev.IsBuild)
-	state.IsRuntime = types.BoolValue(ev.IsRuntime)
+	if parentType == "applications" {
+		state.IsBuild = types.BoolValue(ev.IsBuild)
+		state.IsRuntime = types.BoolValue(ev.IsRuntime)
+	} else {
+		// Ignore Coolify model defaults (true/true); keep provider semantics.
+		state.IsBuild = types.BoolValue(false)
+		state.IsRuntime = types.BoolValue(false)
+	}
 	state.IsLiteral = types.BoolValue(ev.IsLiteral)
 	state.IsMultiline = types.BoolValue(ev.IsMultiline)
 	state.Comment = types.StringValue(ev.Comment)
@@ -333,7 +358,7 @@ func (r *environmentVariableResource) Create(ctx context.Context, req resource.C
 		Value:     plan.Value.ValueString(),
 		IsPreview: isPreview,
 	}
-	opts := writeOptsFromPlan(parentType, &plan)
+	opts := writeOptsFromPlan(parentType, &plan, false)
 
 	createResp, err := r.client.CreateEnvVar(ctx, parentType, parentUUID, ev, opts)
 	if err != nil {
@@ -342,23 +367,8 @@ func (r *environmentVariableResource) Create(ctx context.Context, req resource.C
 	}
 
 	plan.UUID = types.StringValue(createResp.UUID)
+	// Known plan values are preserved; null/unknown get Coolify defaults.
 	applyCreateDefaults(parentType, &plan)
-	// Overwrite defaults with known plan values that were sent.
-	if opts.IsBuild != nil {
-		plan.IsBuild = types.BoolValue(*opts.IsBuild)
-	}
-	if opts.IsRuntime != nil {
-		plan.IsRuntime = types.BoolValue(*opts.IsRuntime)
-	}
-	if opts.IsLiteral != nil {
-		plan.IsLiteral = types.BoolValue(*opts.IsLiteral)
-	}
-	if opts.IsMultiline != nil {
-		plan.IsMultiline = types.BoolValue(*opts.IsMultiline)
-	}
-	if opts.Comment != nil {
-		plan.Comment = types.StringValue(*opts.Comment)
-	}
 	plan.IsPreview = types.BoolValue(isPreview)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -398,7 +408,7 @@ func (r *environmentVariableResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	flattenEnvToModel(ev, &state)
+	flattenEnvToModel(parentType, ev, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -423,18 +433,7 @@ func (r *environmentVariableResource) Update(ctx context.Context, req resource.U
 		Value:     plan.Value.ValueString(),
 		IsPreview: plan.IsPreview.ValueBool(),
 	}
-	opts := writeOptsFromPlan(parentType, &plan)
-	// Ensure application flags are always sent on update when known in plan.
-	if parentType == "applications" {
-		if opts.IsBuild == nil && !plan.IsBuild.IsNull() && !plan.IsBuild.IsUnknown() {
-			b := plan.IsBuild.ValueBool()
-			opts.IsBuild = &b
-		}
-		if opts.IsRuntime == nil && !plan.IsRuntime.IsNull() && !plan.IsRuntime.IsUnknown() {
-			b := plan.IsRuntime.ValueBool()
-			opts.IsRuntime = &b
-		}
-	}
+	opts := writeOptsFromPlan(parentType, &plan, true)
 
 	if err := r.client.UpdateEnvVar(ctx, parentType, parentUUID, ev, opts); err != nil {
 		resp.Diagnostics.AddError("Error updating environment variable", fmt.Sprintf("%s %s env var %s: %s", parentLabel(parentType), parentUUID, plan.UUID.ValueString(), err))

--- a/internal/service/environmentvariable/resource.go
+++ b/internal/service/environmentvariable/resource.go
@@ -44,6 +44,10 @@ type environmentVariableResourceModel struct {
 	Value           types.String `tfsdk:"value"`
 	IsPreview       types.Bool   `tfsdk:"is_preview"`
 	IsBuild         types.Bool   `tfsdk:"is_build"`
+	IsRuntime       types.Bool   `tfsdk:"is_runtime"`
+	IsLiteral       types.Bool   `tfsdk:"is_literal"`
+	IsMultiline     types.Bool   `tfsdk:"is_multiline"`
+	Comment         types.String `tfsdk:"comment"`
 }
 
 // NewResource returns a new environmentVariableResource instance.
@@ -60,7 +64,9 @@ func (r *environmentVariableResource) Schema(_ context.Context, _ resource.Schem
 		MarkdownDescription: "Manages an environment variable on a Coolify application, service, or database.\n\n" +
 			"~> **Note:** Each instance requires a List API call to read because the Coolify API does not " +
 			"provide a singular GET endpoint for environment variables. Large numbers of these resources " +
-			"on a single parent resource may cause slower plan/apply times due to this API limitation.",
+			"on a single parent resource may cause slower plan/apply times due to this API limitation.\n\n" +
+			"`is_build` and `is_runtime` are **application-only** (Coolify `is_buildtime` / `is_runtime`). " +
+			"`is_literal`, `is_multiline`, and `comment` are supported for applications, services, and databases.",
 		Attributes: map[string]schema.Attribute{
 			"uuid": schema.StringAttribute{
 				MarkdownDescription: "The unique identifier of the environment variable.",
@@ -121,10 +127,34 @@ func (r *environmentVariableResource) Schema(_ context.Context, _ resource.Schem
 				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"is_build": schema.BoolAttribute{
-				MarkdownDescription: "Whether this variable is available at build time. Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.",
+				MarkdownDescription: "Whether this variable is available at build time (Coolify `is_buildtime`). Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"is_runtime": schema.BoolAttribute{
+				MarkdownDescription: "Whether this variable is available at container runtime (Coolify `is_runtime`). Supported only for application-scoped environment variables. If omitted during create, Coolify defaults application env vars to `true`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"is_literal": schema.BoolAttribute{
+				MarkdownDescription: "Whether the value is treated as a literal (no Coolify escaping/expansion). Defaults to `false` when omitted on create.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"is_multiline": schema.BoolAttribute{
+				MarkdownDescription: "Whether the value is multiline. Defaults to `false` when omitted on create.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"comment": schema.StringAttribute{
+				MarkdownDescription: "Optional human-readable comment for the environment variable (max 256 characters on Coolify).",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -141,35 +171,42 @@ func (r *environmentVariableResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
-	if config.IsBuild.IsNull() || config.IsBuild.IsUnknown() {
-		return
+	// Application-only flags: is_build and is_runtime.
+	appOnly := []struct {
+		attr path.Path
+		val  types.Bool
+		name string
+		api  string
+	}{
+		{path.Root("is_build"), config.IsBuild, "is_build", "is_buildtime"},
+		{path.Root("is_runtime"), config.IsRuntime, "is_runtime", "is_runtime"},
 	}
 
-	if !config.ApplicationUUID.IsNull() && !config.ApplicationUUID.IsUnknown() {
-		return
-	}
-
-	if !config.ServiceUUID.IsNull() && !config.ServiceUUID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("is_build"),
-			"Unsupported build-time environment variable scope",
-			"`is_build` is only supported for application-scoped environment variables because Coolify does not persist `is_buildtime` for services.",
-		)
-	}
-
-	if !config.DatabaseUUID.IsNull() && !config.DatabaseUUID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("is_build"),
-			"Unsupported build-time environment variable scope",
-			"`is_build` is only supported for application-scoped environment variables because Coolify does not persist `is_buildtime` for databases.",
-		)
+	for _, f := range appOnly {
+		if f.val.IsNull() || f.val.IsUnknown() {
+			continue
+		}
+		if !config.ApplicationUUID.IsNull() && !config.ApplicationUUID.IsUnknown() {
+			continue
+		}
+		if !config.ServiceUUID.IsNull() && !config.ServiceUUID.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				f.attr,
+				"Unsupported environment variable scope",
+				fmt.Sprintf("`%s` is only supported for application-scoped environment variables because Coolify does not persist `%s` for services.", f.name, f.api),
+			)
+		}
+		if !config.DatabaseUUID.IsNull() && !config.DatabaseUUID.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				f.attr,
+				"Unsupported environment variable scope",
+				fmt.Sprintf("`%s` is only supported for application-scoped environment variables because Coolify does not persist `%s` for databases.", f.name, f.api),
+			)
+		}
 	}
 }
 
-// parentTypeAndUUID resolves which parent resource UUID is set and returns the
-// API parent type ("applications", "services", or "databases") and the UUID.
 // parentLabel returns a user-friendly singular label for the API slug.
-// NOTE: update this when adding new parent types to parentTypeAndUUID().
 func parentLabel(slug string) string {
 	switch slug {
 	case "applications":
@@ -196,6 +233,81 @@ func parentTypeAndUUID(m *environmentVariableResourceModel) (string, string, boo
 	return "", "", false
 }
 
+func boolPtrIfKnown(v types.Bool) *bool {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	b := v.ValueBool()
+	return &b
+}
+
+func stringPtrIfKnown(v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	s := v.ValueString()
+	return &s
+}
+
+// writeOptsFromPlan builds create/update opts. Application-only flags are
+// only set for applications. Shared flags apply to all parents.
+func writeOptsFromPlan(parentType string, plan *environmentVariableResourceModel) *client.EnvVarWriteOpts {
+	opts := &client.EnvVarWriteOpts{
+		IsLiteral:   boolPtrIfKnown(plan.IsLiteral),
+		IsMultiline: boolPtrIfKnown(plan.IsMultiline),
+		Comment:     stringPtrIfKnown(plan.Comment),
+	}
+	if parentType == "applications" {
+		opts.IsBuild = boolPtrIfKnown(plan.IsBuild)
+		opts.IsRuntime = boolPtrIfKnown(plan.IsRuntime)
+	}
+	return opts
+}
+
+// applyCreateDefaults fills Optional+Computed fields after create when the
+// user omitted them (Coolify defaults).
+func applyCreateDefaults(parentType string, plan *environmentVariableResourceModel) {
+	if plan.IsPreview.IsNull() || plan.IsPreview.IsUnknown() {
+		plan.IsPreview = types.BoolValue(false)
+	}
+	if parentType == "applications" {
+		if plan.IsBuild.IsNull() || plan.IsBuild.IsUnknown() {
+			plan.IsBuild = types.BoolValue(true)
+		}
+		if plan.IsRuntime.IsNull() || plan.IsRuntime.IsUnknown() {
+			plan.IsRuntime = types.BoolValue(true)
+		}
+	} else {
+		// Not meaningful for service/database; store false so state is known.
+		plan.IsBuild = types.BoolValue(false)
+		plan.IsRuntime = types.BoolValue(false)
+	}
+	if plan.IsLiteral.IsNull() || plan.IsLiteral.IsUnknown() {
+		plan.IsLiteral = types.BoolValue(false)
+	}
+	if plan.IsMultiline.IsNull() || plan.IsMultiline.IsUnknown() {
+		plan.IsMultiline = types.BoolValue(false)
+	}
+	if plan.Comment.IsNull() || plan.Comment.IsUnknown() {
+		plan.Comment = types.StringValue("")
+	}
+}
+
+func flattenEnvToModel(ev client.EnvironmentVariable, state *environmentVariableResourceModel) {
+	priorValue := ""
+	if !state.Value.IsNull() && !state.Value.IsUnknown() {
+		priorValue = state.Value.ValueString()
+	}
+	state.Key = types.StringValue(ev.Key)
+	state.Value = types.StringValue(client.PreserveEnvVarValue(ev.Value, priorValue))
+	state.IsPreview = types.BoolValue(ev.IsPreview)
+	state.IsBuild = types.BoolValue(ev.IsBuild)
+	state.IsRuntime = types.BoolValue(ev.IsRuntime)
+	state.IsLiteral = types.BoolValue(ev.IsLiteral)
+	state.IsMultiline = types.BoolValue(ev.IsMultiline)
+	state.Comment = types.StringValue(ev.Comment)
+}
+
 func (r *environmentVariableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan environmentVariableResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -211,32 +323,44 @@ func (r *environmentVariableResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	isPreview := plan.IsPreview.ValueBool()
-	stateIsBuild := false
-	var createIsBuild *bool
-	if !plan.IsBuild.IsNull() && !plan.IsBuild.IsUnknown() {
-		stateIsBuild = plan.IsBuild.ValueBool()
-		createIsBuild = &stateIsBuild
-	} else if parentType == "applications" {
-		stateIsBuild = true
+	isPreview := false
+	if !plan.IsPreview.IsNull() && !plan.IsPreview.IsUnknown() {
+		isPreview = plan.IsPreview.ValueBool()
 	}
 
 	ev := client.EnvironmentVariable{
 		Key:       plan.Key.ValueString(),
 		Value:     plan.Value.ValueString(),
 		IsPreview: isPreview,
-		IsBuild:   stateIsBuild,
 	}
+	opts := writeOptsFromPlan(parentType, &plan)
 
-	createResp, err := r.client.CreateEnvVar(ctx, parentType, parentUUID, ev, createIsBuild)
+	createResp, err := r.client.CreateEnvVar(ctx, parentType, parentUUID, ev, opts)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating environment variable", fmt.Sprintf("env var %s: %s", plan.Key.ValueString(), err))
 		return
 	}
 
 	plan.UUID = types.StringValue(createResp.UUID)
+	applyCreateDefaults(parentType, &plan)
+	// Overwrite defaults with known plan values that were sent.
+	if opts.IsBuild != nil {
+		plan.IsBuild = types.BoolValue(*opts.IsBuild)
+	}
+	if opts.IsRuntime != nil {
+		plan.IsRuntime = types.BoolValue(*opts.IsRuntime)
+	}
+	if opts.IsLiteral != nil {
+		plan.IsLiteral = types.BoolValue(*opts.IsLiteral)
+	}
+	if opts.IsMultiline != nil {
+		plan.IsMultiline = types.BoolValue(*opts.IsMultiline)
+	}
+	if opts.Comment != nil {
+		plan.Comment = types.StringValue(*opts.Comment)
+	}
 	plan.IsPreview = types.BoolValue(isPreview)
-	plan.IsBuild = types.BoolValue(stateIsBuild)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	tflog.Debug(ctx, "created resource", map[string]interface{}{"resource_type": "coolify_environment_variable", "uuid": plan.UUID.ValueString()})
 }
@@ -274,16 +398,7 @@ func (r *environmentVariableResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	priorValue := ""
-	if !state.Value.IsNull() && !state.Value.IsUnknown() {
-		priorValue = state.Value.ValueString()
-	}
-
-	state.Key = types.StringValue(ev.Key)
-	state.Value = types.StringValue(client.PreserveEnvVarValue(ev.Value, priorValue))
-	state.IsPreview = types.BoolValue(ev.IsPreview)
-	state.IsBuild = types.BoolValue(ev.IsBuild)
-
+	flattenEnvToModel(ev, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -296,26 +411,38 @@ func (r *environmentVariableResource) Update(ctx context.Context, req resource.U
 
 	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_environment_variable", "uuid": plan.UUID.ValueString()})
 
-	ev := client.EnvironmentVariable{
-		Key:       plan.Key.ValueString(),
-		Value:     plan.Value.ValueString(),
-		IsPreview: plan.IsPreview.ValueBool(),
-		IsBuild:   plan.IsBuild.ValueBool(),
-	}
-
 	parentType, parentUUID, ok := parentTypeAndUUID(&plan)
 	if !ok {
 		resp.Diagnostics.AddError("Configuration Error", "One of application_uuid, service_uuid, or database_uuid must be set")
 		return
 	}
 
-	if err := r.client.UpdateEnvVar(ctx, parentType, parentUUID, ev); err != nil {
+	// On update, plan values are known (UseStateForUnknown / user input).
+	ev := client.EnvironmentVariable{
+		Key:       plan.Key.ValueString(),
+		Value:     plan.Value.ValueString(),
+		IsPreview: plan.IsPreview.ValueBool(),
+	}
+	opts := writeOptsFromPlan(parentType, &plan)
+	// Ensure application flags are always sent on update when known in plan.
+	if parentType == "applications" {
+		if opts.IsBuild == nil && !plan.IsBuild.IsNull() && !plan.IsBuild.IsUnknown() {
+			b := plan.IsBuild.ValueBool()
+			opts.IsBuild = &b
+		}
+		if opts.IsRuntime == nil && !plan.IsRuntime.IsNull() && !plan.IsRuntime.IsUnknown() {
+			b := plan.IsRuntime.ValueBool()
+			opts.IsRuntime = &b
+		}
+	}
+
+	if err := r.client.UpdateEnvVar(ctx, parentType, parentUUID, ev, opts); err != nil {
 		resp.Diagnostics.AddError("Error updating environment variable", fmt.Sprintf("%s %s env var %s: %s", parentLabel(parentType), parentUUID, plan.UUID.ValueString(), err))
 		return
 	}
 
-	plan.IsPreview = types.BoolValue(ev.IsPreview)
-	plan.IsBuild = types.BoolValue(ev.IsBuild)
+	// Ensure Optional+Computed values are known in state after update.
+	applyCreateDefaults(parentType, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/internal/service/environmentvariable/resource_test.go
+++ b/internal/service/environmentvariable/resource_test.go
@@ -414,11 +414,15 @@ func TestEnvironmentVariableResource_ReadMatchesExactUUIDEvenWithDuplicateKeys(t
 func TestEnvironmentVariableResource_Import(t *testing.T) {
 	t.Parallel()
 	envVar := client.EnvironmentVariable{
-		UUID:      "eeee0001-0001-4000-8000-000000000001",
-		Key:       "IMPORT_VAR",
-		Value:     "import-value",
-		IsPreview: false,
-		IsBuild:   true,
+		UUID:        "eeee0001-0001-4000-8000-000000000001",
+		Key:         "IMPORT_VAR",
+		Value:       "import-value",
+		IsPreview:   false,
+		IsBuild:     true,
+		IsRuntime:   true,
+		IsLiteral:   false,
+		IsMultiline: false,
+		Comment:     "",
 	}
 
 	mux := http.NewServeMux()
@@ -1642,4 +1646,231 @@ func checkEnvVarDestroy(serverURL, parentType, parentUUID string) resource.TestC
 		}
 		return nil
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnvironmentVariableResource_ApplicationExtendedFlags
+// ---------------------------------------------------------------------------
+
+func TestEnvironmentVariableResource_ApplicationExtendedFlags(t *testing.T) {
+	t.Parallel()
+	envVar := client.EnvironmentVariable{
+		UUID:        "env-ext-uuid",
+		Key:         "BUILD_SECRET",
+		Value:       "s3cret",
+		IsPreview:   false,
+		IsBuild:     true,
+		IsRuntime:   false,
+		IsLiteral:   true,
+		IsMultiline: false,
+		Comment:     "build only",
+	}
+	mu := sync.Mutex{}
+	deleted := false
+	var lastPOST map[string]interface{}
+	var lastPATCH map[string]interface{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("appUUID") != "cccc0001-0001-4000-8000-000000000001" {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		lastPOST = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": envVar.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if deleted {
+			json.NewEncoder(w).Encode([]client.EnvironmentVariable{})
+			return
+		}
+		json.NewEncoder(w).Encode([]client.EnvironmentVariable{envVar})
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{appUUID}/envs", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		lastPATCH = body
+		if v, ok := body["comment"].(string); ok {
+			envVar.Comment = v
+		}
+		if v, ok := body["is_runtime"].(bool); ok {
+			envVar.IsRuntime = v
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{appUUID}/envs/{envUUID}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		deleted = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "cccc0001-0001-4000-8000-000000000001"
+					key              = "BUILD_SECRET"
+					value            = "s3cret"
+					is_build         = true
+					is_runtime       = false
+					is_literal       = true
+					comment          = "build only"
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_build", "true"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_runtime", "false"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_literal", "true"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_multiline", "false"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "comment", "build only"),
+					resource.TestCheckFunc(func(_ *terraform.State) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if lastPOST["is_buildtime"] != true {
+							return fmt.Errorf("POST is_buildtime = %v, want true", lastPOST["is_buildtime"])
+						}
+						if lastPOST["is_runtime"] != false {
+							return fmt.Errorf("POST is_runtime = %v, want false", lastPOST["is_runtime"])
+						}
+						if lastPOST["is_literal"] != true {
+							return fmt.Errorf("POST is_literal = %v, want true", lastPOST["is_literal"])
+						}
+						if lastPOST["comment"] != "build only" {
+							return fmt.Errorf("POST comment = %v", lastPOST["comment"])
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "cccc0001-0001-4000-8000-000000000001"
+					key              = "BUILD_SECRET"
+					value            = "s3cret"
+					is_build         = true
+					is_runtime       = true
+					is_literal       = true
+					comment          = "now runtime too"
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_runtime", "true"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "comment", "now runtime too"),
+					resource.TestCheckFunc(func(_ *terraform.State) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if lastPATCH["is_runtime"] != true {
+							return fmt.Errorf("PATCH is_runtime = %v, want true", lastPATCH["is_runtime"])
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestEnvironmentVariableResource_ValidateConfig_RuntimeOnService(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testEnvVarResourceConfig(srv.URL, `
+				service_uuid = "dddd0001-0001-4000-8000-000000000001"
+				key          = "X"
+				value        = "1"
+				is_runtime   = true
+			`),
+			ExpectError: regexp.MustCompile(`only supported for application-scoped`),
+		}},
+	})
+}
+
+func TestEnvironmentVariableResource_ServiceLiteralComment(t *testing.T) {
+	t.Parallel()
+	envVar := client.EnvironmentVariable{
+		UUID:      "env-svc-lit",
+		Key:       "FLAG",
+		Value:     "1",
+		IsLiteral: true,
+		Comment:   "svc note",
+	}
+	mu := sync.Mutex{}
+	var lastPOST map[string]interface{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/services/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		lastPOST = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": envVar.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/services/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]client.EnvironmentVariable{envVar})
+	})
+	mux.HandleFunc("DELETE /api/v1/services/{uuid}/envs/{envUUID}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testEnvVarResourceConfig(srv.URL, `
+				service_uuid = "dddd0001-0001-4000-8000-000000000001"
+				key          = "FLAG"
+				value        = "1"
+				is_literal   = true
+				comment      = "svc note"
+			`),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_literal", "true"),
+				resource.TestCheckResourceAttr("coolify_environment_variable.test", "comment", "svc note"),
+				resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_build", "false"),
+				resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_runtime", "false"),
+				resource.TestCheckFunc(func(_ *terraform.State) error {
+					mu.Lock()
+					defer mu.Unlock()
+					if _, ok := lastPOST["is_buildtime"]; ok {
+						return fmt.Errorf("service POST must not send is_buildtime")
+					}
+					if _, ok := lastPOST["is_runtime"]; ok {
+						return fmt.Errorf("service POST must not send is_runtime")
+					}
+					if lastPOST["is_literal"] != true {
+						return fmt.Errorf("is_literal = %v", lastPOST["is_literal"])
+					}
+					return nil
+				}),
+			),
+		}},
+	})
 }

--- a/internal/service/environmentvariable/resource_test.go
+++ b/internal/service/environmentvariable/resource_test.go
@@ -1807,12 +1807,36 @@ func TestEnvironmentVariableResource_ValidateConfig_RuntimeOnService(t *testing.
 	})
 }
 
+func TestEnvironmentVariableResource_ValidateConfig_RuntimeOnDatabase(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testEnvVarResourceConfig(srv.URL, `
+				database_uuid = "eeee0001-0001-4000-8000-000000000001"
+				key           = "X"
+				value         = "1"
+				is_runtime    = true
+			`),
+			ExpectError: regexp.MustCompile(`only supported for application-scoped`),
+		}},
+	})
+}
+
 func TestEnvironmentVariableResource_ServiceLiteralComment(t *testing.T) {
 	t.Parallel()
+	// Coolify model defaults is_buildtime/is_runtime to true even for services;
+	// provider must not thrash state by reading those into app-only attrs.
 	envVar := client.EnvironmentVariable{
 		UUID:      "env-svc-lit",
 		Key:       "FLAG",
 		Value:     "1",
+		IsBuild:   true,
+		IsRuntime: true,
 		IsLiteral: true,
 		Comment:   "svc note",
 	}
@@ -1872,5 +1896,160 @@ func TestEnvironmentVariableResource_ServiceLiteralComment(t *testing.T) {
 				}),
 			),
 		}},
+	})
+}
+
+func TestEnvironmentVariableResource_ApplicationMultiline(t *testing.T) {
+	t.Parallel()
+	envVar := client.EnvironmentVariable{
+		UUID:        "env-ml",
+		Key:         "CERT",
+		Value:       "line1\nline2",
+		IsBuild:     true,
+		IsRuntime:   true,
+		IsMultiline: true,
+	}
+	mu := sync.Mutex{}
+	var lastPOST map[string]interface{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		lastPOST = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": envVar.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]client.EnvironmentVariable{envVar})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}/envs/{envUUID}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: testEnvVarResourceConfig(srv.URL, `
+				application_uuid = "aaaa0001-0001-4000-8000-000000000001"
+				key              = "CERT"
+				value            = "line1\nline2"
+				is_multiline     = true
+			`),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_multiline", "true"),
+				resource.TestCheckFunc(func(_ *terraform.State) error {
+					mu.Lock()
+					defer mu.Unlock()
+					if lastPOST["is_multiline"] != true {
+						return fmt.Errorf("POST is_multiline = %v, want true", lastPOST["is_multiline"])
+					}
+					return nil
+				}),
+			),
+		}},
+	})
+}
+
+func TestEnvironmentVariableResource_UpdateValueOnlyPreservesLiteral(t *testing.T) {
+	t.Parallel()
+	// Coolify application update uses is_literal ?? false; a value-only update
+	// must still send is_literal so a true value is not cleared.
+	envVar := client.EnvironmentVariable{
+		UUID:      "env-lit-upd",
+		Key:       "TOKEN",
+		Value:     "v1",
+		IsBuild:   true,
+		IsRuntime: true,
+		IsLiteral: true,
+	}
+	mu := sync.Mutex{}
+	var lastPATCH map[string]interface{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if v, ok := body["value"].(string); ok {
+			envVar.Value = v
+		}
+		if v, ok := body["is_literal"].(bool); ok {
+			envVar.IsLiteral = v
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"uuid": envVar.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]client.EnvironmentVariable{envVar})
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{uuid}/envs", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		lastPATCH = body
+		mu.Unlock()
+		if v, ok := body["value"].(string); ok {
+			envVar.Value = v
+		}
+		if v, ok := body["is_literal"].(bool); ok {
+			envVar.IsLiteral = v
+		}
+		if v, ok := body["is_multiline"].(bool); ok {
+			envVar.IsMultiline = v
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}/envs/{envUUID}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "aaaa0001-0001-4000-8000-000000000001"
+					key              = "TOKEN"
+					value            = "v1"
+					is_literal       = true
+				`),
+				Check: resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_literal", "true"),
+			},
+			{
+				Config: testEnvVarResourceConfig(srv.URL, `
+					application_uuid = "aaaa0001-0001-4000-8000-000000000001"
+					key              = "TOKEN"
+					value            = "v2"
+					is_literal       = true
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "value", "v2"),
+					resource.TestCheckResourceAttr("coolify_environment_variable.test", "is_literal", "true"),
+					resource.TestCheckFunc(func(_ *terraform.State) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if lastPATCH["is_literal"] != true {
+							return fmt.Errorf("PATCH is_literal = %v, want true (must not omit)", lastPATCH["is_literal"])
+						}
+						if lastPATCH["is_multiline"] != false {
+							return fmt.Errorf("PATCH is_multiline = %v, want false (must not omit)", lastPATCH["is_multiline"])
+						}
+						return nil
+					}),
+				),
+			},
+		},
 	})
 }

--- a/internal/spectest/contract_test.go
+++ b/internal/spectest/contract_test.go
@@ -448,19 +448,16 @@ func TestContractCoverage_PrivateKey(t *testing.T) {
 func TestContractCoverage_EnvironmentVariable(t *testing.T) {
 	t.Parallel()
 	contractCoverageTest(t, "EnvironmentVariable", reflect.TypeOf(client.EnvironmentVariable{}), map[string]bool{
-		"resourceable_id":   true,
-		"resourceable_type": true,
-		"team_id":           true,
+		"resourceable_id":   true, // polymorphic FK
+		"resourceable_type": true, // polymorphic FK
+		"team_id":           true, // internal FK
 		"real_value":        true, // computed accessor
-		"version":           true,
-		"comment":           true, // not exposed in provider
-		"is_literal":        true, // internal flag
-		"is_multiline":      true, // internal flag
-		"is_required":       true, // internal flag
-		"is_runtime":        true, // internal flag
-		"is_shared":         true, // internal flag
-		"is_shown_once":     true, // internal flag
+		"version":           true, // Coolify internal version stamp
+		"is_required":       true, // deferred product surface
+		"is_shared":         true, // computed/shared-var surface, not TF resource field
+		"is_shown_once":     true, // deferred UI-only flag (see #619 optional)
 		"order":             true, // UI ordering
+		// is_runtime, is_literal, is_multiline, comment, is_buildtime covered on client (#619)
 	})
 }
 


### PR DESCRIPTION
## Summary

Expose Coolify environment variable deploy/metadata fields that were previously unsupported in Terraform:

| Field | Scope | Notes |
|-------|--------|-------|
| `is_runtime` | Application only | Coolify default `true`; pairs with existing `is_build` (`is_buildtime`) |
| `is_literal` | App, service, database | Literal value handling |
| `is_multiline` | App, service, database | Multiline storage |
| `comment` | App, service, database | Optional metadata (max 256 chars) |

`ValidateConfig` rejects `is_build` / `is_runtime` on service and database parents (same pattern as before for `is_build`).

## Test plan

- [x] Unit tests: client create/update payloads for application and service
- [x] Resource tests: create with new flags, service literal, ValidateConfig rejects runtime on service
- [x] Contract ignore list updated for remaining deferred env fields
- [x] `make ci` green locally
- [ ] CI green on PR

Closes #619