### PR TITLE
chore(security): ignore unreachable GO-2026-5932 for Scorecard OSV

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,7 @@ This provider follows these security principles:
 - Test credentials use placeholder values (`"test-token"`)
 - No real API tokens or secrets are committed to the repository
 - `.gitleaks.toml` allowlists suppress false positives in test fixtures and examples
+- `tools/osv-scanner.toml` ignores GO-2026-5932 (unfixed `x/crypto/openpgp` advisory; not imported; `govulncheck` clean)
 
 ## Assurance Case
 

--- a/tools/osv-scanner.toml
+++ b/tools/osv-scanner.toml
@@ -1,0 +1,6 @@
+# OSV-Scanner config for tools/go.mod only (does not cascade from repo root).
+# OpenSSF Scorecard's Vulnerabilities check runs OSV-Scanner over the tree.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "Advisory targets golang.org/x/crypto/openpgp (frozen, no fixed release). Provider and tools do not import that path; OpenPGP is ProtonMail/go-crypto via HashiCorp tooling. govulncheck reports 0 call-path findings."


### PR DESCRIPTION
## Summary

- Add `tools/osv-scanner.toml` with `[[IgnoredVulns]]` for **GO-2026-5932** (frozen `golang.org/x/crypto/openpgp`, no fixed release; we do not import it; OpenPGP is ProtonMail/go-crypto; `govulncheck` is clean).
- One-line note in `SECURITY.md` so the exception is visible to auditors.

OSV config is scoped to the directory that holds the scanned `go.mod` (`tools/`), which is what Scorecard/OSV walks for that module.

## Test plan

- [ ] CI green
- [ ] After next Scorecard run: residual openpgp vuln should drop if OSV honors the config