### PR TITLE
test: harden version-gate field lists and observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 - Run `terraform fmt -recursive examples/` before committing HCL changes
 - **Scenario and resource counts live in 5+ files.** When adding a scenario, resource, or data source, grep for the old count across all docs before committing:
   ```bash
-  grep -rn '16 ACME\|16 tested\|16 scenario' AGENTS.md README.md ROADMAP.md templates/ docs/
+  grep -rn '17 ACME\|17 tested\|17 scenario\|16 ACME\|16 tested\|16 scenario' AGENTS.md README.md ROADMAP.md templates/ docs/
   ```
   Known locations for scenario counts: `AGENTS.md` (Project section), `README.md` (feature table + body text), `ROADMAP.md`, `templates/guides/architecture.md.tmpl` (ASCII diagram). Also check if a table row is missing in `README.md` for the new scenario.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-37 resources, 54 data sources, 1100+ tests (unit + acceptance), 9 CI jobs.
+37 resources, 54 data sources, 1140+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1100+ tests (unit + acceptance)
+- 1140+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 37 |
 | Data sources | 44 |
-| Tests | 1100+ unit and acceptance tests |
+| Tests | 1140+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -304,7 +304,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1100+ tests, race detector enabled)
+make test                                       # Run unit tests (1140+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,13 +13,11 @@ The provider covers the core Coolify resource model:
 - 17 ACME Corp scenario examples with integration tests
 - Full import support for adopting existing Coolify resources
 - Coolify v4.2 surfaces: destinations, DigitalOcean/Vultr server provisioning
