### PR TITLE
docs: document autogenerate_domain and public create default

### DIFF
--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -197,6 +197,19 @@ value the API returned on Read. Common triggers:
 3. If the field is a password you set, the token permissions are the
    most likely cause
 
+### Unexpected public domain (`sslip.io` or wildcard FQDN)
+
+**Symptom:** after `terraform apply`, the application has a public URL
+like `http://{uuid}.{ip}.sslip.io` even though you never set `domains`.
+
+**Cause:** Coolify defaults `autogenerate_domain` to `true` on create.
+When `domains` is blank, it generates a Traefik host automatically.
+
+**Fix:** set `autogenerate_domain = false` for internal apps (workers,
+queues, sidecars). See the [Domains and HTTPS](domains-and-https)
+guide. Clearing an existing FQDN with `domains = ""` is blocked by a
+Coolify update-path bug (`$request->has('domains')`); tracked as #647.
+
 ### "forces replacement"
 
 ```

--- a/docs/guides/domains-and-https.md
+++ b/docs/guides/domains-and-https.md
@@ -128,26 +128,54 @@ resource "coolify_application" "web" {
 All domains receive TLS certificates. Requests to any of them route to
 the same application container.
 
-## Wildcard Domains
+## Auto-generated Domains
 
-Servers have a `wildcard_domain` attribute that enables automatic domain
-assignment for applications that do not set an explicit `domains` value:
+On **create**, Coolify defaults `autogenerate_domain` to `true`. If you
+omit `domains` (or leave it blank), Coolify assigns a public FQDN and
+installs a Traefik/Caddy host for it:
+
+| Server config | Generated FQDN shape |
+|---------------|----------------------|
+| Wildcard domain set | `https://{application-uuid}.{wildcard}` |
+| No wildcard | `http://{application-uuid}.{server-ip}.sslip.io` |
+
+The provider exposes this as create-only `autogenerate_domain`
+(default `true`), matching Coolify's `$request->boolean('autogenerate_domain', true)`.
 
 ```hcl
-resource "coolify_server" "prod" {
+resource "coolify_application_docker_image" "public" {
   # ...
-  # This is a read-only attribute set via Coolify UI/API
-  # wildcard_domain = "example.com"
+  # domains omitted + default autogenerate_domain = true
+  # -> Coolify generates sslip.io or wildcard FQDN
 }
 ```
 
-When a wildcard domain is configured on the server, Coolify generates
-a domain like `<app-name>.<wildcard-domain>` for applications that
-do not have an explicit `domains` attribute set.
+Servers may also show a read-only `wildcard_domain` from Coolify UI/API
+configuration. Prefer explicit `domains = "https://..."` for production
+hostnames with Let's Encrypt HTTP-01.
 
--> **Wildcard TLS** requires DNS-01 validation (not HTTP-01) and
-additional proxy configuration. For most setups, explicit per-app
-domains with HTTP-01 validation are simpler and recommended.
+-> **Wildcard TLS** (server-level wildcards) often needs DNS-01 validation.
+For most setups, explicit per-app domains with HTTP-01 are simpler.
+
+## Internal Applications (No Public URL)
+
+Workers, queues, and sidecars that must **not** get a Traefik host should
+disable generation and leave `domains` empty:
+
+```hcl
+resource "coolify_application_docker_image" "worker" {
+  name                = "background-worker"
+  project_uuid        = coolify_project.main.uuid
+  server_uuid         = data.coolify_server.prod.uuid
+  docker_image        = "myorg/worker:latest"
+  ports_exposes       = "8080"
+  autogenerate_domain = false
+  # domains omitted or domains = ""
+}
+```
+
+Without `autogenerate_domain = false`, Coolify still generates a public
+sslip/wildcard URL even when you never set `domains`.
 
 ## Troubleshooting
 

