### PR TITLE
test: contract skip taxonomy, write and schema coverage gates

### DIFF
--- a/.github/contract-freshness-issue.md
+++ b/.github/contract-freshness-issue.md
@@ -1,0 +1,16 @@
+The weekly contract-freshness check detected field or route changes in the upstream Coolify source code.
+
+## After updating the pin
+
+1. Run `make contract-extract` (or the versioned extract you use) and commit the pin (`testdata/contracts/coolify-v4.json` and versioned files as needed).
+2. Run `make contract-check` and `go test ./internal/spectest/ -run 'ContractCoverage|WriteCoverage|SchemaCoverage' -count=1`.
+3. For every new fillable or allow-list field:
+   - Implement client + Terraform schema, **or**
+   - Mark **deferred** with an open issue (`#N`) in the skip taxonomy / schema registry, **or**
+   - Mark **internal** / **n/a** only if truly non-user-facing (FK, computed, wrong parent, superseded name).
+4. Do **not** use comments like "internal flag" for public API fields (for example Coolify `$allowedFields` on create/update).
+5. Contract pipeline references:
+   - Ignore taxonomy: #622
+   - `allowed_fields` vs client write input: #623
+   - Schema coverage registry: #621
+   - Deferred field backlog: #626

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,12 +398,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh label create contract-drift --description "Upstream Coolify source contract has changed" --color "d93f0b" --force 2>/dev/null || true
+          BODY_FILE=.github/contract-freshness-issue.md
           EXISTING=$(gh issue list --label "contract-drift" --state open --json number --jq length)
           if [ "$EXISTING" = "0" ]; then
             gh issue create \
               --title "Upstream Coolify contract has changed" \
               --label "contract-drift" \
-              --body "The weekly contract-freshness check detected field or route changes in the upstream Coolify source code. Run \`make contract-extract\` to update the pinned contract and review the changes with \`make contract-check\`."
+              --body-file "$BODY_FILE"
+          else
+            NUM=$(gh issue list --label "contract-drift" --state open --json number --jq '.[0].number')
+            gh issue comment "$NUM" --body-file "$BODY_FILE"
           fi
 
   scenario-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,10 +405,9 @@ jobs:
               --title "Upstream Coolify contract has changed" \
               --label "contract-drift" \
               --body-file "$BODY_FILE"
-          else
-            NUM=$(gh issue list --label "contract-drift" --state open --json number --jq '.[0].number')
-            gh issue comment "$NUM" --body-file "$BODY_FILE"
           fi
+          # When a drift issue is already open, do not re-post the same checklist
+          # every week (noise). The open issue already carries the taxonomy body.
 
   scenario-tests:
     name: Scenario Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ mismatches, and zero validation rules when we compared it against the source.
 - `internal/acctest/` - Shared test utilities (provider factories, mock server wrappers, acceptance test helpers)
 - `internal/validate/` - Input validators (UUID format, FQDN URL)
 - `internal/spectest/` - OpenAPI spec compliance tests, API coverage tracking, and contract coverage tests
+- Contract skip taxonomy (`internal/spectest/skip.go`): `internal` (FK/computed), `deferred` (public field + open issue `#N`), `n/a` (wrong surface). Never label public `$allowedFields` as internal. Schema registry Phase A: EnvironmentVariable (`schema_coverage.go`). Write-path check: application env `allowed_fields` vs client input (`write_coverage_test.go`). Weekly drift issue body: `.github/contract-freshness-issue.md`.
 - `scripts/` - Contract extraction (`extract-contract.py`), OpenAPI generation (`generate-openapi.py`), contract diff (`diff-contracts.sh`)
 - `testdata/contracts/` - Versioned contract JSON files extracted from Coolify source (source of truth for API field definitions)
 - `examples/` - Working HCL examples per resource + multi-resource scenarios

--- a/internal/client/environment_variables.go
+++ b/internal/client/environment_variables.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
+	"strings"
 )
 
 // EnvironmentVariable represents a single environment variable from the Coolify API.
@@ -221,4 +223,37 @@ func (c *Client) BulkUpdateEnvVars(ctx context.Context, parentType, parentUUID s
 	}
 	c.listCache.invalidate(envPath(parentType, parentUUID))
 	return nil