+- Published on both [Terraform Registry](https://registry.terraform.io/providers/coolify-terraform/coolify)
+  and [OpenTofu Registry](https://search.opentofu.org/provider/coolify-terraform/coolify)
+  ([#414](https://github.com/coolify-terraform/terraform-provider-coolify/issues/414))
 
 ## Near Term
-
-### OpenTofu Registry publication
-
-Register the provider on the OpenTofu Registry for users who use OpenTofu
-instead of HashiCorp Terraform. ([#414](https://github.com/coolify-terraform/terraform-provider-coolify/issues/414))
 
 ### Notification channel resources
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -45,7 +45,14 @@ the raw API communication.
 [DEBUG] creating resource: resource_type=coolify_server
 [DEBUG] reading resource: resource_type=coolify_server uuid=abc-123
 [DEBUG] resource not found, removing from state: resource_type=coolify_server uuid=abc-123
+[DEBUG] withholding Coolify >= v4.2.0 application write fields unsupported on this instance: uuid=app-1 version=4.1.2 fields=[is_gzip_enabled]
+[DEBUG] skipping post-create patch: only Coolify>=4.2.0 write fields, unsupported on this Coolify version: uuid=app-1
 ```
+
+When connected to Coolify older than v4.2.0, the provider may log that it is
+withholding application settings so the PATCH does not 422. See the
+[Common Errors](./common-errors) guide for the plan-time warning and upgrade
+guidance.
 
 ### At TRACE Level
 

--- a/internal/client/applications.go
+++ b/internal/client/applications.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type Application struct {
@@ -394,6 +396,13 @@ func (c *Client) CreatePublicApplication(ctx context.Context, input CreatePublic
 }
 func (c *Client) UpdateApplication(ctx context.Context, uuid string, input UpdateApplicationInput) (*Application, error) {
 	if !c.SupportsApplicationSettings() {
+		if withheld := input.versionGatedWriteKeysPresent(); len(withheld) > 0 {
+			tflog.Debug(ctx, "withholding Coolify >= v4.2.0 application write fields unsupported on this instance", map[string]interface{}{
+				"uuid":    uuid,
+				"version": c.CoolifyVersion,
+				"fields":  withheld,
+			})
+		}
 		input.clearApplicationSettings()
 	}
 	var a Application
@@ -401,6 +410,26 @@ func (c *Client) UpdateApplication(ctx context.Context, uuid string, input Updat
 		return nil, fmt.Errorf("updating application %s: %w", uuid, err)
 	}
 	return &a, nil
+}
+
+// versionGatedWriteKeysPresent returns ApplicationSettingsWriteJSONKeys that
+// would appear on the wire for this input (before clearApplicationSettings).
+func (i UpdateApplicationInput) versionGatedWriteKeysPresent() []string {
+	raw, err := json.Marshal(i)
+	if err != nil {
+		return nil
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil
+	}
+	var present []string
+	for _, key := range ApplicationSettingsWriteJSONKeys {
+		if _, ok := body[key]; ok {
+			present = append(present, key)
+		}
+	}
+	return present
 }
 
 // clearApplicationSettings drops every application write field that Coolify

--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -16,6 +16,31 @@ import (
 // the entire request, which fails Create and leaves the resource tainted.
 const minApplicationSettingsVersion = "4.2.0"
 
+// ApplicationSettingsWriteJSONKeys lists Coolify application PATCH JSON keys
+// accepted only on >= v4.2.0 (APPLICATION_SETTING_FIELDS plus the two v4.2.0
+// literals is_preview_deployments_enabled and use_build_secrets).
+//
+// clearApplicationSettings and the plan-time warning list in the application
+// service package must stay aligned with this slice. Prefer this list in tests
+// over re-declaring the keys.
+var ApplicationSettingsWriteJSONKeys = []string{
+	"is_preview_deployments_enabled",
+	"use_build_secrets",
+	"is_git_submodules_enabled",
+	"is_git_lfs_enabled",
+	"is_git_shallow_clone_enabled",
+	"disable_build_cache",
+	"inject_build_args_to_dockerfile",
+	"include_source_commit_in_build",
+	"is_env_sorting_enabled",
+	"is_pr_deployments_public_enabled",
+	"stop_grace_period",
+	"docker_images_to_keep",
+	"is_gzip_enabled",
+	"is_stripprefix_enabled",
+	"is_raw_compose_deployment_enabled",
+}
+
 // SupportsApplicationSettings reports whether the connected instance accepts
 // Coolify >= v4.2.0 application write fields (APPLICATION_SETTING_FIELDS plus
 // is_preview_deployments_enabled and use_build_secrets, which landed as

--- a/internal/client/version_gate_test.go
+++ b/internal/client/version_gate_test.go
@@ -8,17 +8,6 @@ import (
 	"testing"
 )
 
-// versionGatedWriteFieldKeys are application PATCH fields Coolify accepts only
-// on >= v4.2.0 (APPLICATION_SETTING_FIELDS plus the two v4.2.0 literals).
-var settingFieldKeys = []string{
-	"is_preview_deployments_enabled", "use_build_secrets",
-	"is_git_submodules_enabled", "is_git_lfs_enabled", "is_git_shallow_clone_enabled",
-	"disable_build_cache", "inject_build_args_to_dockerfile", "include_source_commit_in_build",
-	"is_env_sorting_enabled", "is_pr_deployments_public_enabled", "stop_grace_period",
-	"docker_images_to_keep", "is_gzip_enabled", "is_stripprefix_enabled",
-	"is_raw_compose_deployment_enabled",
-}
-
 // fullSettingsInput sets every ApplicationSetting field plus one ordinary field,
 // so a stripped payload is still a valid, non-empty request.
 func fullSettingsInput() UpdateApplicationInput {
@@ -100,7 +89,7 @@ func TestUpdateApplication_VersionGate(t *testing.T) {
 			if _, ok := body["name"]; !ok {
 				t.Error("the gate dropped a non-settings field; only settings may be withheld")
 			}
-			for _, key := range settingFieldKeys {
+			for _, key := range ApplicationSettingsWriteJSONKeys {
 				_, sent := body[key]
 				if sent != tt.wantSettings {
 					t.Errorf("Coolify %q: %s sent=%v, want %v", tt.version, key, sent, tt.wantSettings)

--- a/internal/client/version_gate_test.go
+++ b/internal/client/version_gate_test.go
@@ -148,3 +148,54 @@ func TestHasOnlyApplicationSettings(t *testing.T) {
 		t.Error("input with a non-settings field still has work to do; want false")
 	}
 }
+
+func TestVersionGatedWriteKeysPresent(t *testing.T) {
+	t.Parallel()
+
+	if got := (UpdateApplicationInput{}).versionGatedWriteKeysPresent(); len(got) != 0 {
+		t.Fatalf("empty input: got %v", got)
+	}
+	got := fullSettingsInput().versionGatedWriteKeysPresent()
+	if len(got) != len(ApplicationSettingsWriteJSONKeys) {
+		t.Fatalf("got %d keys %v, want %d", len(got), got, len(ApplicationSettingsWriteJSONKeys))
+	}
+}
+
+// TestFullSettingsInput_CoversExportedKeys fails if ApplicationSettingsWriteJSONKeys
+// grows without fullSettingsInput (and thus clearApplicationSettings) following.
+func TestFullSettingsInput_CoversExportedKeys(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(fullSettingsInput())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range ApplicationSettingsWriteJSONKeys {
+		if _, ok := body[key]; !ok {
+			t.Errorf("fullSettingsInput omits %q; update the fixture and clearApplicationSettings", key)
+		}
+	}
+
+	cleared := fullSettingsInput()
+	cleared.clearApplicationSettings()
+	clearedRaw, err := json.Marshal(cleared)
+	if err != nil {
+		t.Fatalf("marshal cleared: %v", err)
+	}
+	var clearedBody map[string]json.RawMessage
+	if err := json.Unmarshal(clearedRaw, &clearedBody); err != nil {
+		t.Fatalf("unmarshal cleared: %v", err)
+	}
+	for _, key := range ApplicationSettingsWriteJSONKeys {
+		if _, ok := clearedBody[key]; ok {
+			t.Errorf("clearApplicationSettings left %q in the payload", key)
+		}
+	}
+	if _, ok := clearedBody["name"]; !ok {
+		t.Error("clearApplicationSettings must not drop non-settings fields")
+	}
+}

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -2465,14 +2465,7 @@ func TestApplicationResource_ImportCompoundEmptyEnv(t *testing.T) {
 func TestApplicationResource_SettingsWithheldOnOldCoolify(t *testing.T) {
 	t.Parallel()
 
-	settingKeys := []string{
-		"is_preview_deployments_enabled", "use_build_secrets",
-		"is_git_submodules_enabled", "is_git_lfs_enabled", "is_git_shallow_clone_enabled",
-		"disable_build_cache", "inject_build_args_to_dockerfile", "include_source_commit_in_build",
-		"is_env_sorting_enabled", "is_pr_deployments_public_enabled", "stop_grace_period",
-		"docker_images_to_keep", "is_gzip_enabled", "is_stripprefix_enabled",
-		"is_raw_compose_deployment_enabled",
-	}
+	settingKeys := client.ApplicationSettingsWriteJSONKeys
 
 	trueVal := true
 	currentApp := client.Application{

--- a/internal/service/application/version_gated_writes_test.go
+++ b/internal/service/application/version_gated_writes_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -43,6 +44,37 @@ func TestConfiguredVersionGatedWriteAttrs(t *testing.T) {
 		want := []string{"is_gzip_enabled", "is_preview_deployments_enabled", "stop_grace_period"}
 		if strings.Join(got, ",") != strings.Join(want, ",") {
 			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	// Drift guard: every JSON key the client strips on Coolify < 4.2.0 must
+	// surface in the plan warning list when configured (and no extra keys).
+	t.Run("matches client ApplicationSettingsWriteJSONKeys", func(t *testing.T) {
+		t.Parallel()
+		tb := types.BoolValue(true)
+		ti := types.Int64Value(1)
+		f := commonAppFields{
+			IsPreviewDeploymentsEnabled:   &tb,
+			UseBuildSecrets:               &tb,
+			IsGitSubmodulesEnabled:        &tb,
+			IsGitLfsEnabled:               &tb,
+			IsGitShallowCloneEnabled:      &tb,
+			DisableBuildCache:             &tb,
+			InjectBuildArgsToDockerfile:   &tb,
+			IncludeSourceCommitInBuild:    &tb,
+			IsEnvSortingEnabled:           &tb,
+			IsPrDeploymentsPublicEnabled:  &tb,
+			StopGracePeriod:               &ti,
+			DockerImagesToKeep:            &ti,
+			IsGzipEnabled:                 &tb,
+			IsStripprefixEnabled:          &tb,
+			IsRawComposeDeploymentEnabled: &tb,
+		}
+		got := configuredVersionGatedWriteAttrs(f)
+		want := append([]string(nil), client.ApplicationSettingsWriteJSONKeys...)
+		sort.Strings(want)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("warn attrs drifted from client strip list\ngot:  %v\nwant: %v", got, want)
 		}
 	})
 }

--- a/templates/guides/troubleshooting.md.tmpl
+++ b/templates/guides/troubleshooting.md.tmpl
@@ -45,7 +45,14 @@ the raw API communication.
 [DEBUG] creating resource: resource_type=coolify_server
 [DEBUG] reading resource: resource_type=coolify_server uuid=abc-123
 [DEBUG] resource not found, removing from state: resource_type=coolify_server uuid=abc-123
+[DEBUG] withholding Coolify >= v4.2.0 application write fields unsupported on this instance: uuid=app-1 version=4.1.2 fields=[is_gzip_enabled]
+[DEBUG] skipping post-create patch: only Coolify>=4.2.0 write fields, unsupported on this Coolify version: uuid=app-1
 ```
+
+When connected to Coolify older than v4.2.0, the provider may log that it is
+withholding application settings so the PATCH does not 422. See the
+[Common Errors](./common-errors) guide for the plan-time warning and upgrade
+guidance.
 
 ### At TRACE Level
 


### PR DESCRIPTION
## Summary

Multi-perspective improve batch on main after the 4.1/4.2 application settings and domains work.

- Export `ApplicationSettingsWriteJSONKeys` as the single list of Coolify >= v4.2.0 application write keys; wire client strip tests and resource 422 mocks to it
- Drift guards so plan-warning attrs, `fullSettingsInput`, and `clearApplicationSettings` cannot diverge silently
- DEBUG log when the version gate withholds fields on Coolify < v4.2.0 (troubleshooting guide updated)
- Documented test floor 1100+ → 1140+
- ROADMAP: OpenTofu Registry publication marked done (#414 already closed)

## Test plan

- [x] `make ci` green locally
- [x] Targeted package tests for version gate / alignment
- [ ] CI on this PR green