### PR TITLE
docs: destination_uuid examples and test floor (MPI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-37 resources, 54 data sources, 1140+ tests (unit + acceptance), 9 CI jobs.
+37 resources, 54 data sources, 1150+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1140+ tests (unit + acceptance)
+- 1150+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 37 |
 | Data sources | 54 |
-| Tests | 1140+ unit and acceptance tests |
+| Tests | 1150+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -304,7 +304,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1140+ tests, race detector enabled)
+make test                                       # Run unit tests (1150+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/guides/connecting-resources.md
+++ b/docs/guides/connecting-resources.md
@@ -15,6 +15,14 @@ applications to databases and other services.
 
 Every Coolify project gets its own Docker network. All resources (apps,
 databases, services) within that project are attached to the same network.
+
+On Coolify **>= v4.2.0**, a server can also have **multiple destinations**
+(extra Docker networks managed with `coolify_destination`). When more than
+one destination exists, create calls require `destination_uuid` on the
+application, database, or service (create-only). If you omit it, the
+provider auto-resolves when possible (prefers network name `coolify`).
+See the Common Errors guide for the multi-destination API message.
+
 This means:
 
 - **Containers can reach each other by resource name.** If your database

--- a/docs/guides/migration-from-community.md
+++ b/docs/guides/migration-from-community.md
@@ -18,7 +18,7 @@ This provider is a complete rewrite using the Terraform Plugin Framework
 
 - **37 resources** vs. ~10 in the community provider
 - **54 data sources** with filtering support