+}
+
+// EnvVarWriteJSONTags returns JSON object keys present on create/update env
+// write payloads for the given parent type ("applications", "services", or
+// "databases"). Used by contract write-coverage tests (#623).
+func EnvVarWriteJSONTags(parentType string) map[string]struct{} {
+	var sample interface{}
+	if parentType == "applications" {
+		sample = applicationEnvVarInput{}
+	} else {
+		sample = envVarInput{}
+	}
+	return jsonTagsFromValue(sample)
+}
+
+func jsonTagsFromValue(v interface{}) map[string]struct{} {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	out := make(map[string]struct{}, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
 }

--- a/internal/spectest/contract_skips.go
+++ b/internal/spectest/contract_skips.go
@@ -1,0 +1,223 @@
+package spectest
+
+// Contract field skip tables (#622). deferred entries must cite an open issue.
+// Umbrella backlog for remaining product fields: #626.
+
+// applicationFieldSkips are Application model + ApplicationSetting fields not
+// required on client.Application.
+var applicationFieldSkips = skipMap(
+	// Internal DB identifiers (not exposed via API)
+	skipInternal("environment_id", "numeric FK"),
+	skipInternal("destination_id", "numeric FK"),
+	skipInternal("destination_type", "morph type"),
+	skipInternal("source_id", "numeric FK"),
+	skipInternal("source_type", "morph type"),
+	skipInternal("private_key_id", "numeric FK"),
+	skipInternal("repository_project_id", "numeric FK"),
+	// Computed/internal fields not exposed by the API
+	skipInternal("config_hash", "computed hash"),
+	skipInternal("custom_healthcheck_found", "computed flag"),
+	skipInternal("compose_parsing_version", "internal parser version"),
+	skipInternal("last_online_at", "runtime status"),
+	skipInternal("last_restart_at", "runtime status"),
+	skipInternal("last_restart_type", "runtime status"),
+	skipInternal("restart_count", "runtime status"),
+	skipInternal("nixpkgsarchive", "internal build archive"),
+	skipInternal("git_full_url", "computed URL"),
+	// Docker compose PR fields (removed in later migrations)
+	skipNA("docker_compose_pr_location", "removed from Coolify API surface"),
+	skipNA("docker_compose_pr", "removed from Coolify API surface"),
+	skipNA("docker_compose_pr_raw", "removed from Coolify API surface"),
+	// Fields served from related models, not Application table
+	skipNA("docker_compose", "served from related model, not Application row"),
+	// Swarm-only fields (not commonly used)
+	skipNA("swarm_replicas", "swarm-only; not in provider surface"),
+	skipNA("swarm_placement_constraints", "swarm-only; not in provider surface"),
+	// Internal-only ApplicationSetting fields not exposed by update API
+	skipInternal("application_id", "settings FK"),
+	skipInternal("custom_internal_name", "settings internal"),
+	skipInternal("disable_build_cache", "settings not on update allow list"),
+	skipInternal("docker_images_to_keep", "settings not on update allow list"),
+	skipInternal("gpu_count", "settings not on update allow list"),
+	skipInternal("gpu_device_ids", "settings not on update allow list"),
+	skipInternal("gpu_driver", "settings not on update allow list"),
+	skipInternal("gpu_options", "settings not on update allow list"),
+	skipInternal("include_source_commit_in_build", "settings not on update allow list"),
+	skipInternal("inject_build_args_to_dockerfile", "settings not on update allow list"),
+	skipInternal("is_consistent_container_name_enabled", "settings not on update allow list"),
+	skipInternal("is_container_label_readonly_enabled", "settings not on update allow list"),
+	skipInternal("is_custom_ssl", "settings not on update allow list"),
+	skipInternal("is_debug_enabled", "settings not on update allow list"),
+	skipInternal("is_dual_cert", "settings not on update allow list"),
+	skipInternal("is_env_sorting_enabled", "settings not on update allow list"),
+	skipInternal("is_git_lfs_enabled", "settings not on update allow list"),
+	skipInternal("is_git_shallow_clone_enabled", "settings not on update allow list"),
+	skipInternal("is_git_submodules_enabled", "settings not on update allow list"),
+	skipInternal("is_gpu_enabled", "settings not on update allow list"),
+	skipInternal("is_gzip_enabled", "settings not on update allow list"),
+	skipInternal("is_http2", "settings not on update allow list"),
+	skipInternal("is_include_timestamps", "settings not on update allow list"),
+	skipInternal("is_log_drain_enabled", "settings not on update allow list"),
+	skipInternal("is_pr_deployments_public_enabled", "settings not on update allow list"),
+	skipInternal("is_preview_deployments_enabled", "settings; version-gated separately where exposed"),
+	skipInternal("is_raw_compose_deployment_enabled", "settings not on update allow list"),
+	skipInternal("is_stripprefix_enabled", "settings not on update allow list"),
+	skipInternal("is_swarm_only_worker_nodes", "settings not on update allow list"),
+	skipInternal("use_build_secrets", "settings; version-gated separately where exposed"),
+	// is_build_server_enabled is the setting name; the API field is use_build_server
+	skipNA("is_build_server_enabled", "API field is use_build_server on Application"),
+	skipDeferred("stop_grace_period", 626, "not yet exposed on application resource"),
+)
+
+var serverCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+	skipInternal("private_key_id", "numeric FK"),
+	skipInternal("proxy", "complex JSON object"),
+	skipInternal("sentinel_token", "hidden by middleware"),
+	skipInternal("sentinel_custom_url", "sentinel config not on base server entity"),
+	skipInternal("sentinel_metrics_token", "sentinel metrics secret"),
+	skipInternal("sentinel_metrics_history", "sentinel metrics config"),
+	skipInternal("sentinel_metrics_interval", "sentinel metrics config"),
+	skipInternal("started_at", "runtime status"),
+	skipInternal("last_online_at", "runtime status"),
+	skipInternal("last_restart_at", "runtime status"),
+	skipInternal("last_restart_type", "runtime status"),
+	skipInternal("restart_count", "runtime status"),
+	skipInternal("unreachable_notification", "runtime flag"),
+	skipInternal("unreachable_count", "runtime counter"),
+	skipInternal("log_drain_notification", "notification flag"),
+	skipInternal("swarm_cluster", "swarm cluster blob"),
+	skipInternal("cloud_provider_token_id", "numeric FK"),
+	skipInternal("detected_traefik_version", "ephemeral status"),
+	skipInternal("hetzner_server_id", "Hetzner-specific tracking"),
+	skipInternal("hetzner_server_status", "Hetzner-specific status"),
+	skipInternal("ip_previous", "internal tracking"),
+	skipInternal("is_validating", "ephemeral status"),
+	skipInternal("server_metadata", "internal metadata"),
+	skipInternal("traefik_outdated_info", "ephemeral status"),
+)
+
+var serviceCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+	skipInternal("environment_id", "numeric FK"),
+	skipInternal("destination_id", "numeric FK"),
+	skipInternal("destination_type", "morph type"),
+	skipInternal("server_id", "numeric FK"),
+	skipInternal("is_container_label_readonly_enabled", "internal label flag"),
+	skipInternal("is_readonly", "internal flag"),
+	skipInternal("compose_parsing_version", "internal config"),
+	skipNA("service_type", "mapped to type in client struct"),
+)
+
+var privateKeyCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+)
+
+// environmentVariableCoverageSkips: after #619, deploy flags are on the client.
+// Remaining product/UI fields track under #626.
+var environmentVariableCoverageSkips = skipMap(
+	skipInternal("resourceable_id", "polymorphic FK"),
+	skipInternal("resourceable_type", "polymorphic FK"),
+	skipInternal("team_id", "FK"),
+	skipInternal("real_value", "computed accessor"),
+	skipInternal("version", "Coolify internal version stamp"),
+	skipDeferred("is_required", 626, "product surface not yet managed in Terraform"),
+	skipDeferred("is_shared", 626, "shared-var surface not managed as resource field"),
+	skipDeferred("is_shown_once", 626, "UI reveal-once; not deploy semantics"),
+	skipDeferred("order", 626, "UI ordering not managed in Terraform"),
+)
+
+var scheduledTaskCoverageSkips = skipMap(
+	skipInternal("application_id", "numeric FK"),
+	skipInternal("service_id", "numeric FK"),
+	skipInternal("team_id", "FK"),
+	skipInternal("container", "not user-facing container name"),
+	skipDeferred("timeout", 626, "not yet exposed on scheduled_task resource"),
+)
+
+var projectCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+)
+
+var githubAppCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+	skipInternal("private_key_id", "numeric FK"),
+	skipInternal("client_secret", "sensitive write-only; hidden on read"),
+	skipInternal("is_system_wide", "system flag"),
+	skipInternal("administration", "GitHub permission scope"),
+	skipInternal("contents", "GitHub permission scope"),
+	skipInternal("custom_port", "internal git config"),
+	skipInternal("custom_user", "internal git config"),
+	skipInternal("is_public", "internal flag"),
+	skipInternal("metadata", "GitHub permission scope"),
+	skipInternal("pull_requests", "GitHub permission scope"),
+)
+
+var databaseBackupCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+	skipInternal("database_id", "numeric FK"),
+	skipDeferred("description", 626, "not yet exposed on database_backup"),
+	skipDeferred("disable_local_backup", 626, "not yet on client DatabaseBackup entity"),
+	skipNA("s3_storage_id", "numeric FK; provider uses s3_storage_uuid"),
+)
+
+var cloudTokenCoverageSkips = skipMap(
+	skipInternal("team_id", "FK"),
+)
+
+var storageCoverageSkips = skipMap(
+	skipInternal("container_id", "internal Docker container ID"),
+	skipNA("resource_id", "numeric FK; provider uses resource_uuid"),
+	skipDeferred("is_preview_suffix_enabled", 626, "not yet exposed on storage resource"),
+)
+
+var serverSettingCoverageSkips = skipMap(
+	skipInternal("server_id", "FK"),
+	skipNA("is_build_server", "on Server entity, not Settings"),
+	skipDeferred("is_force_disabled", 626, "not yet exposed on server settings"),
+	skipNA("is_reachable", "on Server entity, not Settings"),
+	skipNA("is_usable", "on Server entity, not Settings"),
+	skipDeferred("is_swarm_manager", 626, "not yet exposed on server settings"),
+	skipDeferred("is_swarm_worker", 626, "not yet exposed on server settings"),
+	skipDeferred("sentinel_custom_url", 626, "not yet exposed on server settings"),
+	skipNA("sentinel_metrics_refresh_rate_in_seconds", "old contract name; superseded by sentinel_metrics_refresh_rate_seconds"),
+	skipNA("sentinel_push_interval_in_seconds", "old contract name; superseded by sentinel_push_interval_seconds"),
+	skipDeferred("sentinel_token", 626, "sensitive; not yet exposed"),
+	skipDeferred("is_logdrain_axiom_enabled", 626, "not yet exposed"),
+	skipDeferred("logdrain_axiom_api_key", 626, "sensitive; not yet exposed"),
+	skipDeferred("logdrain_axiom_dataset_name", 626, "not yet exposed"),
+	skipDeferred("is_logdrain_custom_enabled", 626, "not yet exposed"),
+	skipDeferred("logdrain_custom_config", 626, "not yet exposed"),
+	skipDeferred("logdrain_custom_config_parser", 626, "not yet exposed"),
+	skipDeferred("is_logdrain_highlight_enabled", 626, "not yet exposed"),
+	skipDeferred("logdrain_highlight_project_id", 626, "not yet exposed"),
+	skipDeferred("is_logdrain_newrelic_enabled", 626, "not yet exposed"),
+	skipDeferred("logdrain_newrelic_base_uri", 626, "not yet exposed"),
+	skipDeferred("logdrain_newrelic_license_key", 626, "sensitive; not yet exposed"),
+	skipDeferred("disable_application_image_retention", 626, "not yet exposed"),
+	skipDeferred("force_disabled", 626, "not yet exposed"),
+	skipDeferred("is_jump_server", 626, "not yet exposed"),
+	skipDeferred("is_sentinel_debug_enabled", 626, "not yet exposed"),
+)
+
+var environmentCoverageSkips = skipMap(
+	skipNA("project_id", "numeric FK; provider uses project_uuid"),
+	skipNA("uuid", "provider identifies environments by name"),
+)
+
+var databaseModelSkips = skipMap(
+	skipInternal("environment_id", "numeric FK"),
+	skipInternal("destination_id", "numeric FK"),
+	skipInternal("destination_type", "morph type"),
+	skipInternal("started_at", "runtime status"),
+	skipInternal("last_online_at", "runtime status"),
+	skipInternal("last_restart_at", "runtime status"),
+	skipInternal("last_restart_type", "runtime status"),
+	skipInternal("restart_count", "runtime status"),
+)
+
+// appEnvWriteSkips: allowed_fields on application create_env / update_env that
+// are intentionally not on applicationEnvVarInput (#623).
+var appEnvWriteSkips = skipMap(
+	skipDeferred("is_shown_once", 626, "UI reveal-once; not sent on write path yet"),
+)

