### PR TITLE
test: strengthen validator assertions and bump plugin-log

### DIFF
--- a/docs/guides/migration-from-community.md
+++ b/docs/guides/migration-from-community.md
@@ -17,8 +17,8 @@ This provider is a complete rewrite using the Terraform Plugin Framework
 (not the older SDK v2). It offers:
 
 - **37 resources** vs. ~10 in the community provider
-- **44 data sources** with filtering support
-- **890+ tests** (unit + acceptance + scenario)
+- **54 data sources** with filtering support
+- **1140+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,
   cloud tokens, GitHub App sources, and resource actions (start/stop/restart)
 - Contract-verified field coverage against the real Coolify source code

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
-	github.com/hashicorp/terraform-plugin-log v0.10.0
+	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/pb33f/libopenapi-validator v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/
 github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
-github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
-github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
+github.com/hashicorp/terraform-plugin-log v0.11.0 h1:WjhcpZIVqP8YRe83+dIZXncwSgtu4vh27i23G33PUQY=
+github.com/hashicorp/terraform-plugin-log v0.11.0/go.mod h1:XygBz8+m5kgwTb73MMyrnUjeNQeVWECEfg+h2opMsj0=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 h1:2yPUd7esMOpuTaG3y1iEla1iw+tla+3ZEkkBnmOAre4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1/go.mod h1:sq8qsxh+PwdvTQFcd17kfCoBgQo46ADNMvCpKE7t/gY=
 github.com/hashicorp/terraform-plugin-testing v1.16.0 h1:GB97nGnJ1hESpDrCjqZig38RodSF0gdRzxlDupLXP38=

--- a/internal/service/application/resource_github_app_test.go
+++ b/internal/service/application/resource_github_app_test.go
@@ -703,7 +703,7 @@ func TestGitHubAppApplicationResource_InvalidBuildPack(t *testing.T) {
 					build_pack       = "invalid_pack"
 					ports_exposes    = "3000"
 				`),
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`(?s)build_pack value must be one of:.*nixpacks`),
 			},
 		},
 	})

--- a/internal/service/application/resource_private_git_test.go
+++ b/internal/service/application/resource_private_git_test.go
@@ -585,7 +585,7 @@ func TestPrivateGitApplicationResource_InvalidBuildPack(t *testing.T) {
 					build_pack       = "invalid_pack"
 					ports_exposes    = "3000"
 				`),
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`(?s)build_pack value must be one of:.*nixpacks`),
 			},
 		},
 	})

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -1929,7 +1929,7 @@ func TestApplicationResource_ValidateRedirect(t *testing.T) {
 					ports_exposes  = "3000"
 					redirect       = "invalid"
 				`),
-				ExpectError: regexp.MustCompile(`www`),
+				ExpectError: regexp.MustCompile(`redirect.*must be one of.*"www".*"non-www".*"both"`),
 			},
 		},
 	})
@@ -1956,7 +1956,7 @@ func TestApplicationResource_ValidatePortsMappings(t *testing.T) {
 					ports_exposes  = "3000"
 					ports_mappings = "abc"
 				`),
-				ExpectError: regexp.MustCompile(`host:container`),
+				ExpectError: regexp.MustCompile(`expected host:container format, got "abc"`),
 			},
 		},
 	})

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -675,7 +675,7 @@ func TestApplicationResource_InvalidBuildPack(t *testing.T) {
 					build_pack     = "invalid"
 					ports_exposes  = "3000"
 				`),
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`(?s)build_pack value must be one of:.*nixpacks`),
 			},
 		},
 	})

--- a/internal/service/database/mariadb/resource_test.go
+++ b/internal/service/database/mariadb/resource_test.go
@@ -369,7 +369,7 @@ resource "coolify_database_mariadb" "test" {
   ssl_mode     = "bogus"
 }
 `,
-				ExpectError: regexp.MustCompile(`must be one of`),
+				ExpectError: regexp.MustCompile(`(?s)ssl_mode value must be one of:`),
 			},
 		},
 	})

--- a/internal/service/resourceaction/resource_test.go
+++ b/internal/service/resourceaction/resource_test.go
@@ -268,7 +268,8 @@ resource "coolify_resource_action" "bad" {
   action        = "delete"
 }
 `,
-				ExpectError: regexp.MustCompile("delete"),
+				// Framework OneOf: value must be one of start/stop/restart (not "delete").
+				ExpectError: regexp.MustCompile(`action.*must be one of.*start.*stop.*restart`),
 			},
 		},
 	})
@@ -407,7 +408,8 @@ resource "coolify_resource_action" "bad" {
   action        = "start"
 }
 `,
-				ExpectError: regexp.MustCompile("container"),
+				// Framework OneOf wraps the allowed list across lines in diagnostics.
+				ExpectError: regexp.MustCompile(`(?s)resource_type value must be one of: \["application" "database".*"service"\]`),
 			},
 		},
 	})

--- a/internal/service/scheduledtask/resource_test.go
+++ b/internal/service/scheduledtask/resource_test.go
@@ -762,7 +762,7 @@ func TestScheduledTaskResource_CronAlias(t *testing.T) {
 					frequency        = "@daily"
 				`),
 				// The API call fails (NotFoundHandler), but validation passes.
-				ExpectError: regexp.MustCompile(`Error creating`),
+				ExpectError: regexp.MustCompile(`Error creating scheduled task`),
 			},
 		},
 	})

--- a/templates/guides/migration-from-community.md.tmpl
+++ b/templates/guides/migration-from-community.md.tmpl
@@ -17,8 +17,8 @@ This provider is a complete rewrite using the Terraform Plugin Framework
 (not the older SDK v2). It offers:
 
 - **37 resources** vs. ~10 in the community provider
-- **44 data sources** with filtering support
-- **890+ tests** (unit + acceptance + scenario)
+- **54 data sources** with filtering support
+- **1140+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,
   cloud tokens, GitHub App sources, and resource actions (start/stop/restart)
 - Contract-verified field coverage against the real Coolify source code


### PR DESCRIPTION
## Summary

MPI cycle 2 (Test Auditor first after #666):

- Strengthen weak `ExpectError` regexes so validator tests assert the attribute and allowed values (resource_action, application redirect/ports/build_pack, scheduled_task, mariadb ssl_mode)
- Refresh community migration guide counts (54 data sources, 1140+ tests)
- Bump `terraform-plugin-log` v0.10.0 → v0.11.0

## Test plan

- [x] `make ci` green locally
- [x] Targeted unit tests for strengthened ExpectError cases
- [ ] CI on this PR green