-- **1140+ tests** (unit + acceptance + scenario)
+- **1150+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,
   cloud tokens, GitHub App sources, and resource actions (start/stop/restart)
 - Contract-verified field coverage against the real Coolify source code

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -36,6 +36,7 @@ resource "coolify_application" "example" {
   domains        = "https://app.example.com"
 
   # Optional fields (uncomment as needed):
+  # destination_uuid         = coolify_destination.app_net.uuid  # create-only; required when the server has multiple Docker networks
   # redirect                 = "both"                # WWW redirect: "www", "non-www", or "both" (default: "both")
   # base_directory           = "/app"                 # Base directory for the application source code (default: "/")
   # watch_paths              = "/src:/lib"            # Paths to watch for changes (triggers auto-deploy)

--- a/docs/resources/database_postgresql.md
+++ b/docs/resources/database_postgresql.md
@@ -19,9 +19,10 @@ variable "postgres_password" {
 }
 
 resource "coolify_database_postgresql" "example" {
-  name              = "my-postgres"
-  project_uuid      = coolify_project.example.uuid
-  server_uuid       = coolify_server.example.uuid
+  name         = "my-postgres"
+  project_uuid = coolify_project.example.uuid
+  server_uuid  = coolify_server.example.uuid
+  # destination_uuid = coolify_destination.app_net.uuid  # create-only; multi-destination servers
   image             = "postgres:16"
   postgres_user     = "app"
   postgres_password = var.postgres_password

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -16,6 +16,8 @@ Destinations map to Coolify standalone/swarm Docker networks used when deploying
 ## Example Usage
 
 ```terraform
+# Requires Coolify >= v4.2.0. Pass uuid into application, database, or service
+# create as destination_uuid when the server has more than one network.
 resource "coolify_destination" "app_net" {
   server_uuid = coolify_server.main.uuid
   network     = "coolify-app"

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -24,6 +24,9 @@ resource "coolify_service" "catalog" {
   server_uuid      = coolify_server.example.uuid
   environment_name = "production"
 
+  # Optional: pin Docker network when the server has multiple destinations (create-only)
+  # destination_uuid = coolify_destination.app_net.uuid
+
   # Optional: connect service containers to the Coolify Docker network
   # connect_to_docker_network = true
 }

--- a/examples/resources/coolify_application/resource.tf
+++ b/examples/resources/coolify_application/resource.tf
@@ -9,6 +9,7 @@ resource "coolify_application" "example" {
   domains        = "https://app.example.com"
 
   # Optional fields (uncomment as needed):
+  # destination_uuid         = coolify_destination.app_net.uuid  # create-only; required when the server has multiple Docker networks
   # redirect                 = "both"                # WWW redirect: "www", "non-www", or "both" (default: "both")
   # base_directory           = "/app"                 # Base directory for the application source code (default: "/")
   # watch_paths              = "/src:/lib"            # Paths to watch for changes (triggers auto-deploy)

--- a/examples/resources/coolify_database_postgresql/resource.tf
+++ b/examples/resources/coolify_database_postgresql/resource.tf
@@ -4,9 +4,10 @@ variable "postgres_password" {
 }
 
 resource "coolify_database_postgresql" "example" {
-  name              = "my-postgres"
-  project_uuid      = coolify_project.example.uuid
-  server_uuid       = coolify_server.example.uuid
+  name         = "my-postgres"
+  project_uuid = coolify_project.example.uuid
+  server_uuid  = coolify_server.example.uuid
+  # destination_uuid = coolify_destination.app_net.uuid  # create-only; multi-destination servers
   image             = "postgres:16"
   postgres_user     = "app"
   postgres_password = var.postgres_password

--- a/examples/resources/coolify_destination/resource.tf
+++ b/examples/resources/coolify_destination/resource.tf
@@ -1,3 +1,5 @@
+# Requires Coolify >= v4.2.0. Pass uuid into application, database, or service
+# create as destination_uuid when the server has more than one network.
 resource "coolify_destination" "app_net" {
   server_uuid = coolify_server.main.uuid
   network     = "coolify-app"

--- a/examples/resources/coolify_service/resource.tf
+++ b/examples/resources/coolify_service/resource.tf
@@ -9,6 +9,9 @@ resource "coolify_service" "catalog" {
   server_uuid      = coolify_server.example.uuid
   environment_name = "production"
 
+  # Optional: pin Docker network when the server has multiple destinations (create-only)
+  # destination_uuid = coolify_destination.app_net.uuid
+
   # Optional: connect service containers to the Coolify Docker network
   # connect_to_docker_network = true
 }

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -58,6 +58,23 @@ func TestUpdateServiceInput_PublicPatchSurfaceMatchesExpectedKeys(t *testing.T) 
 	}
 }
 
+// Regression: Coolify update_by_uuid does not allow destination_uuid; create-only.
+func TestUpdateServiceInput_NoDestinationUUID(t *testing.T) {
+	t.Parallel()
+	for _, k := range expectedWritableServiceUpdateKeys {
+		if k == "destination_uuid" {
+			t.Fatal("UpdateServiceInput must not include destination_uuid (create-only field)")
+		}
+	}
+	updateType := reflect.TypeOf(client.UpdateServiceInput{})
+	for i := 0; i < updateType.NumField(); i++ {
+		key, _, _ := strings.Cut(updateType.Field(i).Tag.Get("json"), ",")
+		if key == "destination_uuid" {
+			t.Fatal("UpdateServiceInput JSON tag destination_uuid found; remove it")
+		}
+	}
+}
+
 const serviceTestConfig = `
 resource "coolify_service" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"

--- a/templates/guides/connecting-resources.md.tmpl
+++ b/templates/guides/connecting-resources.md.tmpl
@@ -15,6 +15,14 @@ applications to databases and other services.
 
 Every Coolify project gets its own Docker network. All resources (apps,
 databases, services) within that project are attached to the same network.
+
+On Coolify **>= v4.2.0**, a server can also have **multiple destinations**
+(extra Docker networks managed with `coolify_destination`). When more than
+one destination exists, create calls require `destination_uuid` on the
+application, database, or service (create-only). If you omit it, the
+provider auto-resolves when possible (prefers network name `coolify`).
+See the Common Errors guide for the multi-destination API message.
+
 This means:
 
 - **Containers can reach each other by resource name.** If your database

--- a/templates/guides/migration-from-community.md.tmpl
+++ b/templates/guides/migration-from-community.md.tmpl
@@ -18,7 +18,7 @@ This provider is a complete rewrite using the Terraform Plugin Framework
 
 - **37 resources** vs. ~10 in the community provider
 - **54 data sources** with filtering support
-- **1140+ tests** (unit + acceptance + scenario)
+- **1150+ tests** (unit + acceptance + scenario)
 - Database backup management, scheduled tasks, storage volumes,
   cloud tokens, GitHub App sources, and resource actions (start/stop/restart)
 - Contract-verified field coverage against the real Coolify source code


### PR DESCRIPTION
## Summary

MPI polish pass after destination_uuid landed for apps, databases, and services.

## Changes

- Documented test floor **1150+** (actual ~1153)
- Examples: optional `destination_uuid` comments on application, service, postgres, destination
- Connecting-resources guide: multi-destination / `destination_uuid` create-only note
- Regression test: `UpdateServiceInput` must never grow `destination_uuid` (Coolify create-only)

## Gate notes

- Open **release PR #679** (`chore(main): release 0.1.13`) is green and mergeable; **not merged** (needs explicit approval).
- Remaining open issues are blocked-upstream or non-code (#647, #445, #394, #393, #591, #475).

## Verification

- `make ci` green locally