--- a/internal/spectest/contract_skips.go
+++ b/internal/spectest/contract_skips.go
@@ -59,11 +59,12 @@ var applicationFieldSkips = skipMap(
 	skipInternal("is_include_timestamps", "settings not on update allow list"),
 	skipInternal("is_log_drain_enabled", "settings not on update allow list"),
 	skipInternal("is_pr_deployments_public_enabled", "settings not on update allow list"),
-	skipInternal("is_preview_deployments_enabled", "settings; version-gated separately where exposed"),
+	// Public on ApplicationsController create/update allowed_fields (must not be internal).
+	skipDeferred("is_preview_deployments_enabled", 626, "public allow-list field; not yet on application client/schema"),
 	skipInternal("is_raw_compose_deployment_enabled", "settings not on update allow list"),
 	skipInternal("is_stripprefix_enabled", "settings not on update allow list"),
 	skipInternal("is_swarm_only_worker_nodes", "settings not on update allow list"),
-	skipInternal("use_build_secrets", "settings; version-gated separately where exposed"),
+	skipDeferred("use_build_secrets", 626, "public allow-list field; not yet on application client/schema"),
 	// is_build_server_enabled is the setting name; the API field is use_build_server
 	skipNA("is_build_server_enabled", "API field is use_build_server on Application"),
 	skipDeferred("stop_grace_period", 626, "not yet exposed on application resource"),
@@ -87,7 +88,8 @@ var serverCoverageSkips = skipMap(
 	skipInternal("unreachable_count", "runtime counter"),
 	skipInternal("log_drain_notification", "notification flag"),
 	skipInternal("swarm_cluster", "swarm cluster blob"),
-	skipInternal("cloud_provider_token_id", "numeric FK"),
+	// Public on cloud create-server allow lists; provider maps tokens via UUID fields.
+	skipNA("cloud_provider_token_id", "numeric FK; cloud server resources use token UUID fields"),
 	skipInternal("detected_traefik_version", "ephemeral status"),
 	skipInternal("hetzner_server_id", "Hetzner-specific tracking"),
 	skipInternal("hetzner_server_status", "Hetzner-specific status"),
@@ -131,7 +133,7 @@ var scheduledTaskCoverageSkips = skipMap(
 	skipInternal("application_id", "numeric FK"),
 	skipInternal("service_id", "numeric FK"),
 	skipInternal("team_id", "FK"),
-	skipInternal("container", "not user-facing container name"),
+	skipDeferred("container", 626, "on create/update allow list; not yet on scheduled_task schema"),
 	skipDeferred("timeout", 626, "not yet exposed on scheduled_task resource"),
 )
 
@@ -142,15 +144,16 @@ var projectCoverageSkips = skipMap(
 var githubAppCoverageSkips = skipMap(
 	skipInternal("team_id", "FK"),
 	skipInternal("private_key_id", "numeric FK"),
-	skipInternal("client_secret", "sensitive write-only; hidden on read"),
-	skipInternal("is_system_wide", "system flag"),
-	skipInternal("administration", "GitHub permission scope"),
-	skipInternal("contents", "GitHub permission scope"),
-	skipInternal("custom_port", "internal git config"),
-	skipInternal("custom_user", "internal git config"),
-	skipInternal("is_public", "internal flag"),
-	skipInternal("metadata", "GitHub permission scope"),
-	skipInternal("pull_requests", "GitHub permission scope"),
+	// Public on GithubController create/update allow lists (must not be internal).
+	skipDeferred("client_secret", 626, "write-only sensitive; not on client entity read struct"),
+	skipDeferred("is_system_wide", 626, "public allow-list field; not yet on github_app client/schema"),
+	skipInternal("administration", "GitHub permission scope blob"),
+	skipInternal("contents", "GitHub permission scope blob"),
+	skipDeferred("custom_port", 626, "public allow-list field; not yet on github_app client/schema"),
+	skipDeferred("custom_user", 626, "public allow-list field; not yet on github_app client/schema"),
+	skipNA("is_public", "GitHub App visibility flag; not mapped on provider github_app resource"),
+	skipInternal("metadata", "GitHub permission scope blob"),
+	skipInternal("pull_requests", "GitHub permission scope blob"),
 )
 
 var databaseBackupCoverageSkips = skipMap(

--- a/internal/spectest/contract_test.go
+++ b/internal/spectest/contract_test.go
@@ -17,10 +17,16 @@ import (
 // This is the single source of truth for field definitions, defaults,
 // types, and sensitive markings.
 type contractFile struct {
-	Version            string                   `json:"version"`
-	Models             map[string]contractModel `json:"models"`
-	Enums              map[string][]string      `json:"enums"`
-	ValidationPatterns map[string]string        `json:"validation_patterns"`
+	Version            string                      `json:"version"`
+	Models             map[string]contractModel    `json:"models"`
+	Endpoints          map[string]contractEndpoint `json:"endpoints"`
+	Enums              map[string][]string         `json:"enums"`
+	ValidationPatterns map[string]string           `json:"validation_patterns"`
+}
+
+// contractEndpoint is a Coolify controller action with an allow list.
+type contractEndpoint struct {
+	AllowedFields []string `json:"allowed_fields"`
 }
 
 type contractModel struct {
@@ -87,91 +93,7 @@ func jsonTagsFromStruct(t reflect.Type) map[string]reflect.StructField {
 	return tags
 }
 
-// fieldsToIgnore are contract fields that are intentionally not in our client
-// structs because they are internal-only (DB IDs, morphs, computed, etc.).
-var fieldsToIgnore = map[string]map[string]bool{
-	"Application": {
-		// Internal DB identifiers (not exposed via API)
-		"environment_id":        true,
-		"destination_id":        true,
-		"destination_type":      true,
-		"source_id":             true,
-		"source_type":           true,
-		"private_key_id":        true,
-		"repository_project_id": true,
-		// Computed/internal fields not exposed by the API
-		"config_hash":              true,
-		"custom_healthcheck_found": true,
-		"compose_parsing_version":  true,
-		"last_online_at":           true,
-		"last_restart_at":          true,
-		"last_restart_type":        true,
-		"restart_count":            true,
-		"nixpkgsarchive":           true,
-		"git_full_url":             true,
-		// Docker compose PR fields (removed in later migrations)
-		"docker_compose_pr_location": true,
-		"docker_compose_pr":          true,
-		"docker_compose_pr_raw":      true,
-		// Fields served from related models, not Application table
-		"docker_compose": true,
-		// Swarm-only fields (not commonly used)
-		"swarm_replicas":              true,
-		"swarm_placement_constraints": true,
-		// Internal-only ApplicationSetting fields not exposed by update API
-		"application_id":                       true,
-		"custom_internal_name":                 true,
-		"disable_build_cache":                  true,
-		"docker_images_to_keep":                true,
-		"gpu_count":                            true,
-		"gpu_device_ids":                       true,
-		"gpu_driver":                           true,
-		"gpu_options":                          true,
-		"include_source_commit_in_build":       true,
-		"inject_build_args_to_dockerfile":      true,
-		"is_consistent_container_name_enabled": true,
-		"is_container_label_readonly_enabled":  true,
-		"is_custom_ssl":                        true,
-		"is_debug_enabled":                     true,
-		"is_dual_cert":                         true,
-		"is_env_sorting_enabled":               true,
-		"is_git_lfs_enabled":                   true,
-		"is_git_shallow_clone_enabled":         true,
-		"is_git_submodules_enabled":            true,
-		"is_gpu_enabled":                       true,
-		"is_gzip_enabled":                      true,
-		"is_http2":                             true,
-		"is_include_timestamps":                true,
-		"is_log_drain_enabled":                 true,
-		"is_pr_deployments_public_enabled":     true,
-		"is_preview_deployments_enabled":       true,
-		"is_raw_compose_deployment_enabled":    true,
-		"is_stripprefix_enabled":               true,
-		"is_swarm_only_worker_nodes":           true,
-		"use_build_secrets":                    true,
-		// is_build_server_enabled is the setting name; the API field is use_build_server (already in struct)
-		"is_build_server_enabled": true,
-		"stop_grace_period":       true, // not exposed yet
-	},
-	"Server": {
-		"proxy":                         true,
-		"traefik_outdated_info":         true,
-		"server_metadata":               true,
-		"logdrain_axiom_api_key":        true,
-		"logdrain_newrelic_license_key": true,
-		"delete_unused_volumes":         true,
-		"delete_unused_networks":        true,
-		"unreachable_notification_sent": true,
-		"unreachable_count":             true,
-		"validation_logs":               true,
-		"hetzner_server_id":             true,
-		"hetzner_server_status":         true,
-		"is_validating":                 true,
-		"detected_traefik_version":      true,
-		"ip_previous":                   true,
-		"sentinel_updated_at":           true,
-	},
-}
+// Application / Server model skips live in contract_skips.go (taxonomy #622).
 
 // TestContractCoverage_Application checks that client.Application has JSON
 // tags for all user-facing fillable fields in the contract, and that the
@@ -186,12 +108,12 @@ func TestContractCoverage_Application(t *testing.T) {
 	}
 
 	goTags := jsonTagsFromStruct(reflect.TypeOf(client.Application{}))
-	ignore := fieldsToIgnore["Application"]
+	ignore := applicationFieldSkips
 
 	var missing []string
 	var typeMismatches []string
 	for fieldName, field := range appContract.Fields {
-		if !field.Fillable || ignore[fieldName] {
+		if !field.Fillable || isSkipped(ignore, fieldName) {
 			continue
 		}
 		goField, ok := goTags[fieldName]
@@ -206,7 +128,7 @@ func TestContractCoverage_Application(t *testing.T) {
 
 	// Also check settings fields
 	for fieldName := range appContract.SettingsFields {
-		if ignore[fieldName] {
+		if isSkipped(ignore, fieldName) {
 			continue
 		}
 		if _, ok := goTags[fieldName]; !ok {
@@ -239,16 +161,7 @@ func TestContractCoverage_Databases(t *testing.T) {
 		"StandaloneKeydb", "StandaloneDragonfly",
 	}
 
-	dbIgnore := map[string]bool{
-		"environment_id":    true,
-		"destination_id":    true,
-		"destination_type":  true,
-		"started_at":        true,
-		"last_online_at":    true,
-		"last_restart_at":   true,
-		"last_restart_type": true,
-		"restart_count":     true,
-	}
+	dbIgnore := databaseModelSkips
 
 	for _, modelName := range dbModels {
 		model, ok := c.Models[modelName]
@@ -260,7 +173,7 @@ func TestContractCoverage_Databases(t *testing.T) {
 		var missing []string
 		var typeMismatches []string
 		for fieldName, field := range model.Fields {
-			if !field.Fillable || dbIgnore[fieldName] {
+			if !field.Fillable || isSkipped(dbIgnore, fieldName) {
 				continue
 			}
 			goField, ok := goTags[fieldName]
@@ -351,7 +264,8 @@ func checkTypeCompatibility(field contractField, goType reflect.Type) error {
 
 // contractCoverageTest is a reusable helper for model contract tests.
 // It checks both field name coverage and Go type compatibility.
-func contractCoverageTest(t *testing.T, modelName string, goType reflect.Type, ignore map[string]bool) {
+// ignore uses the skip taxonomy (#622): internal / deferred+#N / n/a.
+func contractCoverageTest(t *testing.T, modelName string, goType reflect.Type, ignore map[string]FieldSkip) {
 	t.Helper()
 	c := loadContract(t)
 	model, ok := c.Models[modelName]
@@ -360,14 +274,15 @@ func contractCoverageTest(t *testing.T, modelName string, goType reflect.Type, i
 	}
 	goTags := jsonTagsFromStruct(goType)
 	if ignore == nil {
-		ignore = map[string]bool{}
+		ignore = map[string]FieldSkip{}
 	}
+	requireValidSkips(t, ignore)
 
 	var missing []string
 	var typeMismatches []string
 
 	for fieldName, field := range model.Fields {
-		if !field.Fillable || ignore[fieldName] {
+		if !field.Fillable || isSkipped(ignore, fieldName) {
 			continue
 		}
 		goField, ok := goTags[fieldName]
@@ -394,176 +309,63 @@ func contractCoverageTest(t *testing.T, modelName string, goType reflect.Type, i
 
 func TestContractCoverage_Server(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "Server", reflect.TypeOf(client.Server{}), map[string]bool{
-		"team_id":                   true,
-		"private_key_id":            true,
-		"proxy":                     true, // complex JSON object
-		"sentinel_token":            true, // hidden by middleware
-		"sentinel_custom_url":       true,
-		"sentinel_metrics_token":    true,
-		"sentinel_metrics_history":  true,
-		"sentinel_metrics_interval": true,
-		"started_at":                true,
-		"last_online_at":            true,
-		"last_restart_at":           true,
-		"last_restart_type":         true,
-		"restart_count":             true,
-		"unreachable_notification":  true,
-		"unreachable_count":         true,
-		"log_drain_notification":    true,
-		"swarm_cluster":             true,
-		"cloud_provider_token_id":   true, // internal FK
-		"detected_traefik_version":  true, // ephemeral status
-		"hetzner_server_id":         true, // Hetzner-specific
-		"hetzner_server_status":     true, // Hetzner-specific
-		"ip_previous":               true, // internal tracking
-		"is_validating":             true, // ephemeral status
-		"server_metadata":           true, // internal metadata
-		"traefik_outdated_info":     true, // ephemeral status
-	})
+	contractCoverageTest(t, "Server", reflect.TypeOf(client.Server{}), serverCoverageSkips)
 }
 
 func TestContractCoverage_Service(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "Service", reflect.TypeOf(client.Service{}), map[string]bool{
-		"team_id":                             true,
-		"environment_id":                      true,
-		"destination_id":                      true,
-		"destination_type":                    true,
-		"server_id":                           true,
-		"is_container_label_readonly_enabled": true,
-		"is_readonly":                         true,
-		"compose_parsing_version":             true, // internal config
-		"service_type":                        true, // mapped to "type" in client struct
-	})
+	contractCoverageTest(t, "Service", reflect.TypeOf(client.Service{}), serviceCoverageSkips)
 }
 
 func TestContractCoverage_PrivateKey(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "PrivateKey", reflect.TypeOf(client.PrivateKey{}), map[string]bool{
-		"team_id": true,
-	})
+	contractCoverageTest(t, "PrivateKey", reflect.TypeOf(client.PrivateKey{}), privateKeyCoverageSkips)
 }
 
 func TestContractCoverage_EnvironmentVariable(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "EnvironmentVariable", reflect.TypeOf(client.EnvironmentVariable{}), map[string]bool{
-		"resourceable_id":   true, // polymorphic FK
-		"resourceable_type": true, // polymorphic FK
-		"team_id":           true, // internal FK
-		"real_value":        true, // computed accessor
-		"version":           true, // Coolify internal version stamp
-		"is_required":       true, // deferred product surface
-		"is_shared":         true, // computed/shared-var surface, not TF resource field
-		"is_shown_once":     true, // deferred UI-only flag (see #619 optional)
-		"order":             true, // UI ordering
-		// is_runtime, is_literal, is_multiline, comment, is_buildtime covered on client (#619)
-	})
+	// is_runtime, is_literal, is_multiline, comment, is_buildtime covered on client (#619)
+	contractCoverageTest(t, "EnvironmentVariable", reflect.TypeOf(client.EnvironmentVariable{}), environmentVariableCoverageSkips)
 }
 
 func TestContractCoverage_ScheduledTask(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "ScheduledTask", reflect.TypeOf(client.ScheduledTask{}), map[string]bool{
-		"application_id": true,
-		"service_id":     true,
-		"team_id":        true,
-		"container":      true, // not user-facing
-		"timeout":        true, // not exposed yet
-	})
+	contractCoverageTest(t, "ScheduledTask", reflect.TypeOf(client.ScheduledTask{}), scheduledTaskCoverageSkips)
 }
 
 func TestContractCoverage_Project(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "Project", reflect.TypeOf(client.Project{}), map[string]bool{
-		"team_id": true,
-	})
+	contractCoverageTest(t, "Project", reflect.TypeOf(client.Project{}), projectCoverageSkips)
 }
 
 func TestContractCoverage_GithubApp(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "GithubApp", reflect.TypeOf(client.GitHubApp{}), map[string]bool{
-		"team_id":        true,
-		"private_key_id": true,
-		"client_secret":  true, // sensitive, hidden
-		"is_system_wide": true,
-		"administration": true, // GitHub permission scope
-		"contents":       true, // GitHub permission scope
-		"custom_port":    true, // internal config
-		"custom_user":    true, // internal config
-		"is_public":      true, // internal flag
-		"metadata":       true, // GitHub permission scope
-		"pull_requests":  true, // GitHub permission scope
-	})
+	contractCoverageTest(t, "GithubApp", reflect.TypeOf(client.GitHubApp{}), githubAppCoverageSkips)
 }
 
 func TestContractCoverage_ScheduledDatabaseBackup(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "ScheduledDatabaseBackup", reflect.TypeOf(client.DatabaseBackup{}), map[string]bool{
-		"team_id":              true,
-		"database_id":          true,
-		"description":          true, // not exposed yet
-		"disable_local_backup": true, // not exposed yet
-		"s3_storage_id":        true, // numeric FK; provider uses s3_storage_uuid
-	})
+	contractCoverageTest(t, "ScheduledDatabaseBackup", reflect.TypeOf(client.DatabaseBackup{}), databaseBackupCoverageSkips)
 }
 
 func TestContractCoverage_CloudToken(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "CloudProviderToken", reflect.TypeOf(client.CloudToken{}), map[string]bool{
-		"team_id": true, // internal FK
-	})
+	contractCoverageTest(t, "CloudProviderToken", reflect.TypeOf(client.CloudToken{}), cloudTokenCoverageSkips)
 }
 
 func TestContractCoverage_Storage(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "LocalPersistentVolume", reflect.TypeOf(client.Storage{}), map[string]bool{
-		"container_id":              true, // internal Docker container ID
-		"resource_id":               true, // numeric FK; provider uses resource_uuid
-		"is_preview_suffix_enabled": true, // not exposed yet
-	})
+	contractCoverageTest(t, "LocalPersistentVolume", reflect.TypeOf(client.Storage{}), storageCoverageSkips)
 }
 
 func TestContractCoverage_ServerSetting(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "ServerSetting", reflect.TypeOf(client.ServerSettings{}), map[string]bool{
-		"server_id": true, // internal FK
-
-		"is_build_server": true, // on Server, not Settings
-
-		"is_force_disabled":   true, // not exposed yet
-		"is_reachable":        true, // on Server, not Settings
-		"is_usable":           true, // on Server, not Settings
-		"is_swarm_manager":    true, // not exposed yet
-		"is_swarm_worker":     true, // not exposed yet
-		"sentinel_custom_url": true, // not exposed yet
-		"sentinel_metrics_refresh_rate_in_seconds": true, // old contract name, superseded by sentinel_metrics_refresh_rate_seconds
-		"sentinel_push_interval_in_seconds":        true, // old contract name, superseded by sentinel_push_interval_seconds
-		"sentinel_token":                           true, // sensitive, not exposed yet
-		"is_logdrain_axiom_enabled":                true, // not exposed yet
-		"logdrain_axiom_api_key":                   true, // sensitive, not exposed yet
-		"logdrain_axiom_dataset_name":              true, // not exposed yet
-		"is_logdrain_custom_enabled":               true, // not exposed yet
-		"logdrain_custom_config":                   true, // not exposed yet
-		"logdrain_custom_config_parser":            true, // not exposed yet
-		"is_logdrain_highlight_enabled":            true, // not exposed yet
-		"logdrain_highlight_project_id":            true, // not exposed yet
-		"is_logdrain_newrelic_enabled":             true, // not exposed yet
-		"logdrain_newrelic_base_uri":               true, // not exposed yet
-		"logdrain_newrelic_license_key":            true, // sensitive, not exposed yet
-		"disable_application_image_retention":      true, // not exposed yet
-
-		"force_disabled":            true, // not exposed yet
-		"is_jump_server":            true, // not exposed yet
-		"is_sentinel_debug_enabled": true, // not exposed yet
-	})
+	contractCoverageTest(t, "ServerSetting", reflect.TypeOf(client.ServerSettings{}), serverSettingCoverageSkips)
 }
 
 func TestContractCoverage_Environment(t *testing.T) {
 	t.Parallel()
-	contractCoverageTest(t, "Environment", reflect.TypeOf(client.Environment{}), map[string]bool{
-		"project_id": true, // internal FK; provider uses project_uuid
-		"uuid":       true, // not used; provider identifies environments by name
-	})
+	contractCoverageTest(t, "Environment", reflect.TypeOf(client.Environment{}), environmentCoverageSkips)
 }
 
 // TestContractCoverage_Report prints a summary of coverage. Run with -v.
@@ -579,11 +381,11 @@ func TestContractCoverage_Report(t *testing.T) {
 	// Check Application coverage
 	if app, ok := c.Models["Application"]; ok {
 		goTags := jsonTagsFromStruct(reflect.TypeOf(client.Application{}))
-		ignore := fieldsToIgnore["Application"]
+		ignore := applicationFieldSkips
 		total := 0
 		covered := 0
 		for name, field := range app.Fields {
-			if !field.Fillable || ignore[name] {
+			if !field.Fillable || isSkipped(ignore, name) {
 				continue
 			}
 			total++

--- a/internal/spectest/schema_coverage.go
+++ b/internal/spectest/schema_coverage.go
@@ -1,0 +1,94 @@
+package spectest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/environmentvariable"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// SchemaCoverageEntry maps a Coolify contract field to a Terraform schema
+// attribute (or an explicit skip). Phase A covers EnvironmentVariable only
+// (#621). Status is StatusCovered or a SkipStatus value.
+type SchemaCoverageEntry struct {
+	ContractField   string
+	SchemaAttribute string // tfsdk name; empty when not covered
+	Status          SkipStatus
+	Issue           int
+	Notes           string
+}
+
+func (e SchemaCoverageEntry) validate() error {
+	if e.ContractField == "" {
+		return fmt.Errorf("ContractField required")
+	}
+	switch e.Status {
+	case StatusCovered:
+		if e.SchemaAttribute == "" {
+			return fmt.Errorf("covered requires SchemaAttribute")
+		}
+		if e.Issue != 0 {
+			return fmt.Errorf("covered must not set Issue")
+		}
+	case SkipInternal, SkipNA:
+		if e.SchemaAttribute != "" {
+			return fmt.Errorf("%s must not set SchemaAttribute", e.Status)
+		}
+		if e.Issue != 0 {
+			return fmt.Errorf("%s must not set Issue", e.Status)
+		}
+		if e.Notes == "" {
+			return fmt.Errorf("%s requires Notes", e.Status)
+		}
+	case SkipDeferred:
+		if e.Issue <= 0 {
+			return fmt.Errorf("deferred requires Issue")
+		}
+		if e.Notes == "" {
+			return fmt.Errorf("deferred requires Notes")
+		}
+	default:
+		return fmt.Errorf("unknown status %q", e.Status)
+	}
+	return nil
+}
+
+// environmentVariableSchemaRegistry is Phase A of the schema coverage
+// registry: every fillable EnvironmentVariable contract field has a row.
+var environmentVariableSchemaRegistry = []SchemaCoverageEntry{
+	{ContractField: "key", SchemaAttribute: "key", Status: StatusCovered},
+	{ContractField: "value", SchemaAttribute: "value", Status: StatusCovered},
+	{ContractField: "is_preview", SchemaAttribute: "is_preview", Status: StatusCovered},
+	{ContractField: "is_buildtime", SchemaAttribute: "is_build", Status: StatusCovered, Notes: "Coolify is_buildtime"},
+	{ContractField: "is_runtime", SchemaAttribute: "is_runtime", Status: StatusCovered},
+	{ContractField: "is_literal", SchemaAttribute: "is_literal", Status: StatusCovered},
+	{ContractField: "is_multiline", SchemaAttribute: "is_multiline", Status: StatusCovered},
+	{ContractField: "comment", SchemaAttribute: "comment", Status: StatusCovered},
+	{ContractField: "is_shown_once", Status: SkipDeferred, Issue: 626, Notes: "UI reveal-once"},
+	{ContractField: "is_required", Status: SkipDeferred, Issue: 626, Notes: "product surface not yet managed"},
+	{ContractField: "is_shared", Status: SkipDeferred, Issue: 626, Notes: "shared-var surface"},
+	{ContractField: "order", Status: SkipDeferred, Issue: 626, Notes: "UI ordering"},
+	{ContractField: "resourceable_id", Status: SkipInternal, Notes: "polymorphic FK"},
+	{ContractField: "resourceable_type", Status: SkipInternal, Notes: "polymorphic FK"},
+	{ContractField: "version", Status: SkipInternal, Notes: "Coolify internal version stamp"},
+}
+
+// resourceSchemaAttributeNames returns top-level attribute names from a resource Schema().
+func resourceSchemaAttributeNames(r resource.Resource) (map[string]struct{}, error) {
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		return nil, fmt.Errorf("schema diagnostics: %v", resp.Diagnostics)
+	}
+	out := make(map[string]struct{}, len(resp.Schema.Attributes))
+	for name := range resp.Schema.Attributes {
+		out[name] = struct{}{}
+	}
+	return out, nil
+}
+
+// coolifyEnvironmentVariableResource constructs the env var resource for schema walk.
+func coolifyEnvironmentVariableResource() resource.Resource {
+	return environmentvariable.NewResource()
+}

--- a/internal/spectest/schema_coverage_test.go
+++ b/internal/spectest/schema_coverage_test.go
@@ -1,0 +1,72 @@
+package spectest
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSchemaCoverage_EnvironmentVariable(t *testing.T) {
+	t.Parallel()
+	c := loadContract(t)
+	model, ok := c.Models["EnvironmentVariable"]
+	if !ok {
+		t.Fatal("EnvironmentVariable model missing from contract")
+	}
+
+	byField := make(map[string]SchemaCoverageEntry, len(environmentVariableSchemaRegistry))
+	for _, e := range environmentVariableSchemaRegistry {
+		if err := e.validate(); err != nil {
+			t.Errorf("registry entry %q: %v", e.ContractField, err)
+			continue
+		}
+		if _, dup := byField[e.ContractField]; dup {
+			t.Errorf("duplicate registry entry for %q", e.ContractField)
+		}
+		byField[e.ContractField] = e
+	}
+
+	// Every fillable contract field must have a registry row.
+	var missingRegistry []string
+	for name, field := range model.Fields {
+		if !field.Fillable {
+			continue
+		}
+		if _, ok := byField[name]; !ok {
+			missingRegistry = append(missingRegistry, name)
+		}
+	}
+	sort.Strings(missingRegistry)
+	if len(missingRegistry) > 0 {
+		t.Errorf("EnvironmentVariable fillable fields missing from schema registry:\n  %s",
+			strings.Join(missingRegistry, "\n  "))
+	}
+
+	// Covered rows must exist on coolify_environment_variable schema.
+	attrs, err := resourceSchemaAttributeNames(coolifyEnvironmentVariableResource())
+	if err != nil {
+		t.Fatalf("resource schema: %v", err)
+	}
+	for _, e := range environmentVariableSchemaRegistry {
+		if e.Status != StatusCovered {
+			continue
+		}
+		if _, ok := attrs[e.SchemaAttribute]; !ok {
+			t.Errorf("covered field %s maps to schema attribute %q which is missing on coolify_environment_variable",
+				e.ContractField, e.SchemaAttribute)
+		}
+	}
+}
+
+func TestSchemaCoverageEntry_DeferredRequiresIssue(t *testing.T) {
+	t.Parallel()
+	err := (SchemaCoverageEntry{
+		ContractField: "x",
+		Status:        SkipDeferred,
+		Issue:         0,
+		Notes:         "gap",
+	}).validate()
+	if err == nil {
+		t.Fatal("expected deferred without issue to fail")
+	}
+}

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -132,25 +132,3 @@ func deferredIssueNumbers(skips map[string]FieldSkip) []int {
 	sort.Ints(out)
 	return out
 }
-
-// allPackageSkipTables returns every skip map defined for contract coverage.
-// Keep this list in sync when adding new skip tables.
-func allPackageSkipTables() []map[string]FieldSkip {
-	return []map[string]FieldSkip{
-		applicationFieldSkips,
-		serverCoverageSkips,
-		serviceCoverageSkips,
-		privateKeyCoverageSkips,
-		environmentVariableCoverageSkips,
-		scheduledTaskCoverageSkips,
-		projectCoverageSkips,
-		githubAppCoverageSkips,
-		databaseBackupCoverageSkips,
-		cloudTokenCoverageSkips,
-		storageCoverageSkips,
-		serverSettingCoverageSkips,
-		environmentCoverageSkips,
-		databaseModelSkips,
-		appEnvWriteSkips,
-	}
-}

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -2,6 +2,7 @@ package spectest
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -128,5 +129,28 @@ func deferredIssueNumbers(skips map[string]FieldSkip) []int {
 			}
 		}
 	}
+	sort.Ints(out)
 	return out
+}
+
+// allPackageSkipTables returns every skip map defined for contract coverage.
+// Keep this list in sync when adding new skip tables.
+func allPackageSkipTables() []map[string]FieldSkip {
+	return []map[string]FieldSkip{
+		applicationFieldSkips,
+		serverCoverageSkips,
+		serviceCoverageSkips,
+		privateKeyCoverageSkips,
+		environmentVariableCoverageSkips,
+		scheduledTaskCoverageSkips,
+		projectCoverageSkips,
+		githubAppCoverageSkips,
+		databaseBackupCoverageSkips,
+		cloudTokenCoverageSkips,
+		storageCoverageSkips,
+		serverSettingCoverageSkips,
+		environmentCoverageSkips,
+		databaseModelSkips,
+		appEnvWriteSkips,
+	}
 }

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -1,0 +1,132 @@
+package spectest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// SkipStatus classifies why a contract field is not required on the client
+// and/or Terraform schema. Public Coolify API fields must never use
+// SkipInternal; use SkipDeferred with an open issue number instead.
+//
+// See #622 (taxonomy), #623 (allowed_fields vs write input), #621 (schema
+// registry), and #624 (freshness issue checklist).
+type SkipStatus string
+
+const (
+	// SkipInternal is for non-user-facing fields: polymorphic FKs, team_id,
+	// computed accessors, ephemeral status, true non-API columns.
+	SkipInternal SkipStatus = "internal"
+	// SkipDeferred is a public product field not yet on the client/schema.
+	// Issue must be a non-zero GitHub issue number tracking the gap.
+	SkipDeferred SkipStatus = "deferred"
+	// SkipNA is wrong surface / never ship / owned by another resource type /
+	// renamed contract field superseded by another name.
+	SkipNA SkipStatus = "n/a"
+	// StatusCovered means the field is present (used by schema registry only;
+	// not a skip).
+	StatusCovered SkipStatus = "covered"
+)
+
+// FieldSkip is one intentional skip of a contract field.
+type FieldSkip struct {
+	Field  string
+	Status SkipStatus
+	Issue  int    // required when Status == SkipDeferred
+	Reason string // short why (required non-empty)
+}
+
+// skipInternal marks a true non-user-facing field.
+func skipInternal(field, reason string) FieldSkip {
+	return FieldSkip{Field: field, Status: SkipInternal, Reason: reason}
+}
+
+// skipDeferred marks a public product field not yet implemented. issue must
+// be non-zero (open GitHub issue number).
+func skipDeferred(field string, issue int, reason string) FieldSkip {
+	return FieldSkip{Field: field, Status: SkipDeferred, Issue: issue, Reason: reason}
+}
+
+// skipNA marks a field that will never map on this surface.
+func skipNA(field, reason string) FieldSkip {
+	return FieldSkip{Field: field, Status: SkipNA, Reason: reason}
+}
+
+// skipMap builds a field-name → skip table and validates taxonomy rules.
+// Panics on invalid entries so misuse fails at test init, not silently.
+func skipMap(skips ...FieldSkip) map[string]FieldSkip {
+	out := make(map[string]FieldSkip, len(skips))
+	for _, s := range skips {
+		if err := validateFieldSkip(s); err != nil {
+			panic(fmt.Sprintf("invalid FieldSkip for %q: %v", s.Field, err))
+		}
+		if _, dup := out[s.Field]; dup {
+			panic(fmt.Sprintf("duplicate FieldSkip for %q", s.Field))
+		}
+		out[s.Field] = s
+	}
+	return out
+}
+
+func validateFieldSkip(s FieldSkip) error {
+	if s.Field == "" {
+		return fmt.Errorf("empty field name")
+	}
+	if strings.TrimSpace(s.Reason) == "" {
+		return fmt.Errorf("reason required")
+	}
+	switch s.Status {
+	case SkipInternal, SkipNA:
+		if s.Issue != 0 {
+			return fmt.Errorf("%s must not set Issue (got %d)", s.Status, s.Issue)
+		}
+	case SkipDeferred:
+		if s.Issue <= 0 {
+			return fmt.Errorf("deferred requires positive Issue number")
+		}
+	default:
+		return fmt.Errorf("unknown status %q", s.Status)
+	}
+	// Banned phrasing that historically hid public API as "internal".
+	low := strings.ToLower(s.Reason)
+	if s.Status != SkipInternal && strings.Contains(low, "internal flag") {
+		return fmt.Errorf("reason must not use %q for non-internal skip", "internal flag")
+	}
+	return nil
+}
+
+// isSkipped reports whether field has a skip entry.
+func isSkipped(skips map[string]FieldSkip, field string) bool {
+	_, ok := skips[field]
+	return ok
+}
+
+// requireValidSkips fails the test if any skip violates taxonomy rules.
+// Use in tests that build skip maps dynamically.
+func requireValidSkips(t *testing.T, skips map[string]FieldSkip) {
+	t.Helper()
+	for name, s := range skips {
+		if s.Field == "" {
+			s.Field = name
+		}
+		if err := validateFieldSkip(s); err != nil {
+			t.Errorf("skip %q: %v", name, err)
+		}
+	}
+}
+
+// deferredIssueNumbers returns sorted unique issue numbers used by deferred skips.
+func deferredIssueNumbers(skips map[string]FieldSkip) []int {
+	seen := map[int]struct{}{}
+	var out []int
+	for _, s := range skips {
+		if s.Status == SkipDeferred && s.Issue > 0 {
+			if _, ok := seen[s.Issue]; !ok {
+				seen[s.Issue] = struct{}{}
+				out = append(out, s.Issue)
+			}
+		}
+	}
+	return out
+}

--- a/internal/spectest/skip_test.go
+++ b/internal/spectest/skip_test.go
@@ -1,6 +1,8 @@
 package spectest
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -61,4 +63,90 @@ func TestSkipMap_PanicsOnDuplicate(t *testing.T) {
 		skipInternal("team_id", "FK"),
 		skipInternal("team_id", "FK again"),
 	)
+}
+
+// skipTableEndpointScope pairs a skip table with the contract endpoint name
+// prefixes it is allowed to justify. Shared field names (e.g. is_public) must
+// only be checked against the endpoints for that surface.
+type skipTableEndpointScope struct {
+	name     string
+	skips    map[string]FieldSkip
+	prefixes []string
+}
+
+// TestSkipTaxonomy_NoInternalOnAllowedFields fails if skipInternal is used for
+// a field that appears on allowed_fields of a scoped endpoint (the #619 class).
+func TestSkipTaxonomy_NoInternalOnAllowedFields(t *testing.T) {
+	t.Parallel()
+	c := loadContract(t)
+
+	scopes := []skipTableEndpointScope{
+		{"applicationFieldSkips", applicationFieldSkips, []string{"ApplicationsController::"}},
+		{"appEnvWriteSkips", appEnvWriteSkips, []string{
+			"ApplicationsController::create_env",
+			"ApplicationsController::update_env_by_uuid",
+		}},
+		{"environmentVariableCoverageSkips", environmentVariableCoverageSkips, []string{
+			"ApplicationsController::create_env",
+			"ApplicationsController::update_env_by_uuid",
+		}},
+		{"githubAppCoverageSkips", githubAppCoverageSkips, []string{"GithubController::"}},
+		{"scheduledTaskCoverageSkips", scheduledTaskCoverageSkips, []string{"ScheduledTasksController::"}},
+		{"serverCoverageSkips", serverCoverageSkips, []string{
+			"ServersController::",
+			"HetznerController::",
+			"DigitalOceanController::",
+			"VultrController::",
+		}},
+		{"databaseModelSkips", databaseModelSkips, []string{"DatabasesController::"}},
+		{"databaseBackupCoverageSkips", databaseBackupCoverageSkips, []string{"DatabasesController::"}},
+		{"serviceCoverageSkips", serviceCoverageSkips, []string{"ServicesController::", "ServiceApplicationsController::", "ServiceDatabasesController::"}},
+		{"storageCoverageSkips", storageCoverageSkips, []string{"ApplicationsController::", "ServicesController::"}},
+		{"cloudTokenCoverageSkips", cloudTokenCoverageSkips, []string{"CloudTokensController::", "CloudProviderTokensController::"}},
+		{"projectCoverageSkips", projectCoverageSkips, []string{"ProjectController::", "ProjectsController::"}},
+		{"environmentCoverageSkips", environmentCoverageSkips, []string{"ProjectController::", "ProjectsController::"}},
+		{"privateKeyCoverageSkips", privateKeyCoverageSkips, []string{"SecurityController::", "PrivateKeysController::"}},
+		{"serverSettingCoverageSkips", serverSettingCoverageSkips, []string{"ServersController::"}},
+	}
+
+	var violations []string
+	for _, sc := range scopes {
+		for field, skip := range sc.skips {
+			if skip.Status != SkipInternal {
+				continue
+			}
+			var hits []string
+			for epName, ep := range c.Endpoints {
+				if !endpointMatchesPrefixes(epName, sc.prefixes) {
+					continue
+				}
+				for _, af := range ep.AllowedFields {
+					if af == field {
+						hits = append(hits, epName)
+						break
+					}
+				}
+			}
+			if len(hits) > 0 {
+				sort.Strings(hits)
+				violations = append(violations, fmt.Sprintf(
+					"%s: %s marked internal but is on allowed_fields of: %s",
+					sc.name, field, strings.Join(hits, ", ")))
+			}
+		}
+	}
+	sort.Strings(violations)
+	if len(violations) > 0 {
+		t.Errorf("public allowed_fields must not use skipInternal:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func endpointMatchesPrefixes(name string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) || name == p {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/spectest/skip_test.go
+++ b/internal/spectest/skip_test.go
@@ -1,0 +1,64 @@
+package spectest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateFieldSkip_DeferredRequiresIssue(t *testing.T) {
+	t.Parallel()
+	err := validateFieldSkip(FieldSkip{
+		Field:  "is_shown_once",
+		Status: SkipDeferred,
+		Issue:  0,
+		Reason: "UI flag",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Issue") {
+		t.Fatalf("expected deferred without issue to fail, got %v", err)
+	}
+}
+
+func TestValidateFieldSkip_InternalFlagBannedOnDeferred(t *testing.T) {
+	t.Parallel()
+	err := validateFieldSkip(FieldSkip{
+		Field:  "is_runtime",
+		Status: SkipDeferred,
+		Issue:  626,
+		Reason: "internal flag we might expose later",
+	})
+	if err == nil || !strings.Contains(err.Error(), "internal flag") {
+		t.Fatalf("expected banned phrase error, got %v", err)
+	}
+}
+
+func TestSkipMap_ValidDeferred(t *testing.T) {
+	t.Parallel()
+	m := skipMap(
+		skipInternal("team_id", "FK"),
+		skipDeferred("order", 626, "UI ordering not managed in Terraform"),
+		skipNA("service_type", "mapped to type in client"),
+	)
+	if !isSkipped(m, "order") {
+		t.Fatal("expected order skipped")
+	}
+	if isSkipped(m, "key") {
+		t.Fatal("key should not be skipped")
+	}
+	issues := deferredIssueNumbers(m)
+	if len(issues) != 1 || issues[0] != 626 {
+		t.Fatalf("deferred issues = %v, want [626]", issues)
+	}
+}
+
+func TestSkipMap_PanicsOnDuplicate(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on duplicate")
+		}
+	}()
+	_ = skipMap(
+		skipInternal("team_id", "FK"),
+		skipInternal("team_id", "FK again"),
+	)
+}

--- a/internal/spectest/write_coverage_test.go
+++ b/internal/spectest/write_coverage_test.go
@@ -1,0 +1,67 @@
+package spectest
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+)
+
+// TestWriteCoverage_ApplicationEnv ensures application env create/update
+// allowed_fields appear on the client write payload type (#623 Phase A).
+func TestWriteCoverage_ApplicationEnv(t *testing.T) {
+	t.Parallel()
+	c := loadContract(t)
+
+	endpoints := []string{
+		"ApplicationsController::create_env",
+		"ApplicationsController::update_env_by_uuid",
+	}
+	tags := client.EnvVarWriteJSONTags("applications")
+	if len(tags) == 0 {
+		t.Fatal("EnvVarWriteJSONTags(applications) returned empty set")
+	}
+	requireValidSkips(t, appEnvWriteSkips)
+
+	for _, name := range endpoints {
+		ep, ok := c.Endpoints[name]
+		if !ok {
+			t.Fatalf("endpoint %s not found in contract", name)
+		}
+		if len(ep.AllowedFields) == 0 {
+			t.Fatalf("endpoint %s has empty allowed_fields", name)
+		}
+		var missing []string
+		for _, field := range ep.AllowedFields {
+			if isSkipped(appEnvWriteSkips, field) {
+				continue
+			}
+			if _, ok := tags[field]; !ok {
+				missing = append(missing, field)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Errorf("%s allowed_fields missing from application env write input:\n  %s",
+				name, strings.Join(missing, "\n  "))
+		}
+	}
+}
+
+// TestWriteCoverage_ServiceEnvSanity ensures service write payloads never
+// claim is_runtime / is_buildtime (parent-scoped allow lists).
+func TestWriteCoverage_ServiceEnvSanity(t *testing.T) {
+	t.Parallel()
+	tags := client.EnvVarWriteJSONTags("services")
+	for _, forbidden := range []string{"is_runtime", "is_buildtime"} {
+		if _, ok := tags[forbidden]; ok {
+			t.Errorf("service env write input must not include %s", forbidden)
+		}
+	}
+	for _, required := range []string{"key", "value", "is_preview", "is_literal", "is_multiline", "comment"} {
+		if _, ok := tags[required]; !ok {
+			t.Errorf("service env write input missing %s", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the contract-pipeline follow-ups from the #619 post-mortem so product gaps cannot hide behind green client coverage.

| Issue | Change |
|-------|--------|
| #622 | Skip taxonomy: `internal` / `deferred+#N` / `n/a` for all `TestContractCoverage_*` maps |
| #623 | Phase A: application `create_env` / `update_env_by_uuid` `allowed_fields` vs write input JSON tags |
| #621 | Phase A schema registry for EnvironmentVariable + resource `Schema()` attribute check |
| #624 | Weekly freshness issue body checklist (`.github/contract-freshness-issue.md`); comment existing drift issues |

Also filed **#626** as the deferred-field umbrella used by taxonomy rows for remaining non-#619 product skips.

### Note on #620

Already merged separately as PR #620 (`ValidateConfig` unknown guards + client error context).

## Test plan

- [x] `go test ./internal/spectest/ -run 'ContractCoverage|WriteCoverage|SchemaCoverage|Skip'`
- [x] `make ci`
- [ ] CI green on PR

Closes #621, Closes #622, Closes #623, Closes #624