--- a/docs/resources/application_docker_image.md
+++ b/docs/resources/application_docker_image.md
@@ -23,6 +23,7 @@ resource "coolify_application_docker_image" "nginx" {
 
   # Optional fields (uncomment as needed):
   # docker_registry_image_tag = "1.27-alpine"  # Pin to a specific image tag instead of :latest
+  # autogenerate_domain       = false          # Internal apps: no sslip/wildcard public FQDN
 }
 ```
 

--- a/examples/resources/coolify_application_docker_image/resource.tf
+++ b/examples/resources/coolify_application_docker_image/resource.tf
@@ -8,4 +8,5 @@ resource "coolify_application_docker_image" "nginx" {
 
   # Optional fields (uncomment as needed):
   # docker_registry_image_tag = "1.27-alpine"  # Pin to a specific image tag instead of :latest
+  # autogenerate_domain       = false          # Internal apps: no sslip/wildcard public FQDN
 }

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -50,6 +50,10 @@ func TestApplicationResource_Create(t *testing.T) {
 				return
 			}
 		}
+		// Default true matches Coolify $request->boolean('autogenerate_domain', true).
+		if v, ok := body["autogenerate_domain"].(bool); !ok || !v {
+			t.Errorf("POST create expected autogenerate_domain=true by default, got %v", body["autogenerate_domain"])
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
@@ -102,6 +106,7 @@ func TestApplicationResource_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("coolify_application.test", "build_pack", "nixpacks"),
 					resource.TestCheckResourceAttr("coolify_application.test", "ports_exposes", "3000"),
 					resource.TestCheckResourceAttr("coolify_application.test", "environment_name", "production"),
+					resource.TestCheckResourceAttr("coolify_application.test", "autogenerate_domain", "true"),
 				),
 			},
 			{

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -197,6 +197,19 @@ value the API returned on Read. Common triggers:
 3. If the field is a password you set, the token permissions are the
    most likely cause
 
+### Unexpected public domain (`sslip.io` or wildcard FQDN)
+
+**Symptom:** after `terraform apply`, the application has a public URL
+like `http://{uuid}.{ip}.sslip.io` even though you never set `domains`.
+
+**Cause:** Coolify defaults `autogenerate_domain` to `true` on create.
+When `domains` is blank, it generates a Traefik host automatically.
+
+**Fix:** set `autogenerate_domain = false` for internal apps (workers,
+queues, sidecars). See the [Domains and HTTPS](domains-and-https)
+guide. Clearing an existing FQDN with `domains = ""` is blocked by a
+Coolify update-path bug (`$request->has('domains')`); tracked as #647.
+
 ### "forces replacement"
 
 ```

--- a/templates/guides/domains-and-https.md.tmpl
+++ b/templates/guides/domains-and-https.md.tmpl
@@ -128,26 +128,54 @@ resource "coolify_application" "web" {
 All domains receive TLS certificates. Requests to any of them route to
 the same application container.
 
-## Wildcard Domains
+## Auto-generated Domains
 
-Servers have a `wildcard_domain` attribute that enables automatic domain
-assignment for applications that do not set an explicit `domains` value:
+On **create**, Coolify defaults `autogenerate_domain` to `true`. If you
+omit `domains` (or leave it blank), Coolify assigns a public FQDN and
+installs a Traefik/Caddy host for it:
+
+| Server config | Generated FQDN shape |
+|---------------|----------------------|
+| Wildcard domain set | `https://{application-uuid}.{wildcard}` |
+| No wildcard | `http://{application-uuid}.{server-ip}.sslip.io` |
+
+The provider exposes this as create-only `autogenerate_domain`
+(default `true`), matching Coolify's `$request->boolean('autogenerate_domain', true)`.
 
 ```hcl
-resource "coolify_server" "prod" {
+resource "coolify_application_docker_image" "public" {
   # ...
-  # This is a read-only attribute set via Coolify UI/API
-  # wildcard_domain = "example.com"
+  # domains omitted + default autogenerate_domain = true
+  # -> Coolify generates sslip.io or wildcard FQDN
 }
 ```
 
-When a wildcard domain is configured on the server, Coolify generates
-a domain like `<app-name>.<wildcard-domain>` for applications that
-do not have an explicit `domains` attribute set.
+Servers may also show a read-only `wildcard_domain` from Coolify UI/API
+configuration. Prefer explicit `domains = "https://..."` for production
+hostnames with Let's Encrypt HTTP-01.
 
--> **Wildcard TLS** requires DNS-01 validation (not HTTP-01) and
-additional proxy configuration. For most setups, explicit per-app
-domains with HTTP-01 validation are simpler and recommended.
+-> **Wildcard TLS** (server-level wildcards) often needs DNS-01 validation.
+For most setups, explicit per-app domains with HTTP-01 are simpler.
+
+## Internal Applications (No Public URL)
+
+Workers, queues, and sidecars that must **not** get a Traefik host should
+disable generation and leave `domains` empty:
+
+```hcl
+resource "coolify_application_docker_image" "worker" {
+  name                = "background-worker"
+  project_uuid        = coolify_project.main.uuid
+  server_uuid         = data.coolify_server.prod.uuid
+  docker_image        = "myorg/worker:latest"
+  ports_exposes       = "8080"
+  autogenerate_domain = false
+  # domains omitted or domains = ""
+}
+```
+
+Without `autogenerate_domain = false`, Coolify still generates a public
+sslip/wildcard URL even when you never set `domains`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

MPI cycle after #646: document Coolify domain auto-generation and assert the public application create path sends the new default.

- Domains guide: auto-generated FQDNs (sslip/wildcard) and internal apps with `autogenerate_domain = false`
- Common errors: unexpected public domain symptom + #647 clear caveat
- Example: optional `autogenerate_domain` comment on docker_image
- Unit: `coolify_application` create body asserts `autogenerate_domain=true` by default

## Related

- Builds on #646 (`autogenerate_domain` feature)
- Tracks Coolify empty-domains clear gap as #647 (blocked-upstream)

## Test plan

- [x] `make ci`
- [x] `go test ./internal/service/application/ -run TestApplicationResource_Create`