### PR TITLE
fix: version-gate ApplicationSetting writes for Coolify 4.1.x

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -73,9 +73,9 @@ resource "coolify_application" "example" {
 - `custom_network_aliases` (String) Custom network aliases for the container.
 - `custom_nginx_configuration` (String) Custom Nginx configuration for the application. The provider accepts plain text or pre-encoded base64; encoding is handled automatically.
 - `description` (String) A description of the application.
-- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`.
+- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_compose_domains` (String) Domain mappings for Docker Compose services (`build_pack = "dockercompose"`). Send a JSON array of objects with `name` (compose service name) and `domain` (comma-separated http(s) URLs), for example `jsonencode([{ name = "web", domain = "https://app.example.com" }])`. Coolify accepts only that array form on write, stores an object map keyed by service name, and returns the object form on GET; the provider normalizes both shapes so Terraform plans stay empty after apply. Coolify rejects this field until `docker_compose_raw` is set. For git-sourced compose apps, Coolify only populates `docker_compose_raw` after a deployment loads the compose file from the repository; there is no separate load-compose API. This ordering is a Coolify API constraint on all Coolify versions supported by this provider (v4.1.0 and later). Recommended two-stage apply: (1) create without `docker_compose_domains` and deploy once (`instant_deploy = true` or a manual deploy), wait until the deployment succeeds; (2) add `docker_compose_domains` and apply again. Alternatively use `coolify_service` with inline `docker_compose_raw` when the compose file can live in Terraform.
-- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`.
+- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_registry_image_tag` (String) The Docker registry image tag.
 - `dockerfile` (String, Sensitive) Inline Dockerfile content (base64 encoded). For `coolify_application_dockerfile` resources, use `dockerfile_location` instead; this field is only used by Git-backed application types that embed a Dockerfile inline.
 - `dockerfile_location` (String) The path to the Dockerfile, relative to the repository root.
@@ -100,26 +100,26 @@ resource "coolify_application" "example" {
 - `health_check_type` (String) The type of health check. Valid values: `http`, `cmd`.
 - `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication.
 - `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`.
-- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`.
+- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `install_command` (String) The command to run during the install phase.
 - `instant_deploy` (Boolean) Whether to immediately deploy the application after creation. When `true`, Coolify triggers a deployment right away. When `false` (default), the application is created but not deployed.
 - `is_auto_deploy_enabled` (Boolean) Whether auto-deploy on push is enabled.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled.
-- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`.
+- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_force_https_enabled` (Boolean) Whether to force HTTPS for the application.
-- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`.
-- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`.
-- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`.
-- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`.
+- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_http_basic_auth_enabled` (Boolean) Whether HTTP Basic Authentication is enabled.
-- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`.
+- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_preserve_repository_enabled` (Boolean) Whether to preserve the full Git repository (instead of shallow clone).
 - `is_preview_deployments_enabled` (Boolean) Whether preview deployments (e.g. pull requests) are enabled for this application. Requires Coolify >= v4.2.0. When omitted, Coolify defaults to `false`.
-- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.
+- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_spa` (Boolean) Whether the application is a single-page application.
 - `is_static` (Boolean) Whether the application is a static site.
-- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.
+- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
 - `limits_cpuset` (String) CPU set restriction (e.g., `0-3`, `0,2`).

--- a/docs/resources/application_docker_image.md
+++ b/docs/resources/application_docker_image.md
@@ -47,9 +47,9 @@ resource "coolify_application_docker_image" "nginx" {
 - `custom_network_aliases` (String) Custom network aliases for the container.
 - `custom_nginx_configuration` (String) Custom Nginx configuration for the application. The provider accepts plain text or pre-encoded base64; encoding is handled automatically.
 - `description` (String) A description of the application.
-- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`.
+- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_compose_domains` (String) Domain mappings for Docker Compose services (`build_pack = "dockercompose"`). Send a JSON array of objects with `name` (compose service name) and `domain` (comma-separated http(s) URLs), for example `jsonencode([{ name = "web", domain = "https://app.example.com" }])`. Coolify accepts only that array form on write, stores an object map keyed by service name, and returns the object form on GET; the provider normalizes both shapes so Terraform plans stay empty after apply. Coolify rejects this field until `docker_compose_raw` is set. For git-sourced compose apps, Coolify only populates `docker_compose_raw` after a deployment loads the compose file from the repository; there is no separate load-compose API. This ordering is a Coolify API constraint on all Coolify versions supported by this provider (v4.1.0 and later). Recommended two-stage apply: (1) create without `docker_compose_domains` and deploy once (`instant_deploy = true` or a manual deploy), wait until the deployment succeeds; (2) add `docker_compose_domains` and apply again. Alternatively use `coolify_service` with inline `docker_compose_raw` when the compose file can live in Terraform.
-- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`.
+- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_registry_image_tag` (String) The Docker registry image tag.
 - `dockerfile` (String, Sensitive) Inline Dockerfile content (base64 encoded). For `coolify_application_dockerfile` resources, use `dockerfile_location` instead; this field is only used by Git-backed application types that embed a Dockerfile inline.
 - `domains` (String) Application URL(s) as a comma-separated list of http:// or https:// URLs. Empty string is allowed in Terraform (validator and PATCH body send `domains: ""`). When omitted on create, Coolify may auto-generate a domain unless `autogenerate_domain` is false. Clearing an existing FQDN on update requires Coolify to treat empty `domains` as present (current Coolify uses `$request->has('domains')` with `ConvertEmptyStringsToNull`, which drops empty clears; tracked upstream).
@@ -72,26 +72,26 @@ resource "coolify_application_docker_image" "nginx" {
 - `health_check_type` (String) The type of health check. Valid values: `http`, `cmd`.
 - `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication.
 - `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`.
-- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`.
+- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `install_command` (String) The command to run during the install phase.
 - `instant_deploy` (Boolean) Whether to immediately deploy the application after creation. When `true`, Coolify triggers a deployment right away. When `false` (default), the application is created but not deployed.
 - `is_auto_deploy_enabled` (Boolean) Whether auto-deploy on push is enabled.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled.
-- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`.
+- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_force_https_enabled` (Boolean) Whether to force HTTPS for the application.
-- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`.
-- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`.
-- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`.
-- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`.
+- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_http_basic_auth_enabled` (Boolean) Whether HTTP Basic Authentication is enabled.
-- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`.
+- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_preserve_repository_enabled` (Boolean) Whether to preserve the full Git repository (instead of shallow clone).
 - `is_preview_deployments_enabled` (Boolean) Whether preview deployments (e.g. pull requests) are enabled for this application. Requires Coolify >= v4.2.0. When omitted, Coolify defaults to `false`.
-- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.
+- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_spa` (Boolean) Whether the application is a single-page application.
 - `is_static` (Boolean) Whether the application is a static site.
-- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.
+- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
 - `limits_cpuset` (String) CPU set restriction (e.g., `0-3`, `0,2`).

--- a/docs/resources/application_dockerfile.md
+++ b/docs/resources/application_dockerfile.md
@@ -57,9 +57,9 @@ resource "coolify_application_dockerfile" "app" {
 - `custom_network_aliases` (String) Custom network aliases for the container.
 - `custom_nginx_configuration` (String) Custom Nginx configuration for the application. The provider accepts plain text or pre-encoded base64; encoding is handled automatically.
 - `description` (String) A description of the application.
-- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`.
+- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_compose_domains` (String) Domain mappings for Docker Compose services (`build_pack = "dockercompose"`). Send a JSON array of objects with `name` (compose service name) and `domain` (comma-separated http(s) URLs), for example `jsonencode([{ name = "web", domain = "https://app.example.com" }])`. Coolify accepts only that array form on write, stores an object map keyed by service name, and returns the object form on GET; the provider normalizes both shapes so Terraform plans stay empty after apply. Coolify rejects this field until `docker_compose_raw` is set. For git-sourced compose apps, Coolify only populates `docker_compose_raw` after a deployment loads the compose file from the repository; there is no separate load-compose API. This ordering is a Coolify API constraint on all Coolify versions supported by this provider (v4.1.0 and later). Recommended two-stage apply: (1) create without `docker_compose_domains` and deploy once (`instant_deploy = true` or a manual deploy), wait until the deployment succeeds; (2) add `docker_compose_domains` and apply again. Alternatively use `coolify_service` with inline `docker_compose_raw` when the compose file can live in Terraform.
-- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`.
+- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_registry_image_tag` (String) The Docker registry image tag.
 - `dockerfile` (String, Sensitive) Inline Dockerfile content (base64 encoded). For `coolify_application_dockerfile` resources, use `dockerfile_location` instead; this field is only used by Git-backed application types that embed a Dockerfile inline.
 - `dockerfile_target_build` (String) The target stage for multi-stage Docker builds.
@@ -83,26 +83,26 @@ resource "coolify_application_dockerfile" "app" {
 - `health_check_type` (String) The type of health check. Valid values: `http`, `cmd`.
 - `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication.
 - `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`.
-- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`.
+- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `install_command` (String) The command to run during the install phase.
 - `instant_deploy` (Boolean) Whether to immediately deploy the application after creation. When `true`, Coolify triggers a deployment right away. When `false` (default), the application is created but not deployed.
 - `is_auto_deploy_enabled` (Boolean) Whether auto-deploy on push is enabled.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled.
-- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`.
+- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_force_https_enabled` (Boolean) Whether to force HTTPS for the application.
-- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`.
-- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`.
-- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`.
-- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`.
+- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_http_basic_auth_enabled` (Boolean) Whether HTTP Basic Authentication is enabled.
-- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`.
+- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_preserve_repository_enabled` (Boolean) Whether to preserve the full Git repository (instead of shallow clone).
 - `is_preview_deployments_enabled` (Boolean) Whether preview deployments (e.g. pull requests) are enabled for this application. Requires Coolify >= v4.2.0. When omitted, Coolify defaults to `false`.
-- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.
+- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_spa` (Boolean) Whether the application is a single-page application.
 - `is_static` (Boolean) Whether the application is a static site.
-- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.
+- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
 - `limits_cpuset` (String) CPU set restriction (e.g., `0-3`, `0,2`).

--- a/docs/resources/application_github_app.md
+++ b/docs/resources/application_github_app.md
@@ -51,9 +51,9 @@ resource "coolify_application_github_app" "app" {
 - `custom_network_aliases` (String) Custom network aliases for the container.
 - `custom_nginx_configuration` (String) Custom Nginx configuration for the application. The provider accepts plain text or pre-encoded base64; encoding is handled automatically.
 - `description` (String) A description of the application.
-- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`.
+- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_compose_domains` (String) Domain mappings for Docker Compose services (`build_pack = "dockercompose"`). Send a JSON array of objects with `name` (compose service name) and `domain` (comma-separated http(s) URLs), for example `jsonencode([{ name = "web", domain = "https://app.example.com" }])`. Coolify accepts only that array form on write, stores an object map keyed by service name, and returns the object form on GET; the provider normalizes both shapes so Terraform plans stay empty after apply. Coolify rejects this field until `docker_compose_raw` is set. For git-sourced compose apps, Coolify only populates `docker_compose_raw` after a deployment loads the compose file from the repository; there is no separate load-compose API. This ordering is a Coolify API constraint on all Coolify versions supported by this provider (v4.1.0 and later). Recommended two-stage apply: (1) create without `docker_compose_domains` and deploy once (`instant_deploy = true` or a manual deploy), wait until the deployment succeeds; (2) add `docker_compose_domains` and apply again. Alternatively use `coolify_service` with inline `docker_compose_raw` when the compose file can live in Terraform.
-- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`.
+- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_registry_image_tag` (String) The Docker registry image tag.
 - `dockerfile` (String, Sensitive) Inline Dockerfile content (base64 encoded). For `coolify_application_dockerfile` resources, use `dockerfile_location` instead; this field is only used by Git-backed application types that embed a Dockerfile inline.
 - `dockerfile_location` (String) The path to the Dockerfile, relative to the repository root.
@@ -78,26 +78,26 @@ resource "coolify_application_github_app" "app" {
 - `health_check_type` (String) The type of health check. Valid values: `http`, `cmd`.
 - `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication.
 - `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`.
-- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`.
+- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `install_command` (String) The command to run during the install phase.
 - `instant_deploy` (Boolean) Whether to immediately deploy the application after creation. When `true`, Coolify triggers a deployment right away. When `false` (default), the application is created but not deployed.
 - `is_auto_deploy_enabled` (Boolean) Whether auto-deploy on push is enabled.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled.
-- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`.
+- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_force_https_enabled` (Boolean) Whether to force HTTPS for the application.
-- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`.
-- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`.
-- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`.
-- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`.
+- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_http_basic_auth_enabled` (Boolean) Whether HTTP Basic Authentication is enabled.
-- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`.
+- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_preserve_repository_enabled` (Boolean) Whether to preserve the full Git repository (instead of shallow clone).
 - `is_preview_deployments_enabled` (Boolean) Whether preview deployments (e.g. pull requests) are enabled for this application. Requires Coolify >= v4.2.0. When omitted, Coolify defaults to `false`.
-- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.
+- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_spa` (Boolean) Whether the application is a single-page application.
 - `is_static` (Boolean) Whether the application is a static site.
-- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.
+- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
 - `limits_cpuset` (String) CPU set restriction (e.g., `0-3`, `0,2`).

--- a/docs/resources/application_private_git.md
+++ b/docs/resources/application_private_git.md
@@ -49,9 +49,9 @@ resource "coolify_application_private_git" "api" {
 - `custom_network_aliases` (String) Custom network aliases for the container.
 - `custom_nginx_configuration` (String) Custom Nginx configuration for the application. The provider accepts plain text or pre-encoded base64; encoding is handled automatically.
 - `description` (String) A description of the application.
-- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`.
+- `disable_build_cache` (Boolean) Whether to disable the Docker build cache for this application. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_compose_domains` (String) Domain mappings for Docker Compose services (`build_pack = "dockercompose"`). Send a JSON array of objects with `name` (compose service name) and `domain` (comma-separated http(s) URLs), for example `jsonencode([{ name = "web", domain = "https://app.example.com" }])`. Coolify accepts only that array form on write, stores an object map keyed by service name, and returns the object form on GET; the provider normalizes both shapes so Terraform plans stay empty after apply. Coolify rejects this field until `docker_compose_raw` is set. For git-sourced compose apps, Coolify only populates `docker_compose_raw` after a deployment loads the compose file from the repository; there is no separate load-compose API. This ordering is a Coolify API constraint on all Coolify versions supported by this provider (v4.1.0 and later). Recommended two-stage apply: (1) create without `docker_compose_domains` and deploy once (`instant_deploy = true` or a manual deploy), wait until the deployment succeeds; (2) add `docker_compose_domains` and apply again. Alternatively use `coolify_service` with inline `docker_compose_raw` when the compose file can live in Terraform.
-- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`.
+- `docker_images_to_keep` (Number) Number of Docker images to keep for this application. Coolify default is `2`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `docker_registry_image_tag` (String) The Docker registry image tag.
 - `dockerfile` (String, Sensitive) Inline Dockerfile content (base64 encoded). For `coolify_application_dockerfile` resources, use `dockerfile_location` instead; this field is only used by Git-backed application types that embed a Dockerfile inline.
 - `dockerfile_location` (String) The path to the Dockerfile, relative to the repository root.
@@ -76,26 +76,26 @@ resource "coolify_application_private_git" "api" {
 - `health_check_type` (String) The type of health check. Valid values: `http`, `cmd`.
 - `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication.
 - `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`.
-- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`.
+- `include_source_commit_in_build` (Boolean) Whether to include the source commit SHA in the build. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `inject_build_args_to_dockerfile` (Boolean) Whether to inject build arguments into the Dockerfile. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `install_command` (String) The command to run during the install phase.
 - `instant_deploy` (Boolean) Whether to immediately deploy the application after creation. When `true`, Coolify triggers a deployment right away. When `false` (default), the application is created but not deployed.
 - `is_auto_deploy_enabled` (Boolean) Whether auto-deploy on push is enabled.
 - `is_container_label_escape_enabled` (Boolean) Whether container label escaping is enabled.
-- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`.
+- `is_env_sorting_enabled` (Boolean) Whether environment variables are sorted. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_force_https_enabled` (Boolean) Whether to force HTTPS for the application.
-- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`.
-- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`.
-- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`.
-- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`.
+- `is_git_lfs_enabled` (Boolean) Whether Git LFS objects are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_shallow_clone_enabled` (Boolean) Whether Git uses a shallow clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_git_submodules_enabled` (Boolean) Whether Git submodules are fetched during clone. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
+- `is_gzip_enabled` (Boolean) Whether gzip compression is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_http_basic_auth_enabled` (Boolean) Whether HTTP Basic Authentication is enabled.
-- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`.
+- `is_pr_deployments_public_enabled` (Boolean) Whether preview deployments from public pull requests are enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_preserve_repository_enabled` (Boolean) Whether to preserve the full Git repository (instead of shallow clone).
 - `is_preview_deployments_enabled` (Boolean) Whether preview deployments (e.g. pull requests) are enabled for this application. Requires Coolify >= v4.2.0. When omitted, Coolify defaults to `false`.
-- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.
+- `is_raw_compose_deployment_enabled` (Boolean) Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `is_spa` (Boolean) Whether the application is a single-page application.
 - `is_static` (Boolean) Whether the application is a static site.
-- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.
+- `is_stripprefix_enabled` (Boolean) Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
 - `limits_cpuset` (String) CPU set restriction (e.g., `0-3`, `0,2`).

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -26,14 +26,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+// DefaultTestCoolifyVersion is the version mock servers report by default.
+//
+// It is a 4.2.x version because the provider gates some writes on the connected
+// version (see client.SupportsApplicationSettings): a mock reporting 4.1.x would
+// silently put every unit test on the withholding path, and tests asserting that
+// a settings field reaches the API would fail for reasons unrelated to what they
+// cover. Use WithVersionEndpointVersion to exercise the older behaviour on
+// purpose.
+const DefaultTestCoolifyVersion = "v4.2.0-test"
+
 // WithVersionEndpoint wraps an http.Handler to also respond to
 // GET /api/v1/version, which the provider calls during Configure
 // to validate the connection.
 func WithVersionEndpoint(next http.Handler) http.Handler {
+	return WithVersionEndpointVersion(next, DefaultTestCoolifyVersion)
+}
+
+// WithVersionEndpointVersion is WithVersionEndpoint with an explicit version,
+// for tests that need to pin the connected Coolify to a particular release.
+func WithVersionEndpointVersion(next http.Handler, version string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/version" {
 			w.Header().Set("Content-Type", "text/html")
-			_, _ = w.Write([]byte(`v4.1.0-test`))
+			_, _ = w.Write([]byte(version))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/client/applications.go
+++ b/internal/client/applications.go
@@ -393,11 +393,60 @@ func (c *Client) CreatePublicApplication(ctx context.Context, input CreatePublic
 	return &a, nil
 }
 func (c *Client) UpdateApplication(ctx context.Context, uuid string, input UpdateApplicationInput) (*Application, error) {
+	if !c.SupportsApplicationSettings() {
+		input.clearApplicationSettings()
+	}
 	var a Application
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/applications/%s", url.PathEscape(uuid)), input, &a); err != nil {
 		return nil, fmt.Errorf("updating application %s: %w", uuid, err)
 	}
 	return &a, nil
+}
+
+// clearApplicationSettings drops every ApplicationSetting field from the
+// payload. The gate lives here, on the single path every application PATCH
+// takes, rather than in each caller: a field that cannot be written must not
+// depend on which builder assembled the request.
+func (i *UpdateApplicationInput) clearApplicationSettings() {
+	i.IsGitSubmodulesEnabled = nil
+	i.IsGitLfsEnabled = nil
+	i.IsGitShallowCloneEnabled = nil
+	i.DisableBuildCache = nil
+	i.InjectBuildArgsToDockerfile = nil
+	i.IncludeSourceCommitInBuild = nil
+	i.IsEnvSortingEnabled = nil
+	i.IsPrDeploymentsPublicEnabled = nil
+	i.DockerImagesToKeep = nil
+	i.IsGzipEnabled = nil
+	i.IsStripprefixEnabled = nil
+	i.IsRawComposeDeploymentEnabled = nil
+	i.StopGracePeriod = nil
+}
+
+// HasOnlyApplicationSettings reports whether the payload would be empty once
+// the settings fields are dropped. Callers use it to skip a PATCH that the gate
+// would reduce to `{}`.
+//
+// Counted through the JSON encoding rather than by comparing structs: the input
+// carries a json.RawMessage, so it is not comparable, and encoding is what
+// decides which fields actually reach Coolify anyway.
+func (i UpdateApplicationInput) HasOnlyApplicationSettings() bool {
+	stripped := i
+	stripped.clearApplicationSettings()
+	return i.encodedFieldCount() > 0 && stripped.encodedFieldCount() == 0
+}
+
+// encodedFieldCount returns how many fields the input serialises to.
+func (i UpdateApplicationInput) encodedFieldCount() int {
+	raw, err := json.Marshal(i)
+	if err != nil {
+		return 0
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return 0
+	}
+	return len(body)
 }
 func (c *Client) DeleteApplication(ctx context.Context, uuid string) error {
 	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/applications/%s", url.PathEscape(uuid)), nil, nil); err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -26,10 +26,15 @@ const maxResponseSize = 10 << 20
 
 // Client is the Coolify API client.
 type Client struct {
-	BaseURL           string
-	apiToken          string // unexported: prevents %+v leaking the token
-	HTTPClient        *http.Client
-	UserAgent         string
+	BaseURL    string
+	apiToken   string // unexported: prevents %+v leaking the token
+	HTTPClient *http.Client
+	UserAgent  string
+	// CoolifyVersion is the connected instance's version, read once during
+	// provider Configure. Empty when unknown (unit tests, or a Configure that
+	// never ran); callers must treat empty as "assume the newest behaviour"
+	// rather than gating features off.
+	CoolifyVersion    string
 	cfAccessClientID  string // Cloudflare Access CF-Access-Client-Id header
 	cfAccessClientSec string // Cloudflare Access CF-Access-Client-Secret header
 	listCache         listCache

--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"strconv"
+	"strings"
+)
+
+// minApplicationSettingsVersion is the first Coolify release whose application
+// endpoints accept ApplicationSetting fields.
+//
+// Coolify builds the allow list for both create_application and
+// update_by_uuid as a literal list ending in
+// `...self::APPLICATION_SETTING_FIELDS`. That constant does not exist before
+// v4.2.0, so on v4.1.x every settings field falls outside the allow list and
+// comes back 422 "This field is not allowed." — and one rejected field aborts
+// the entire request, which fails Create and leaves the resource tainted.
+const minApplicationSettingsVersion = "4.2.0"
+
+// SupportsApplicationSettings reports whether the connected instance accepts
+// ApplicationSetting fields on the application write endpoints.
+//
+// An unknown version (empty CoolifyVersion) reports true: the provider already
+// refuses to configure against an instance below minCoolifyVersion, so the only
+// way to reach here without a version is a path that never called Configure —
+// unit tests, mostly. Assuming the newest behaviour there keeps those tests
+// exercising the full payload.
+func (c *Client) SupportsApplicationSettings() bool {
+	if c == nil || c.CoolifyVersion == "" {
+		return true
+	}
+	return IsVersionAtLeast(c.CoolifyVersion, minApplicationSettingsVersion)
+}
+
+// IsVersionAtLeast compares two semver-like version strings (e.g. "4.0.0").
+// Returns true if actual >= minimum. Non-parseable versions return true
+// to avoid blocking on unexpected version formats.
+func IsVersionAtLeast(actual, minimum string) bool {
+	parse := func(v string) (int, int, int, bool) {
+		v = strings.TrimPrefix(v, "v")
+		parts := strings.SplitN(v, ".", 3)
+		if len(parts) < 2 {
+			return 0, 0, 0, false
+		}
+		major, err1 := strconv.Atoi(parts[0])
+		minor, err2 := strconv.Atoi(parts[1])
+		patch := 0
+		if len(parts) == 3 {
+			// Strip pre-release suffix (e.g. "0-beta.335")
+			p := strings.SplitN(parts[2], "-", 2)[0]
+			patch, _ = strconv.Atoi(p)
+		}
+		if err1 != nil || err2 != nil {
+			return 0, 0, 0, false
+		}
+		return major, minor, patch, true
+	}
+	aMaj, aMin, aPat, aOk := parse(actual)
+	mMaj, mMin, mPat, mOk := parse(minimum)
+	if !aOk || !mOk {
+		return true
+	}
+	if aMaj != mMaj {
+		return aMaj > mMaj
+	}
+	if aMin != mMin {
+		return aMin > mMin
+	}
+	return aPat >= mPat
+}

--- a/internal/client/version_gate_test.go
+++ b/internal/client/version_gate_test.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// settingFieldKeys mirrors Coolify's APPLICATION_SETTING_FIELDS.
+var settingFieldKeys = []string{
+	"is_git_submodules_enabled", "is_git_lfs_enabled", "is_git_shallow_clone_enabled",
+	"disable_build_cache", "inject_build_args_to_dockerfile", "include_source_commit_in_build",
+	"is_env_sorting_enabled", "is_pr_deployments_public_enabled", "stop_grace_period",
+	"docker_images_to_keep", "is_gzip_enabled", "is_stripprefix_enabled",
+	"is_raw_compose_deployment_enabled",
+}
+
+// fullSettingsInput sets every ApplicationSetting field plus one ordinary field,
+// so a stripped payload is still a valid, non-empty request.
+func fullSettingsInput() UpdateApplicationInput {
+	b := true
+	n := int64(5)
+	name := "gate-probe"
+	return UpdateApplicationInput{
+		Name:                          &name,
+		IsGitSubmodulesEnabled:        &b,
+		IsGitLfsEnabled:               &b,
+		IsGitShallowCloneEnabled:      &b,
+		DisableBuildCache:             &b,
+		InjectBuildArgsToDockerfile:   &b,
+		IncludeSourceCommitInBuild:    &b,
+		IsEnvSortingEnabled:           &b,
+		IsPrDeploymentsPublicEnabled:  &b,
+		DockerImagesToKeep:            &n,
+		IsGzipEnabled:                 &b,
+		IsStripprefixEnabled:          &b,
+		IsRawComposeDeploymentEnabled: &b,
+		StopGracePeriod:               &n,
+	}
+}
+
+// capturingServer records the body of the next PATCH.
+func capturingServer(t *testing.T, body *map[string]json.RawMessage) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(body); err != nil {
+			t.Errorf("decoding PATCH body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{"uuid": "app-1"}); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestUpdateApplication_VersionGate is the regression guard for the Create-time
+// 422 on Coolify 4.1.x. Those releases have no APPLICATION_SETTING_FIELDS
+// constant, so every settings field falls outside the endpoint's allow list and
+// is rejected — and one rejected field aborts the whole request, which fails
+// Create and leaves the resource tainted.
+func TestUpdateApplication_VersionGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		version      string
+		wantSettings bool
+	}{
+		{"4.1.2 withholds settings", "4.1.2", false},
+		{"4.1.0 withholds settings", "4.1.0", false},
+		{"4.2.0 sends settings", "4.2.0", true},
+		{"4.3.0 sends settings", "4.3.0", true},
+		{"v-prefixed 4.2.0 sends settings", "v4.2.0", true},
+		{"unknown version assumes newest", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body map[string]json.RawMessage
+			srv := capturingServer(t, &body)
+			defer srv.Close()
+
+			c := New(srv.URL, "token")
+			c.CoolifyVersion = tt.version
+
+			if _, err := c.UpdateApplication(context.Background(), "app-1", fullSettingsInput()); err != nil {
+				t.Fatalf("UpdateApplication: %v", err)
+			}
+
+			if _, ok := body["name"]; !ok {
+				t.Error("the gate dropped a non-settings field; only settings may be withheld")
+			}
+			for _, key := range settingFieldKeys {
+				_, sent := body[key]
+				if sent != tt.wantSettings {
+					t.Errorf("Coolify %q: %s sent=%v, want %v", tt.version, key, sent, tt.wantSettings)
+				}
+			}
+		})
+	}
+}
+
+func TestSupportsApplicationSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"4.1.0", false},
+		{"4.1.2", false},
+		{"4.2.0", true},
+		{"4.2.1", true},
+		{"5.0.0", true},
+		{"", true},              // unknown: assume newest
+		{"not-a-version", true}, // unparseable: assume newest, matching IsVersionAtLeast
+	}
+	for _, tt := range tests {
+		c := &Client{CoolifyVersion: tt.version}
+		if got := c.SupportsApplicationSettings(); got != tt.want {
+			t.Errorf("SupportsApplicationSettings(%q) = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+	var nilClient *Client
+	if !nilClient.SupportsApplicationSettings() {
+		t.Error("nil client should assume newest behaviour rather than panic")
+	}
+}
+
+func TestHasOnlyApplicationSettings(t *testing.T) {
+	t.Parallel()
+
+	b := true
+	name := "x"
+
+	if (UpdateApplicationInput{}).HasOnlyApplicationSettings() {
+		t.Error("an empty input has nothing to strip; want false")
+	}
+	if !(UpdateApplicationInput{IsGzipEnabled: &b}).HasOnlyApplicationSettings() {
+		t.Error("settings-only input should report true so callers can skip the request")
+	}
+	if (UpdateApplicationInput{Name: &name, IsGzipEnabled: &b}).HasOnlyApplicationSettings() {
+		t.Error("input with a non-settings field still has work to do; want false")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -171,6 +170,9 @@ func (p *coolifyProvider) Configure(ctx context.Context, req provider.ConfigureR
 		)
 		return
 	}
+	// Remembered so write paths can gate fields the connected version rejects
+	// (see client.SupportsApplicationSettings).
+	c.CoolifyVersion = coolifyVersion
 
 	tflog.Debug(ctx, "provider configured", map[string]interface{}{
 		"endpoint": redactEndpointForDiagnostics(endpoint),
@@ -333,35 +335,5 @@ func buildClientConfig(config coolifyProviderModel) client.RetryConfig {
 // Returns true if actual >= minimum. Non-parseable versions return true
 // to avoid blocking on unexpected version formats.
 func isVersionAtLeast(actual, minimum string) bool {
-	parse := func(v string) (int, int, int, bool) {
-		v = strings.TrimPrefix(v, "v")
-		parts := strings.SplitN(v, ".", 3)
-		if len(parts) < 2 {
-			return 0, 0, 0, false
-		}
-		major, err1 := strconv.Atoi(parts[0])
-		minor, err2 := strconv.Atoi(parts[1])
-		patch := 0
-		if len(parts) == 3 {
-			// Strip pre-release suffix (e.g. "0-beta.335")
-			p := strings.SplitN(parts[2], "-", 2)[0]
-			patch, _ = strconv.Atoi(p)
-		}
-		if err1 != nil || err2 != nil {
-			return 0, 0, 0, false
-		}
-		return major, minor, patch, true
-	}
-	aMaj, aMin, aPat, aOk := parse(actual)
-	mMaj, mMin, mPat, mOk := parse(minimum)
-	if !aOk || !mOk {
-		return true
-	}
-	if aMaj != mMaj {
-		return aMaj > mMaj
-	}
-	if aMin != mMin {
-		return aMin > mMin
-	}
-	return aPat >= mPat
+	return client.IsVersionAtLeast(actual, minimum)
 }

--- a/internal/service/application/common_flatten.go
+++ b/internal/service/application/common_flatten.go
@@ -571,8 +571,16 @@ func postCreatePatchExtendedFields(ctx context.Context, c *client.Client, uuid s
 	if !hasNonDefaultAppExtendedFields(f) {
 		return
 	}
-	tflog.Debug(ctx, "patching extended fields after create", map[string]interface{}{"uuid": uuid})
 	input := buildPostCreatePatch(f)
+	// On Coolify < 4.2.0 the client strips the ApplicationSetting fields, so a
+	// plan whose only extended fields are settings would PATCH an empty body.
+	// Skip it rather than spend a request that can change nothing.
+	if !c.SupportsApplicationSettings() && input.HasOnlyApplicationSettings() {
+		tflog.Debug(ctx, "skipping post-create patch: only ApplicationSetting fields, unsupported on this Coolify version",
+			map[string]interface{}{"uuid": uuid})
+		return
+	}
+	tflog.Debug(ctx, "patching extended fields after create", map[string]interface{}{"uuid": uuid})
 	if _, err := c.UpdateApplication(ctx, uuid, input); err != nil {
 		hint := annotateDockerComposeDomainsError(err)
 		converge := ""

--- a/internal/service/application/common_schema.go
+++ b/internal/service/application/common_schema.go
@@ -527,77 +527,89 @@ func securityNetworkAttrs() map[string]schema.Attribute {
 func applicationSettingAttrs() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"is_git_submodules_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether Git submodules are fetched during clone. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether Git submodules are fetched during clone. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_git_lfs_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether Git LFS objects are fetched during clone. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether Git LFS objects are fetched during clone. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_git_shallow_clone_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether Git uses a shallow clone. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether Git uses a shallow clone. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"disable_build_cache": schema.BoolAttribute{
-			MarkdownDescription: "Whether to disable the Docker build cache for this application. Coolify default is `false`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether to disable the Docker build cache for this application. Coolify default is `false`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"inject_build_args_to_dockerfile": schema.BoolAttribute{
-			MarkdownDescription: "Whether to inject build arguments into the Dockerfile. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether to inject build arguments into the Dockerfile. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"include_source_commit_in_build": schema.BoolAttribute{
-			MarkdownDescription: "Whether to include the source commit SHA in the build. Coolify default is `false`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether to include the source commit SHA in the build. Coolify default is `false`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_env_sorting_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether environment variables are sorted. Coolify default is `false`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether environment variables are sorted. Coolify default is `false`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_pr_deployments_public_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether preview deployments from public pull requests are enabled. Coolify default is `false`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether preview deployments from public pull requests are enabled. Coolify default is `false`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"docker_images_to_keep": schema.Int64Attribute{
-			MarkdownDescription: "Number of Docker images to keep for this application. Coolify default is `2`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             int64default.StaticInt64(2),
-			Validators:          []validator.Int64{int64validator.AtLeast(0)},
+			MarkdownDescription: "Number of Docker images to keep for this application. Coolify default is `2`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			Validators:    []validator.Int64{int64validator.AtLeast(0)},
+			PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 		},
 		"is_gzip_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether gzip compression is enabled for the application proxy. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether gzip compression is enabled for the application proxy. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_stripprefix_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(true),
+			MarkdownDescription: "Whether path prefix stripping is enabled for the application proxy. Coolify default is `true`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 		"is_raw_compose_deployment_enabled": schema.BoolAttribute{
-			MarkdownDescription: "Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`.",
-			Optional:            true,
-			Computed:            true,
-			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether raw Docker Compose deployment mode is enabled. Coolify default is `false`. " +
+				"Writing this requires Coolify >= v4.2.0, where it is on the application endpoints' allow list; against older instances the provider omits it rather than fail the whole request with 422.",
+			Optional:      true,
+			Computed:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 		},
 	}
 }

--- a/internal/service/application/contract_write_test.go
+++ b/internal/service/application/contract_write_test.go
@@ -1,0 +1,239 @@
+package application
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// The contract tests in internal/spectest check one direction only: that every
+// field Coolify declares is covered by the client structs. Nothing checked the
+// reverse — that the provider never *sends* a field Coolify refuses.
+//
+// PATCH /applications/{uuid} validates with
+// `array_diff(array_keys($request->all()), $allowedFields)` and returns 422
+// "This field is not allowed." for every extra key. One rejected key fails the
+// whole request, so a single stray field breaks Create for the whole resource.
+//
+// The tests below close that direction for the two request builders. They check
+// against the allow list of the NEWEST supported Coolify: withholding fields on
+// older instances is the version gate's job, covered by
+// TestUpdateApplication_VersionGate in internal/client.
+
+// applicationSettingFields is Coolify's APPLICATION_SETTING_FIELDS constant.
+//
+// It is spelled out here rather than read from the contract because the
+// extractor collects only string literals from `$allowedFields = [...]` and
+// does not expand the trailing `...self::APPLICATION_SETTING_FIELDS` spread, so
+// the generated contracts understate the allow list by exactly these entries.
+// Tracked as #661; once the extractor expands spreads, drop this list and let
+// updateAllowedFields carry them.
+var applicationSettingFields = []string{
+	"is_git_submodules_enabled",
+	"is_git_lfs_enabled",
+	"is_git_shallow_clone_enabled",
+	"disable_build_cache",
+	"inject_build_args_to_dockerfile",
+	"include_source_commit_in_build",
+	"is_env_sorting_enabled",
+	"is_pr_deployments_public_enabled",
+	"stop_grace_period",
+	"docker_images_to_keep",
+	"is_gzip_enabled",
+	"is_stripprefix_enabled",
+	"is_raw_compose_deployment_enabled",
+}
+
+func readContractAllowList(t *testing.T) map[string]bool {
+	t.Helper()
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	dir := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "testdata", "contracts")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading contracts dir: %v", err)
+	}
+	var latest string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			latest = e.Name()
+		}
+	}
+	if latest == "" {
+		t.Fatal("no contract JSON found in testdata/contracts/")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, latest))
+	if err != nil {
+		t.Fatalf("reading contract: %v", err)
+	}
+	var contract struct {
+		Endpoints map[string]struct {
+			AllowedFields []string `json:"allowed_fields"`
+		} `json:"endpoints"`
+	}
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("parsing contract: %v", err)
+	}
+	ep, ok := contract.Endpoints["ApplicationsController::update_by_uuid"]
+	if !ok {
+		t.Fatal("ApplicationsController::update_by_uuid not found in contract")
+	}
+	if len(ep.AllowedFields) == 0 {
+		t.Fatal("update_by_uuid has an empty allow list")
+	}
+	allowed := make(map[string]bool, len(ep.AllowedFields))
+	for _, f := range ep.AllowedFields {
+		allowed[f] = true
+	}
+	return allowed
+}
+
+// updateAllowedFields returns the allow list Coolify >= 4.2.0 applies to
+// PATCH /applications/{uuid}: the literals from the pinned contract, plus the
+// settings spread the extractor misses (see #661).
+func updateAllowedFields(t *testing.T) map[string]bool {
+	t.Helper()
+
+	allowed := readContractAllowList(t)
+	for _, f := range applicationSettingFields {
+		allowed[f] = true
+	}
+	return allowed
+}
+
+// fillCommonAppFields populates every pointer field of commonAppFields, so the
+// builders emit as many keys as they can. Using reflection rather than a
+// literal keeps this test honest as fields are added: a new attribute wired
+// into a builder is covered here the day it lands.
+func fillCommonAppFields(t *testing.T, str string, num int64, b bool) commonAppFields {
+	t.Helper()
+
+	var f commonAppFields
+	v := reflect.ValueOf(&f).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Kind() != reflect.Pointer || !field.CanSet() {
+			continue
+		}
+		switch field.Type() {
+		case reflect.TypeOf((*types.String)(nil)):
+			val := types.StringValue(str)
+			field.Set(reflect.ValueOf(&val))
+		case reflect.TypeOf((*types.Int64)(nil)):
+			val := types.Int64Value(num)
+			field.Set(reflect.ValueOf(&val))
+		case reflect.TypeOf((*types.Bool)(nil)):
+			val := types.BoolValue(b)
+			field.Set(reflect.ValueOf(&val))
+		}
+	}
+	// docker_compose_domains is carried to the wire as a JSON array, so the
+	// generic probe string above would not survive marshalling (#658).
+	domains := types.StringValue(`[{"name":"web","domain":"http://` + str + `.example.com"}]`)
+	f.DockerComposeDomains = &domains
+	return f
+}
+
+// disallowedKeys marshals an input and returns the keys Coolify would reject.
+func disallowedKeys(t *testing.T, input any, allowed map[string]bool) []string {
+	t.Helper()
+
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshalling input: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshalling input: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("input marshalled to an empty body; the builder emitted nothing")
+	}
+	var bad []string
+	for key := range body {
+		if !allowed[key] {
+			bad = append(bad, key)
+		}
+	}
+	sort.Strings(bad)
+	return bad
+}
+
+func TestPostCreatePatch_OnlySendsAllowedFields(t *testing.T) {
+	t.Parallel()
+
+	allowed := updateAllowedFields(t)
+	f := fillCommonAppFields(t, "contract-probe", 7, true)
+
+	if bad := disallowedKeys(t, buildPostCreatePatch(f), allowed); len(bad) > 0 {
+		t.Errorf("post-create PATCH sends %d field(s) outside the update_by_uuid allow list; "+
+			"Coolify answers 422 \"This field is not allowed.\" and aborts the whole request:\n  %s",
+			len(bad), strings.Join(bad, "\n  "))
+	}
+}
+
+func TestUpdateInput_OnlySendsAllowedFields(t *testing.T) {
+	t.Parallel()
+
+	allowed := updateAllowedFields(t)
+	// Differing plan and state so every diff-guarded field is emitted.
+	plan := fillCommonAppFields(t, "contract-probe-plan", 7, true)
+	state := fillCommonAppFields(t, "contract-probe-state", 9, false)
+
+	bad := disallowedKeys(t, buildUpdateInput(plan, state), allowed)
+
+	// Known gaps, tracked separately: these are not ApplicationSetting fields
+	// and removing them would drop practitioner-visible behaviour, so they need
+	// their own decision rather than being silently dropped here.
+	knownGaps := map[string]string{
+		"dockerfile":           "create-only field; editing a Dockerfile in place has no allowed update route",
+		"docker_compose_raw":   "create-only field, and only for the deprecated inline-compose endpoint",
+		"github_app_uuid":      "create-only field; re-pointing an app at another GitHub App has no update route",
+		"preview_url_template": "absent from both allow lists; no write route at all",
+	}
+	var unexpected []string
+	for _, key := range bad {
+		if _, known := knownGaps[key]; !known {
+			unexpected = append(unexpected, key)
+		}
+	}
+	if len(unexpected) > 0 {
+		t.Errorf("update PATCH sends %d unexpected field(s) outside the update_by_uuid allow list:\n  %s",
+			len(unexpected), strings.Join(unexpected, "\n  "))
+	}
+
+	// Guard the gap list itself: once a field gains a write route, drop it here.
+	for key, why := range knownGaps {
+		if allowed[key] {
+			t.Errorf("%q is on the allow list now (%s); remove it from knownGaps", key, why)
+		}
+	}
+}
+
+// TestApplicationSettingFields_AbsentFromExtractedContract pins the #661 bug in
+// place. The moment the extractor learns to expand PHP spreads, this fails, and
+// whoever fixes it can delete applicationSettingFields above and read the whole
+// allow list from the contract instead.
+func TestApplicationSettingFields_AbsentFromExtractedContract(t *testing.T) {
+	t.Parallel()
+
+	literals := readContractAllowList(t)
+	var present []string
+	for _, f := range applicationSettingFields {
+		if literals[f] {
+			present = append(present, f)
+		}
+	}
+	if len(present) > 0 {
+		t.Errorf("the extractor now resolves the APPLICATION_SETTING_FIELDS spread (#661 fixed for %d field(s): %s).\n"+
+			"Delete applicationSettingFields in this file and read the allow list from the contract alone.",
+			len(present), strings.Join(present, ", "))
+	}
+}

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -2445,3 +2445,120 @@ func TestApplicationResource_ImportCompoundEmptyEnv(t *testing.T) {
 		},
 	})
 }
+
+// TestApplicationResource_SettingsWithheldOnOldCoolify is the end-to-end guard
+// for the Create failure this gate exists to prevent (#660).
+//
+// On Coolify 4.1.x there is no APPLICATION_SETTING_FIELDS constant, so every
+// settings field falls outside the endpoint's allow list. The server below
+// answers exactly as Coolify does — 422 for any settings key — so if the
+// provider ever sends them again on an old instance, Create fails here rather
+// than in a practitioner's apply.
+//
+// The plan below covers both halves of the fix at once:
+//
+//   - `is_preserve_repository_enabled` is what arms the post-create PATCH, and
+//     used to drag the whole default settings blob in with it. Dropping the
+//     schema defaults keeps unset settings out of the payload.
+//   - `is_gzip_enabled` is set explicitly, so only the version gate can keep it
+//     out. Without the gate this test fails on the 422 below.
+func TestApplicationResource_SettingsWithheldOnOldCoolify(t *testing.T) {
+	t.Parallel()
+
+	settingKeys := []string{
+		"is_git_submodules_enabled", "is_git_lfs_enabled", "is_git_shallow_clone_enabled",
+		"disable_build_cache", "inject_build_args_to_dockerfile", "include_source_commit_in_build",
+		"is_env_sorting_enabled", "is_pr_deployments_public_enabled", "stop_grace_period",
+		"docker_images_to_keep", "is_gzip_enabled", "is_stripprefix_enabled",
+		"is_raw_compose_deployment_enabled",
+	}
+
+	trueVal := true
+	currentApp := client.Application{
+		UUID:                        "app-old-coolify",
+		Name:                        "old-coolify-app",
+		GitRepository:               "https://github.com/org/repo",
+		GitBranch:                   "main",
+		BuildPack:                   "dockercompose",
+		PortsExposes:                "3000",
+		BaseDirectory:               "/compose",
+		IsPreserveRepositoryEnabled: &trueVal,
+	}
+	mu := sync.Mutex{}
+	deleted := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/public", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": currentApp.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if deleted {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(currentApp)
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := decodeRequestBodyMap(t, w, r)
+		if !ok {
+			return
+		}
+		// Reproduce Coolify 4.1.x: reject anything off the allow list.
+		for _, key := range settingKeys {
+			if _, present := body[key]; present {
+				t.Errorf("PATCH carried %q, which Coolify 4.1.x rejects with 422", key)
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"message": "Validation failed.",
+					"errors":  map[string]string{key: "This field is not allowed."},
+				})
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": currentApp.UUID})
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		deleted = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.1.2"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testApplicationResourceConfig(srv.URL, `
+					project_uuid     = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+					server_uuid      = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+					environment_name = "production"
+					git_repository   = "https://github.com/org/repo"
+					git_branch       = "main"
+					build_pack       = "dockercompose"
+					ports_exposes    = "3000"
+					name             = "old-coolify-app"
+					base_directory   = "/compose"
+
+					is_preserve_repository_enabled = true
+					is_gzip_enabled                = false
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application.test", "is_preserve_repository_enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_application.test", "base_directory", "/compose"),
+					// Withheld from the wire, but still the practitioner's value
+					// in state: the gate must not rewrite what they asked for.
+					resource.TestCheckResourceAttr("coolify_application.test", "is_gzip_enabled", "false"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #660
Ref #655

Reworked from the earlier "stop sending settings" revision, which was too broad: on v4.2.0 these fields are accepted and applied, and dropping them everywhere would have regressed that. Thanks for catching it.

## The bug

Coolify builds the allow list for its application endpoints as a literal list ending in `...self::APPLICATION_SETTING_FIELDS`. That constant does not exist before **v4.2.0**, so on **v4.1.0–v4.1.2** — still inside `minCoolifyVersion` — every settings field falls outside the allow list:

```
422 Validation failed. is_gzip_enabled: This field is not allowed. disable_build_cache: This field is not allowed.
  ...
```

One rejected field aborts the whole request. So any plan setting a single extended field — `is_preserve_repository_enabled` on a `dockercompose` application, say — failed at Create and left the resource **tainted**: every later apply destroyed and recreated it, hit the same 422, and never converged.

Reproduced against Coolify **v4.1.2**.

## The fix

**Gate on the connected version, in one place.** `client.UpdateApplication` is the single path every application PATCH takes, so the gate lives there rather than in each builder — a field that cannot be written should not depend on which caller assembled the request. The version comes from `Configure`, which already fetches it to enforce `minCoolifyVersion`. An unknown version assumes the newest behaviour, so paths that never call `Configure` keep exercising the full payload.

**Stop sending settings nobody asked for.** These attributes carried schema
`Default`s, so the plan filled them in and the post-create PATCH shipped the whole blob on any application touching any extended field. They now use `UseStateForUnknown`, following the pattern #628 set for `is_preview_deployments_enabled` and `use_build_secrets`. Unset settings stay out of the request entirely — which alone fixes the common case, gate or no gate.

**Schema documents the floor**: `Requires Coolify >= v4.2.0` on all thirteen, with `make docs` regenerated.

## Tests

Both halves are locked, and both fail without their fix:

- `TestUpdateApplication_VersionGate` walks the version boundary at the client (4.1.0/4.1.2 withhold, 4.2.0/4.3.0/`v4.2.0` send, unknown sends), and asserts non-settings fields are never touched.
- `TestApplicationResource_SettingsWithheldOnOldCoolify` drives a real resource against a mock that answers 422 exactly as 4.1.x does. It sets `is_gzip_enabled` explicitly, so only the gate can keep it out — reverting the gate fails it on the 422. It also checks the practitioner's value survives in state: withheld from the wire is not the same as rewritten.
- The write-path allow-list guard from the previous revision now checks against the **expanded** 4.2.0 list.

On that last point: the expanded list is spelled out in the test rather than read from the contract, because the extractor does not resolve PHP spreads (#661). `TestApplicationSettingFields_AbsentFromExtractedContract` fails the day it learns to, telling whoever takes #661 to delete the hand-written list — so the workaround cannot quietly outlive the bug it works around.

Mock servers now report 4.2.0 by default, with `WithVersionEndpointVersion` for tests that want an older instance on purpose. Without that, every unit test would have silently run on the withholding path.

## Verification

`gofmt -s` clean, `golangci-lint run ./internal/...` reports 0 issues, and `-race` tests pass on `internal/service/application`, `internal/client`, `internal/provider`, `internal/spectest`, `internal/acctest`. `make docs` regenerated. I could not run the full `./...` suite locally (disk space), so CI is the backstop there.

## Still open, deliberately

Whether these attributes should be presented as `Optional` at all on instances that cannot write them. Since `flatten` keeps the planned value when the API omits the field, setting `is_gzip_enabled = false` on 4.1.x now stays in state and raises no error, while Coolify never hears about it — quiet, and arguably still a lie, just a much smaller one than a tainted resource. A plan-time warning would be the honest next step, but it is a UX call I would rather leave to you
than smuggle into a bug fix.

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally
- [x] `make fmt` ran (gofmt + go mod tidy)
- [x] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources) — no new resource
- [ ] CHANGELOG.md updated — generated by release-please from the commit title
- [x] No breaking changes to existing resources
