### PR TITLE
fix(ci): drop em dash from social-preview repo description

### DIFF
--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -100,7 +100,7 @@ jobs:
           DATASOURCES: ${{ steps.stats.outputs.datasources }}
           TESTS: ${{ steps.stats.outputs.tests }}
         run: |
-          NEW="Terraform provider for Coolify — manage ${RESOURCES} resources, ${DATASOURCES} data sources, ${TESTS} tests. Self-hosted PaaS as code."
+          NEW="Terraform provider for Coolify: manage ${RESOURCES} resources, ${DATASOURCES} data sources, ${TESTS} tests. Self-hosted PaaS as code."
           CURRENT=$(gh repo view --json description --jq '.description')
           if [ "$NEW" != "$CURRENT" ]; then
             gh repo edit --description "$NEW"


### PR DESCRIPTION
## Summary

The Update Social Preview workflow set the repo description with a Unicode em dash. Project human-facing style forbids that character.

## Test plan

- [x] Workflow string uses ASCII colon
- [ ] CI green