### PR TITLE
fix(contract): expand PHP ...self::CONST spreads in allow-list extract

### DIFF
--- a/internal/service/application/contract_write_test.go
+++ b/internal/service/application/contract_write_test.go
@@ -23,53 +23,29 @@ import (
 // whole request, so a single stray field breaks Create for the whole resource.
 //
 // The tests below close that direction for the two request builders. They check
-// against the allow list of the NEWEST supported Coolify: withholding fields on
-// older instances is the version gate's job, covered by
-// TestUpdateApplication_VersionGate in internal/client.
-
-// applicationSettingFields is Coolify's APPLICATION_SETTING_FIELDS constant.
-//
-// It is spelled out here rather than read from the contract because the
-// extractor collects only string literals from `$allowedFields = [...]` and
-// does not expand the trailing `...self::APPLICATION_SETTING_FIELDS` spread, so
-// the generated contracts understate the allow list by exactly these entries.
-// Tracked as #661; once the extractor expands spreads, drop this list and let
-// updateAllowedFields carry them.
-var applicationSettingFields = []string{
-	"is_git_submodules_enabled",
-	"is_git_lfs_enabled",
-	"is_git_shallow_clone_enabled",
-	"disable_build_cache",
-	"inject_build_args_to_dockerfile",
-	"include_source_commit_in_build",
-	"is_env_sorting_enabled",
-	"is_pr_deployments_public_enabled",
-	"stop_grace_period",
-	"docker_images_to_keep",
-	"is_gzip_enabled",
-	"is_stripprefix_enabled",
-	"is_raw_compose_deployment_enabled",
-}
+// against the allow list of the NEWEST supported Coolify (pin / v4.2.0), which
+// includes expanded ...self::APPLICATION_SETTING_FIELDS spreads (#661).
+// Withholding settings on older instances is the version gate's job
+// (TestUpdateApplication_VersionGate).
 
 func readContractAllowList(t *testing.T) map[string]bool {
 	t.Helper()
 
+	// Prefer the pin (coolify-v4.json); fall back to newest versioned file.
 	_, thisFile, _, _ := runtime.Caller(0)
 	dir := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "testdata", "contracts")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("reading contracts dir: %v", err)
+	candidates := []string{
+		filepath.Join(dir, "coolify-v4.json"),
+		filepath.Join(dir, "coolify-v4.2.0.json"),
 	}
-	var latest string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
-			latest = e.Name()
+	var data []byte
+	var err error
+	for _, path := range candidates {
+		data, err = os.ReadFile(path)
+		if err == nil {
+			break
 		}
 	}
-	if latest == "" {
-		t.Fatal("no contract JSON found in testdata/contracts/")
-	}
-	data, err := os.ReadFile(filepath.Join(dir, latest))
 	if err != nil {
 		t.Fatalf("reading contract: %v", err)
 	}
@@ -95,17 +71,37 @@ func readContractAllowList(t *testing.T) map[string]bool {
 	return allowed
 }
 
-// updateAllowedFields returns the allow list Coolify >= 4.2.0 applies to
-// PATCH /applications/{uuid}: the literals from the pinned contract, plus the
-// settings spread the extractor misses (see #661).
-func updateAllowedFields(t *testing.T) map[string]bool {
-	t.Helper()
+// TestContractAllowList_IncludesApplicationSettingFields locks #661: the
+// extractor expands ...self::APPLICATION_SETTING_FIELDS so the pin lists them.
+func TestContractAllowList_IncludesApplicationSettingFields(t *testing.T) {
+	t.Parallel()
 
 	allowed := readContractAllowList(t)
-	for _, f := range applicationSettingFields {
-		allowed[f] = true
+	required := []string{
+		"is_git_submodules_enabled",
+		"is_git_lfs_enabled",
+		"is_git_shallow_clone_enabled",
+		"disable_build_cache",
+		"inject_build_args_to_dockerfile",
+		"include_source_commit_in_build",
+		"is_env_sorting_enabled",
+		"is_pr_deployments_public_enabled",
+		"stop_grace_period",
+		"docker_images_to_keep",
+		"is_gzip_enabled",
+		"is_stripprefix_enabled",
+		"is_raw_compose_deployment_enabled",
 	}
-	return allowed
+	var missing []string
+	for _, f := range required {
+		if !allowed[f] {
+			missing = append(missing, f)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("contract update_by_uuid missing APPLICATION_SETTING_FIELDS after #661: %s",
+			strings.Join(missing, ", "))
+	}
 }
 
 // fillCommonAppFields populates every pointer field of commonAppFields, so the
@@ -169,7 +165,7 @@ func disallowedKeys(t *testing.T, input any, allowed map[string]bool) []string {
 func TestPostCreatePatch_OnlySendsAllowedFields(t *testing.T) {
 	t.Parallel()
 
-	allowed := updateAllowedFields(t)
+	allowed := readContractAllowList(t)
 	f := fillCommonAppFields(t, "contract-probe", 7, true)
 
 	if bad := disallowedKeys(t, buildPostCreatePatch(f), allowed); len(bad) > 0 {
@@ -182,7 +178,7 @@ func TestPostCreatePatch_OnlySendsAllowedFields(t *testing.T) {
 func TestUpdateInput_OnlySendsAllowedFields(t *testing.T) {
 	t.Parallel()
 
-	allowed := updateAllowedFields(t)
+	allowed := readContractAllowList(t)
 	// Differing plan and state so every diff-guarded field is emitted.
 	plan := fillCommonAppFields(t, "contract-probe-plan", 7, true)
 	state := fillCommonAppFields(t, "contract-probe-state", 9, false)
@@ -214,26 +210,5 @@ func TestUpdateInput_OnlySendsAllowedFields(t *testing.T) {
 		if allowed[key] {
 			t.Errorf("%q is on the allow list now (%s); remove it from knownGaps", key, why)
 		}
-	}
-}
-
-// TestApplicationSettingFields_AbsentFromExtractedContract pins the #661 bug in
-// place. The moment the extractor learns to expand PHP spreads, this fails, and
-// whoever fixes it can delete applicationSettingFields above and read the whole
-// allow list from the contract instead.
-func TestApplicationSettingFields_AbsentFromExtractedContract(t *testing.T) {
-	t.Parallel()
-
-	literals := readContractAllowList(t)
-	var present []string
-	for _, f := range applicationSettingFields {
-		if literals[f] {
-			present = append(present, f)
-		}
-	}
-	if len(present) > 0 {
-		t.Errorf("the extractor now resolves the APPLICATION_SETTING_FIELDS spread (#661 fixed for %d field(s): %s).\n"+
-			"Delete applicationSettingFields in this file and read the allow list from the contract alone.",
-			len(present), strings.Join(present, ", "))
 	}
 }

--- a/internal/spectest/contract_skips.go
+++ b/internal/spectest/contract_skips.go
@@ -34,38 +34,31 @@ var applicationFieldSkips = skipMap(
 	// Swarm-only fields (not commonly used)
 	skipNA("swarm_replicas", "swarm-only; not in provider surface"),
 	skipNA("swarm_placement_constraints", "swarm-only; not in provider surface"),
-	// Internal-only ApplicationSetting fields not exposed by update API
+	// Internal-only ApplicationSetting fields not on ApplicationsController
+	// APPLICATION_SETTING_FIELDS / update allow list (UI-only or other surfaces).
+	// Note: disable_build_cache, is_gzip_enabled, is_git_*, stop_grace_period, etc.
+	// ARE on the public allow list via ...self::APPLICATION_SETTING_FIELDS from
+	// Coolify v4.2.0 (extractor expands spreads, #661); they must not be skipInternal.
 	skipInternal("application_id", "settings FK"),
 	skipInternal("custom_internal_name", "settings internal"),
-	skipInternal("disable_build_cache", "settings not on update allow list"),
-	skipInternal("docker_images_to_keep", "settings not on update allow list"),
-	skipInternal("gpu_count", "settings not on update allow list"),
-	skipInternal("gpu_device_ids", "settings not on update allow list"),
-	skipInternal("gpu_driver", "settings not on update allow list"),
-	skipInternal("gpu_options", "settings not on update allow list"),
-	skipInternal("include_source_commit_in_build", "settings not on update allow list"),
-	skipInternal("inject_build_args_to_dockerfile", "settings not on update allow list"),
-	skipInternal("is_consistent_container_name_enabled", "settings not on update allow list"),
-	skipInternal("is_container_label_readonly_enabled", "settings not on update allow list"),
-	skipInternal("is_custom_ssl", "settings not on update allow list"),
-	skipInternal("is_debug_enabled", "settings not on update allow list"),
-	skipInternal("is_dual_cert", "settings not on update allow list"),
-	skipInternal("is_env_sorting_enabled", "settings not on update allow list"),
-	skipInternal("is_git_lfs_enabled", "settings not on update allow list"),
-	skipInternal("is_git_shallow_clone_enabled", "settings not on update allow list"),
-	skipInternal("is_git_submodules_enabled", "settings not on update allow list"),
-	skipInternal("is_gpu_enabled", "settings not on update allow list"),
-	skipInternal("is_gzip_enabled", "settings not on update allow list"),
-	skipInternal("is_http2", "settings not on update allow list"),
-	skipInternal("is_include_timestamps", "settings not on update allow list"),
-	skipInternal("is_log_drain_enabled", "settings not on update allow list"),
-	skipInternal("is_pr_deployments_public_enabled", "settings not on update allow list"),
-	skipInternal("is_raw_compose_deployment_enabled", "settings not on update allow list"),
-	skipInternal("is_stripprefix_enabled", "settings not on update allow list"),
-	skipInternal("is_swarm_only_worker_nodes", "settings not on update allow list"),
+	skipInternal("gpu_count", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("gpu_device_ids", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("gpu_driver", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("gpu_options", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_consistent_container_name_enabled", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_container_label_readonly_enabled", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_custom_ssl", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_debug_enabled", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_dual_cert", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_gpu_enabled", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_http2", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_include_timestamps", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_log_drain_enabled", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
+	skipInternal("is_swarm_only_worker_nodes", "settings UI-only; not in APPLICATION_SETTING_FIELDS"),
 	// is_build_server_enabled is the setting name; the API field is use_build_server
 	skipNA("is_build_server_enabled", "API field is use_build_server on Application"),
-	// is_preview_deployments_enabled, use_build_secrets, stop_grace_period covered on client (#628)
+	// is_preview_deployments_enabled, use_build_secrets, stop_grace_period and
+	// APPLICATION_SETTING_FIELDS are public allow-list fields covered on client (#628, #661)
 )
 
 var serverCoverageSkips = skipMap(

--- a/scripts/check-contract-compat.py
+++ b/scripts/check-contract-compat.py
@@ -38,16 +38,44 @@ KNOWN_VERSION_DEPENDENT: dict[str, set[str]] = {
         "health_check_retries",
         "health_check_start_period",
     },
-    # Coolify v4.2.0 additions not yet modeled as Terraform attributes
-    # (tags are a separate resource surface; preview/build secrets need design).
+    # Coolify v4.2.0 additions. Settings fields land via
+    # ...self::APPLICATION_SETTING_FIELDS (extractor expands spreads, #661).
+    # Provider version-gates writes for Coolify < 4.2.0 (#660 / #662).
     "ApplicationsController::create_application": {
         "is_preview_deployments_enabled",
         "tags",
         "use_build_secrets",
+        # APPLICATION_SETTING_FIELDS (public from v4.2.0)
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled",
     },
     "ApplicationsController::update_by_uuid": {
         "is_preview_deployments_enabled",
         "use_build_secrets",
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled",
     },
     "DatabasesController::create_database": {
         "tags",

--- a/scripts/extract-contract.py
+++ b/scripts/extract-contract.py
@@ -334,19 +334,71 @@ def _clean_rule(rule: str) -> str:
     return "|".join(parts) if parts else rule.strip()
 
 
+def extract_php_string_list_constants(content: str) -> dict[str, list[str]]:
+    """Extract class const string-array definitions from a PHP file.
+
+    Matches ``private/public/protected const NAME = ['a', 'b', ...];``.
+    Used to expand ``...self::NAME`` / ``...static::NAME`` spreads in allow
+    lists (e.g. ApplicationsController::APPLICATION_SETTING_FIELDS).
+    """
+    result: dict[str, list[str]] = {}
+    pattern = re.compile(
+        r"(?:private|public|protected)\s+const\s+([A-Z][A-Z0-9_]*)\s*=\s*\[(.*?)\];",
+        re.DOTALL,
+    )
+    for match in pattern.finditer(content):
+        name = match.group(1)
+        fields = re.findall(r"'([^']+)'", match.group(2))
+        if fields:
+            result[name] = fields
+    return result
+
+
+def expand_allowed_field_list(
+    array_body: str, constants: dict[str, list[str]]
+) -> list[str]:
+    """Expand string literals and PHP spreads inside an allow-list array body.
+
+    Supports ``...self::CONST`` and ``...static::CONST``. Unknown constants are
+    skipped (no phantom fields). Order is literals then spread members, with
+    duplicates removed while preserving first-seen order.
+    """
+    fields: list[str] = []
+    seen: set[str] = set()
+
+    def add(name: str) -> None:
+        if name not in seen:
+            seen.add(name)
+            fields.append(name)
+
+    for lit in re.findall(r"'([^']+)'", array_body):
+        add(lit)
+    for match in re.finditer(
+        r"\.\.\.(?:self|static)::([A-Z][A-Z0-9_]*)", array_body
+    ):
+        const_name = match.group(1)
+        for name in constants.get(const_name, []):
+            add(name)
+    return fields
+
+
 def extract_allowed_fields(content: str) -> dict[str, list[str]]:
     """Extract $allowedFields / $allowed arrays from controller methods.
 
     Coolify mostly uses ``$allowedFields = [...]``. DestinationsController
     (v4.2) uses the shorter ``$allowed = [...]`` for the same purpose.
+
+    PHP spreads such as ``...self::APPLICATION_SETTING_FIELDS`` are expanded
+    from class constants in the same file (#661).
     """
-    result = {}
+    constants = extract_php_string_list_constants(content)
+    result: dict[str, list[str]] = {}
     pattern = re.compile(
         r"\$(?:allowedFields|allowed)\s*=\s*\[(.*?)\];", re.DOTALL
     )
     # Find the enclosing method for context
     for match in pattern.finditer(content):
-        fields = re.findall(r"'([^']+)'", match.group(1))
+        fields = expand_allowed_field_list(match.group(1), constants)
         # Try to find the method name above this position
         preceding = content[:match.start()]
         method_matches = re.findall(r"function\s+(\w+)\s*\(", preceding)
@@ -360,12 +412,15 @@ def extract_allowed_fields(content: str) -> dict[str, list[str]]:
         re.DOTALL,
     )
     for match in merge_pattern.finditer(content):
-        extra = re.findall(r"'([^']+)'", match.group(1))
+        extra = expand_allowed_field_list(match.group(1), constants)
         preceding = content[:match.start()]
         method_matches = re.findall(r"function\s+(\w+)\s*\(", preceding)
         method = method_matches[-1] if method_matches else "unknown"
         if method in result:
-            result[method].extend(extra)
+            existing = result[method]
+            for f in extra:
+                if f not in existing:
+                    existing.append(f)
         else:
             result[method] = extra
 

--- a/scripts/test_extract_contract.py
+++ b/scripts/test_extract_contract.py
@@ -553,6 +553,118 @@ class VolumeBackupsController {
         self.assertEqual(result["validateUpsertRequest"], ["frequency", "enabled", "timeout"])
         self.assertEqual(result["upsert"], ["frequency", "enabled", "timeout"])
 
+    def test_self_const_spread_expanded(self):
+        # ApplicationsController (v4.2+) ends $allowedFields with
+        # ...self::APPLICATION_SETTING_FIELDS. Without expansion the contract
+        # understates the public write surface (#661).
+        php = """<?php
+class ApplicationsController {
+    private const APPLICATION_SETTING_FIELDS = [
+        'is_git_submodules_enabled',
+        'is_gzip_enabled',
+        'stop_grace_period',
+    ];
+
+    public function update_by_uuid(Request $request) {
+        $allowedFields = ['name', 'description', ...self::APPLICATION_SETTING_FIELDS];
+    }
+
+    public function create_application(Request $request) {
+        $allowedFields = ['project_uuid', 'name', ...self::APPLICATION_SETTING_FIELDS];
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(
+            result["update_by_uuid"],
+            [
+                "name",
+                "description",
+                "is_git_submodules_enabled",
+                "is_gzip_enabled",
+                "stop_grace_period",
+            ],
+        )
+        self.assertEqual(
+            result["create_application"],
+            [
+                "project_uuid",
+                "name",
+                "is_git_submodules_enabled",
+                "is_gzip_enabled",
+                "stop_grace_period",
+            ],
+        )
+
+    def test_static_const_spread_expanded(self):
+        php = """<?php
+class Foo {
+    protected const EXTRA = ['a', 'b'];
+    public function update(Request $r) {
+        $allowedFields = ['name', ...static::EXTRA];
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(result["update"], ["name", "a", "b"])
+
+    def test_unknown_const_spread_skipped(self):
+        php = """<?php
+class Foo {
+    public function update(Request $r) {
+        $allowedFields = ['name', ...self::MISSING_CONST];
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(result["update"], ["name"])
+
+    def test_spread_does_not_duplicate_literals(self):
+        php = """<?php
+class Foo {
+    private const EXTRA = ['name', 'other'];
+    public function update(Request $r) {
+        $allowedFields = ['name', ...self::EXTRA];
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(result["update"], ["name", "other"])
+
+    def test_no_spread_unchanged_on_old_controller(self):
+        # Coolify < 4.2.0 has no APPLICATION_SETTING_FIELDS; allow lists stay
+        # literal-only and must not invent settings fields.
+        php = """<?php
+class ApplicationsController {
+    public function update_by_uuid(Request $request) {
+        $allowedFields = ['name', 'is_preserve_repository_enabled'];
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        self.assertEqual(
+            result["update_by_uuid"],
+            ["name", "is_preserve_repository_enabled"],
+        )
+        self.assertNotIn("is_gzip_enabled", result["update_by_uuid"])
+
+
+class TestExtractPhpStringListConstants(unittest.TestCase):
+    def test_private_const_array(self):
+        php = """<?php
+class C {
+    private const APPLICATION_SETTING_FIELDS = [
+        'is_gzip_enabled',
+        'stop_grace_period',
+    ];
+}
+"""
+        result = ec.extract_php_string_list_constants(php)
+        self.assertEqual(
+            result["APPLICATION_SETTING_FIELDS"],
+            ["is_gzip_enabled", "stop_grace_period"],
+        )
+
 
 # ── _clean_rule ─────────────────────────────────────────────────────
 

--- a/testdata/contracts/coolify-v4.2.0.json
+++ b/testdata/contracts/coolify-v4.2.0.json
@@ -1,7 +1,7 @@
 {
   "version": "v4.2.0",
   "extracted_from": "coollabsio/coolify@v4.2.0",
-  "extracted_at": "2026-07-25T11:12:30.470822+00:00",
+  "extracted_at": "2026-08-05T16:01:37.529823+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -6764,7 +6764,20 @@
         "autogenerate_domain",
         "is_container_label_escape_enabled",
         "tags",
-        "is_preserve_repository_enabled"
+        "is_preserve_repository_enabled",
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled"
       ]
     },
     "ApplicationsController::update_by_uuid": {
@@ -6841,7 +6854,20 @@
         "connect_to_docker_network",
         "force_domain_override",
         "is_container_label_escape_enabled",
-        "is_preserve_repository_enabled"
+        "is_preserve_repository_enabled",
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled"
       ]
     },
     "ApplicationsController::update_env_by_uuid": {
@@ -6936,6 +6962,13 @@
         "mongo_initdb_root_password",
         "mongo_initdb_database",
         "tags"
+      ]
+    },
+    "DestinationsController::create": {
+      "allowed_fields": [
+        "name",
+        "network",
+        "type"
       ]
     },
     "DigitalOceanController::createServer": {
@@ -7150,13 +7183,6 @@
         "vultr_ssh_key_ids",
         "cloud_init_script",
         "instant_validate"
-      ]
-    },
-    "DestinationsController::create": {
-      "allowed_fields": [
-        "name",
-        "network",
-        "type"
       ]
     }
   },

--- a/testdata/contracts/coolify-v4.json
+++ b/testdata/contracts/coolify-v4.json
@@ -1,7 +1,7 @@
 {
   "version": "v4.2.0",
   "extracted_from": "coollabsio/coolify@v4.2.0 plus v4.x volume-backup routes (PR #10946+)",
-  "extracted_at": "2026-07-25T11:12:30.470822+00:00",
+  "extracted_at": "2026-08-05T16:01:37.529823+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -6764,7 +6764,20 @@
         "autogenerate_domain",
         "is_container_label_escape_enabled",
         "tags",
-        "is_preserve_repository_enabled"
+        "is_preserve_repository_enabled",
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled"
       ]
     },
     "ApplicationsController::update_by_uuid": {
@@ -6841,7 +6854,20 @@
         "connect_to_docker_network",
         "force_domain_override",
         "is_container_label_escape_enabled",
-        "is_preserve_repository_enabled"
+        "is_preserve_repository_enabled",
+        "is_git_submodules_enabled",
+        "is_git_lfs_enabled",
+        "is_git_shallow_clone_enabled",
+        "disable_build_cache",
+        "inject_build_args_to_dockerfile",
+        "include_source_commit_in_build",
+        "is_env_sorting_enabled",
+        "is_pr_deployments_public_enabled",
+        "stop_grace_period",
+        "docker_images_to_keep",
+        "is_gzip_enabled",
+        "is_stripprefix_enabled",
+        "is_raw_compose_deployment_enabled"
       ]
     },
     "ApplicationsController::update_env_by_uuid": {
@@ -9149,5 +9175,5 @@
       ]
     }
   ],
-  "notes": "Pin is based on v4.2.0 extract. Volume backup PUT/DELETE .../storages/{storage_uuid}/backups routes are from Coolify v4.x after PR coollabsio/coolify#10946 (merged 2026-07-20). They are NOT present in git tag v4.2.0. Nightly CDN may report version 4.2.0 while including tip commits."
+  "notes": "Pin is based on v4.2.0 extract. Volume backup PUT/DELETE .../storages/{storage_uuid}/backups routes are from Coolify v4.x after PR coollabsio/coolify#10946 (merged 2026-07-20). They are NOT present in git tag v4.2.0. Nightly CDN may report version 4.2.0 while including tip commits. Application endpoint allowed_fields include expanded ...self::APPLICATION_SETTING_FIELDS spreads (extractor #661)."
 }


### PR DESCRIPTION
## Summary

Expand PHP \`...self::CONST\` / \`...static::CONST\` spreads when extracting controller \`\$allowedFields\` so Coolify v4.2.0 contracts include \`APPLICATION_SETTING_FIELDS\`.

## Problem

\`extract-contract.py\` only collected quoted string literals. Coolify builds application allow lists as:

\`\`\`php
\$allowedFields = [/* literals */, ...self::APPLICATION_SETTING_FIELDS];
\`\`\`

Contracts omitted the 13 settings fields, so \`allowed_fields\` was understated, \`skipInternal(... \"settings not on update allow list\")\` was a false negative, and write-path checks needed a hand-maintained list (#654 cascade).

## Change

- \`extract_php_string_list_constants\` + \`expand_allowed_field_list\` in the extractor
- Unit tests: self/static spreads, unknown const, dedupe, no-spread v4.1-style controller
- Re-extract \`coolify-v4.2.0.json\`; surgically update pin \`coolify-v4.json\` allow lists (preserve tip volume-backup routes + notes)
- \`contract_skips\`: remove public settings fields from \`skipInternal\`
- \`KNOWN_VERSION_DEPENDENT\`: mark settings fields as known v4.2.0 additions
- \`contract_write_test\`: read real pin allow list; assert settings fields present

## Validation

- \`pytest scripts/test_extract_contract.py scripts/test_check_contract_compat.py\` (76 passed)
- \`go test ./internal/spectest/ ./internal/service/application/\`
- \`make contract-check\` / \`make contract-compat\` green
- Independent reviewer: **APPROVE**

## Related

Closes #661

Ref #660 / #662 (product version-gate already landed)