### PR TITLE
test: MPI improvements (destination retry, envsbulk errors, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 | Area | Coverage |
 |---|---|
 | Managed resources | 37 |
-| Data sources | 44 |
+| Data sources | 54 |
 | Tests | 1140+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -123,6 +123,32 @@ will not send them to the Coolify API.
 **Fix:** upgrade Coolify to **v4.2.0** or later, or remove those attributes
 from configuration. The warning is intentional; it is not a hard error.
 
+### Server has multiple destinations and you do not set destination_uuid
+
+```
+Error: Error creating application: …
+Server has multiple destinations and you do not set destination_uuid.
+```
+
+**Cause:** the Coolify server has more than one Docker network destination
+(Coolify >= v4.2.0). Create APIs require `destination_uuid` when more than
+one destination exists. The provider auto-resolves a destination when it can
+(prefers network `coolify`, then the first standalone destination, then the
+first entry). Resolution fails if the destinations list is empty or the API
+returns an unexpected error.
+
+**Fix:**
+
+1. List destinations with `data.coolify_destinations` or
+   `coolify_destination` resources for the server.
+2. Prefer a single default network named `coolify` so auto-resolution is
+   deterministic.
+3. Explicit `destination_uuid` on application and database resources is
+   tracked in issue
+   [#675](https://github.com/coolify-terraform/terraform-provider-coolify/issues/675);
+   until that lands, keep one destination per server or rely on the
+   `coolify` network naming heuristic.
+
 ### UUID format invalid
 
 ```

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5601,6 +5601,65 @@ func TestClient_CreateDockerfileApplication_ResolvesDestination(t *testing.T) {
 	assert.Equal(t, "dest-1", gotBody["destination_uuid"])
 }
 
+// TestClient_CreateDatabase_ResolvesDestination covers the retry path in
+// CreateDatabase: when Coolify rejects the first POST for missing
+// destination_uuid on a multi-destination server, the client resolves a
+// destination and retries. Applications resolve proactively; databases use
+// this error-driven path (inputWithResolvedDestination).
+func TestClient_CreateDatabase_ResolvesDestination(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/servers/{uuid}/destinations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]Destination{{UUID: "dest-db-1", Network: "coolify", Type: "standalone"}})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{dbType}", func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		if attempts == 1 {
+			http.Error(w, `{"message":"Server has multiple destinations and you do not set destination_uuid."}`, http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Database{UUID: "db-1", Name: "pg"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	db, err := c.CreateDatabase(context.Background(), "postgresql", CreatePostgresqlInput{
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ProjectUUID: "p", ServerUUID: "s", EnvironmentName: "production", Name: "pg",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "db-1", db.UUID)
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, "dest-db-1", gotBody["destination_uuid"])
+}
+
+func TestClient_CreateDatabase_ResolveDestinationFails(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	// Empty destinations list: resolve returns "" and retry is skipped.
+	mux.HandleFunc("GET /api/v1/servers/{uuid}/destinations", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]Destination{})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{dbType}", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Server has multiple destinations and you do not set destination_uuid."}`, http.StatusBadRequest)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.CreateDatabase(context.Background(), "redis", CreateRedisInput{
+		CreateDatabaseBaseInput: CreateDatabaseBaseInput{
+			ProjectUUID: "p", ServerUUID: "s", EnvironmentName: "production",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination_uuid")
+}
+
 func TestApplication_PromoteSettings(t *testing.T) {
 	t.Parallel()
 	preview := true

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -32,16 +32,6 @@ func StringValueOrNull(v types.String) *string {
 	return &s
 }
 
-// IntValueOrNull extracts the underlying Go int64 as an *int pointer.
-// Returns nil when the value is null or unknown.
-func IntValueOrNull(v types.Int64) *int {
-	if v.IsNull() || v.IsUnknown() {
-		return nil
-	}
-	n := int(v.ValueInt64())
-	return &n
-}
-
 // BoolValueOrNull extracts the underlying Go bool as a *bool pointer.
 // Returns nil when the value is null or unknown.
 func BoolValueOrNull(v types.Bool) *bool {

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -44,43 +44,6 @@ func TestStringValueOrNull(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// IntValueOrNull
-// ---------------------------------------------------------------------------
-
-func TestIntValueOrNull(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		input  types.Int64
-		wantNl bool
-		want   int
-	}{
-		{"positive value", types.Int64Value(42), false, 42},
-		{"zero value", types.Int64Value(0), false, 0},
-		{"negative value", types.Int64Value(-1), false, -1},
-		{"null", types.Int64Null(), true, 0},
-		{"unknown", types.Int64Unknown(), true, 0},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := flex.IntValueOrNull(tc.input)
-			if tc.wantNl {
-				if got != nil {
-					t.Fatalf("expected nil, got %v", *got)
-				}
-				return
-			}
-			if got == nil {
-				t.Fatal("expected non-nil pointer, got nil")
-				return
-			}
-			if *got != tc.want {
-				t.Fatalf("expected %v, got %v", tc.want, *got)
-			}
-		})
-	}
-}
 
 // BoolValue / BoolValueOrNull
 // ---------------------------------------------------------------------------

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -44,7 +44,6 @@ func TestStringValueOrNull(t *testing.T) {
 	}
 }
 
-
 // BoolValue / BoolValueOrNull
 // ---------------------------------------------------------------------------
 

--- a/internal/service/envsbulk/resource.go
+++ b/internal/service/envsbulk/resource.go
@@ -82,10 +82,17 @@ func (r *envsBulkResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_envs_bulk"})
+	tflog.Debug(ctx, "creating resource", map[string]interface{}{
+		"resource_type":        "coolify_envs_bulk",
+		"parent_resource_type": plan.ResourceType.ValueString(),
+		"parent_resource_uuid": plan.ResourceUUID.ValueString(),
+	})
 
 	if err := r.bulkUpdate(ctx, &plan); err != nil {
-		resp.Diagnostics.AddError("Error creating bulk env vars", err.Error())
+		resp.Diagnostics.AddError(
+			"Error creating bulk env vars",
+			fmt.Sprintf("%s %s: %s", plan.ResourceType.ValueString(), plan.ResourceUUID.ValueString(), err),
+		)
 		return
 	}
 
@@ -99,10 +106,14 @@ func (r *envsBulkResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	tflog.Debug(ctx, "reading resource", map[string]interface{}{"resource_type": "coolify_envs_bulk"})
-
 	resType := state.ResourceType.ValueString()
 	uuid := state.ResourceUUID.ValueString()
+
+	tflog.Debug(ctx, "reading resource", map[string]interface{}{
+		"resource_type":        "coolify_envs_bulk",
+		"parent_resource_type": resType,
+		"parent_resource_uuid": uuid,
+	})
 
 	envs, err := r.listEnvVars(ctx, resType, uuid)
 	if err != nil {
@@ -110,7 +121,10 @@ func (r *envsBulkResource) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error reading bulk env vars", err.Error())
+		resp.Diagnostics.AddError(
+			"Error reading bulk env vars",
+			fmt.Sprintf("%s %s: %s", resType, uuid, err),
+		)
 		return
 	}
 
@@ -149,10 +163,17 @@ func (r *envsBulkResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_envs_bulk"})
+	tflog.Debug(ctx, "updating resource", map[string]interface{}{
+		"resource_type":        "coolify_envs_bulk",
+		"parent_resource_type": plan.ResourceType.ValueString(),
+		"parent_resource_uuid": plan.ResourceUUID.ValueString(),
+	})
 
 	if err := r.bulkUpdate(ctx, &plan); err != nil {
-		resp.Diagnostics.AddError("Error updating bulk env vars", err.Error())
+		resp.Diagnostics.AddError(
+			"Error updating bulk env vars",
+			fmt.Sprintf("%s %s: %s", plan.ResourceType.ValueString(), plan.ResourceUUID.ValueString(), err),
+		)
 		return
 	}
 
@@ -195,7 +216,10 @@ func (r *envsBulkResource) ImportState(ctx context.Context, req resource.ImportS
 
 	envs, err := r.listEnvVars(ctx, resType, uuid)
 	if err != nil {
-		resp.Diagnostics.AddError("Error importing bulk env vars", err.Error())
+		resp.Diagnostics.AddError(
+			"Error importing bulk env vars",
+			fmt.Sprintf("%s %s: %s", resType, uuid, err),
+		)
 		return
 	}
 

--- a/internal/service/envsbulk/resource_test.go
+++ b/internal/service/envsbulk/resource_test.go
@@ -479,7 +479,7 @@ func TestEnvsBulkResource_CreateAPIError(t *testing.T) {
 						APP_ENV = "test"
 					}
 				`),
-				ExpectError: regexp.MustCompile(`Error creating bulk env vars`),
+				ExpectError: regexp.MustCompile(`Error creating bulk env vars[\s\S]*application 550e8400-e29b-41d4-a716-446655440010`),
 			},
 		},
 	})

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -123,6 +123,32 @@ will not send them to the Coolify API.
 **Fix:** upgrade Coolify to **v4.2.0** or later, or remove those attributes
 from configuration. The warning is intentional; it is not a hard error.
 
+### Server has multiple destinations and you do not set destination_uuid
+
+```
+Error: Error creating application: …
+Server has multiple destinations and you do not set destination_uuid.
+```
+
+**Cause:** the Coolify server has more than one Docker network destination
+(Coolify >= v4.2.0). Create APIs require `destination_uuid` when more than
+one destination exists. The provider auto-resolves a destination when it can
+(prefers network `coolify`, then the first standalone destination, then the
+first entry). Resolution fails if the destinations list is empty or the API
+returns an unexpected error.
+
+**Fix:**
+
+1. List destinations with `data.coolify_destinations` or
+   `coolify_destination` resources for the server.
+2. Prefer a single default network named `coolify` so auto-resolution is
+   deterministic.
+3. Explicit `destination_uuid` on application and database resources is
+   tracked in issue
+   [#675](https://github.com/coolify-terraform/terraform-provider-coolify/issues/675);
+   until that lands, keep one destination per server or rely on the
+   `coolify` network naming heuristic.
+
 ### UUID format invalid
 
 ```


### PR DESCRIPTION
## Summary

Multi-perspective improvement pass on a clean main (no open feature PRs; only blocked-upstream / channel-watch / community issues remaining).

### Changes

- **test(client):** unit coverage for `CreateDatabase` multi-destination retry and empty-destination failure
- **fix(envsbulk):** Create/Read/Update/Import diagnostics and debug logs include parent type + UUID
- **refactor(flex):** remove unused `IntValueOrNull` (only `Int64PtrFromFramework` is used)
- **docs:** README data source count 44 → 54; common-errors section for multi-destination create failures (links #675)

### Tracking

- Closes nothing required; opens [#675](https://github.com/coolify-terraform/terraform-provider-coolify/issues/675) for explicit `destination_uuid` schema work

### Verification

- `make ci` green locally