### PR TITLE
docs: add Coolify version support matrix guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 
 - [Quick Start](docs/guides/quickstart.md) -- deploy your first app in under 5 minutes
 - [Installation](docs/guides/installation.md) -- install and configure the provider
+- [Coolify Version Support](docs/guides/coolify-version-support.md) -- what works on Coolify 4.1, 4.2, and 4.3
 - [Examples](examples/) -- browse per-resource examples
 - [Scenarios](examples/scenarios/) -- see full-stack ACME Corp setups tested against a real Coolify instance
 - [Import Guide](docs/guides/import.md) -- adopt existing resources without rebuilding
@@ -86,6 +87,7 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 
 ## Guides
 
+- [Coolify Version Support](docs/guides/coolify-version-support.md) -- what works on Coolify 4.1, 4.2, and 4.3
 - [Core Concepts](docs/guides/concepts.md) -- understand the resource model
 - [Choosing an Application Type](docs/guides/choosing-application-type.md) -- pick the right resource for your deployment method
 - [Connecting Resources](docs/guides/connecting-resources.md) -- wire apps to databases using Coolify's Docker networking

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -107,6 +107,9 @@ do not want an immediate deploy; the ordering is intrinsic to Coolify.
 
 ### Coolify version cannot write some application settings
 
+Full matrix of which application attributes need Coolify 4.2 vs 4.3:
+[Coolify Version Support](coolify-version-support).
+
 ```
 Warning: Coolify version cannot write some application settings
 
@@ -115,13 +118,20 @@ is_gzip_enabled, …. The provider will keep these values in Terraform state but
 will not send them to the Coolify API.
 ```
 
-**Cause:** Coolify **v4.1.x** rejects several application write fields (the
-`APPLICATION_SETTING_FIELDS` set, plus `is_preview_deployments_enabled` and
-`use_build_secrets`). The provider withholds them on PATCH so Create does not
-422, but still keeps configured values in state.
+**Cause:** Coolify rejects application write fields that are not on that
+version's allow list. The provider withholds them on PATCH so Create does not
+422, but still keeps configured values in state. The same warning title covers
+both gates:
 
-**Fix:** upgrade Coolify to **v4.2.0** or later, or remove those attributes
-from configuration. The warning is intentional; it is not a hard error.
+- Coolify **v4.1.x**: 4.2 settings (gzip, git LFS, preview deploys, build
+  secrets, and related fields)
+- Coolify **v4.2.x**: 4.3 settings (log drain, GPU, `custom_internal_name`,
+  `noindex_domains`, and related fields)
+
+**Fix:** upgrade Coolify to the version named in the warning (**v4.2.0** or
+**v4.3.0** as listed), or remove those attributes from configuration. The
+warning is intentional; it is not a hard error. Full attribute lists:
+[Coolify Version Support](coolify-version-support).
 
 ### Server has multiple destinations and you do not set destination_uuid
 

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -1,0 +1,183 @@
+---
+page_title: "Coolify Version Support"
+subcategory: "Getting Started"
+description: |-
+  What works on Coolify 4.1, 4.2, and 4.3 with this provider: resources, fields, and version-gate behavior.
+---
+
+# Coolify Version Support
+
+This guide answers: **which Coolify version do I need for each resource and field?**
+
+The provider hard-requires Coolify **v4.1.0 or later** on every `terraform plan` /
+`terraform apply`. Within that floor, some APIs only exist on newer Coolify
+lines. The provider still configures against older supported instances, but it
+**withholds** writes that would 422 and emits a **plan warning** when you set
+those attributes.
+
+-> **Check your instance** (see also [Installation](installation)):
+
+```hcl
+data "coolify_version" "current" {}
+
+output "coolify_version" {
+  value = data.coolify_version.current.version
+}
+```
+
+## Support model at a glance
+
+| Coolify | Provider behavior |
+|---------|-------------------|
+| **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
+| **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
+| **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
+| **≥ 4.3.0** | Full current surface: volume backup schedules, `noindex_domains`, GPU/log-drain application settings, etc. |
+
+Pinned API contract today: Coolify **v4.3.1** (`testdata/contracts/coolify-v4.json`).
+The provider remains usable on 4.1.0+ for the common surface.
+
+## Resources and data sources by Coolify version
+
+### Always available (Coolify ≥ 4.1.0)
+
+Core lifecycle, apps, databases, services, env vars, keys, projects, Hetzner
+cloud tokens, GitHub Apps, scheduled tasks, storage volumes, deployments,
+teams, and most list/single data sources.
+
+| Resource / data source family | Notes |
+|-------------------------------|--------|
+| `coolify_project`, `coolify_environment` | |
+| `coolify_server`, `coolify_server_hetzner`, `coolify_server_validate` | Hetzner provision path |
+| `coolify_application*` (public, docker image, dockerfile, private git, github app) | Some **attributes** need 4.2/4.3 (see below) |
+| `coolify_application_preview` | |
+| Eight database engines + `coolify_database_backup`, `coolify_backup_execution` | Core CRUD works on 4.1+. Some optional settings exist only on newer Coolify lines; omit attributes you do not need so plans stay empty on older instances. |
+| `coolify_service`, `coolify_storage` | |
+| `coolify_environment_variable`, `coolify_envs_bulk` | |
+| `coolify_private_key`, `coolify_github_app` | |
+| `coolify_cloud_token`, `coolify_cloud_token_validate` (Hetzner and generic) | |
+| `coolify_scheduled_task` | |
+| `coolify_deployment`, `coolify_resource_action` | |
+| `coolify_api_settings`, `coolify_team` / teams | |
+| `coolify_version` | Read instance version |
+| Most list/single data sources without a version note in the README | |
+
+### Requires Coolify ≥ 4.2.0
+
+| Resource / data source | Role |
+|------------------------|------|
+| `coolify_destination` / `coolify_destinations` | Docker network destinations |
+| `coolify_server_digitalocean` | Provision DO droplets into Coolify |
+| `coolify_server_vultr` | Provision Vultr instances into Coolify |
+| `coolify_digitalocean_*` data sources | regions, sizes, images, ssh_keys |
+| `coolify_vultr_*` data sources | regions, plans, os, ssh_keys |
+
+`destination_uuid` on app, database, or service create works on Coolify 4.1.0+.
+Managing destinations as `coolify_destination` (and multi-destination servers)
+needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
+
+### Requires Coolify ≥ 4.3.0
+
+| Resource / data source | Role |
+|------------------------|------|
+| `coolify_storage_backup` | Scheduled volume/directory backups (VolumeBackups API, [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946)) |
+
+## Application attributes by Coolify version
+
+Application resources share one schema. Attributes that Coolify only accepts
+from a given version are **version-gated on write**:
+
+1. Values remain in Terraform state if you set them.
+2. The client **omits** them from POST/PATCH when the instance is too old.
+3. Plan/apply emits a warning listing the attributes (see
+   [Common Errors](common-errors#coolify-version-cannot-write-some-application-settings)).
+
+### Writes require Coolify ≥ 4.2.0
+
+| Terraform attribute | API JSON key |
+|---------------------|--------------|
+| `is_preview_deployments_enabled` | `is_preview_deployments_enabled` |
+| `use_build_secrets` | `use_build_secrets` |
+| `is_git_submodules_enabled` | `is_git_submodules_enabled` |
+| `is_git_lfs_enabled` | `is_git_lfs_enabled` |
+| `is_git_shallow_clone_enabled` | `is_git_shallow_clone_enabled` |
+| `disable_build_cache` | `disable_build_cache` |
+| `inject_build_args_to_dockerfile` | `inject_build_args_to_dockerfile` |
+| `include_source_commit_in_build` | `include_source_commit_in_build` |
+| `is_env_sorting_enabled` | `is_env_sorting_enabled` |
+| `is_pr_deployments_public_enabled` | `is_pr_deployments_public_enabled` |
+| `stop_grace_period` | `stop_grace_period` |
+| `docker_images_to_keep` | `docker_images_to_keep` |
+| `is_gzip_enabled` | `is_gzip_enabled` |
+| `is_stripprefix_enabled` | `is_stripprefix_enabled` |
+| `is_raw_compose_deployment_enabled` | `is_raw_compose_deployment_enabled` |
+
+### Writes require Coolify ≥ 4.3.0
+
+| Terraform attribute | API JSON key |
+|---------------------|--------------|
+| `is_log_drain_enabled` | `is_log_drain_enabled` |
+| `is_gpu_enabled` | `is_gpu_enabled` |
+| `gpu_driver` | `gpu_driver` |
+| `gpu_count` | `gpu_count` |
+| `gpu_device_ids` | `gpu_device_ids` |
+| `gpu_options` | `gpu_options` |
+| `is_consistent_container_name_enabled` | `is_consistent_container_name_enabled` |
+| `custom_internal_name` | `custom_internal_name` |
+| `noindex_domains` | `noindex_domains` (list of domain URLs) |
+
+### Matrix (application write gates)
+
+| Attribute group | 4.1.x | 4.2.x | ≥ 4.3.0 |
+|-----------------|-------|-------|---------|
+| Core app fields (name, domains, build, limits, health checks, …) | Yes | Yes | Yes |
+| 4.2 settings / preview / build secrets (table above) | State only; no write | Yes | Yes |
+| 4.3 settings + `noindex_domains` | State only; no write | State only; no write | Yes |
+
+## What "does not work" means in practice
+
+| Situation | What you see |
+|-----------|----------------|
+| Coolify &lt; 4.1.0 | Hard error on configure |
+| Resource missing on that Coolify (e.g. storage backup on 4.2) | API 404/405/422 on apply |
+| Version-gated application attribute on older Coolify | Plan **warning**; attribute not in API payload; no 422 from that field alone |
+| You expected the withheld field to change Coolify | It will not until you upgrade Coolify (or remove the attribute) |
+
+There is no silent "half apply" for whole resources: missing endpoints fail.
+Application settings are special because older Coolify rejects the entire
+PATCH if any disallowed field is present, so the provider strips them.
+
+## Provider version vs Coolify version
+
+| Topic | Guidance |
+|-------|----------|
+| Minimum Coolify for this provider | **4.1.0** |
+| Recommended Coolify for full feature set | **≥ 4.3.0** (matches current pin) |
+| Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
+
+Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned
+provider lines; the published registry line remains **0.1.x** with a **4.1.0**
+floor.
+
+## How this stays accurate
+
+Maintainers track version-dependent API fields with:
+
+- Versioned contracts: `testdata/contracts/coolify-v4.*.json`
+- `make contract-compat` and `KNOWN_VERSION_DEPENDENT` in
+  `scripts/check-contract-compat.py`
+- Write-key lists in `internal/client/version.go`
+  (`ApplicationSettingsWriteJSONKeys`, `ApplicationSettingsV43WriteJSONKeys`)
+- Daily/6-hourly Coolify channel watch (CDN + tip source + tip contract drift)
+
+If a resource or attribute docs say `Requires Coolify >= vX.Y.Z`, that string
+is the operator-facing source of truth for that field; this guide summarizes
+the cross-cutting sets.
+
+## Related guides
+
+- [Installation](installation): install, auth, hard version check
+- [Common Errors](common-errors): plan warning text and fixes
+- [Troubleshooting](troubleshooting): DEBUG logs for withheld writes
+- [Day-2 Operations](day-two-operations): upgrading Coolify safely
+- [API Contract Accuracy](api-contract-accuracy): source-derived contract vs OpenAPI

--- a/docs/guides/day-two-operations.md
+++ b/docs/guides/day-two-operations.md
@@ -25,7 +25,8 @@ the API may gain new fields, endpoints, or changed defaults.
   it only works if your Coolify instance is v4.1+.
 - **The provider validates the Coolify version.** On every `plan` and
   `apply`, the provider checks `/api/v1/version`. If the version is
-  below v4.1.0, it refuses to continue.
+  below v4.1.0, it refuses to continue. Feature-level support (4.2 / 4.3
+  APIs) is summarized in [Coolify Version Support](coolify-version-support).
 
 ### Before upgrading
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -12,7 +12,9 @@ description: |-
 | Requirement | Minimum Version |
 |-------------|-----------------|
 | Terraform   | 1.6+            |
-| Coolify     | v4.x            |
+| Coolify     | v4.1.0+         |
+
+Instances older than v4.1.0 are rejected on `terraform plan` / `terraform apply`.
 
 ## Install from Terraform Registry
 
@@ -75,20 +77,20 @@ The provider validates the Coolify version on `terraform plan` /
 will return an error and refuse to continue. Upgrade your Coolify instance
 before using the provider.
 
-### Version compatibility matrix
+### Version compatibility
 
-The provider tracks the latest Coolify v4 release. Older Coolify versions
-may work for basic resources, but the API surface changed significantly
-between v4.0.0 and v4.1.0 (69 application fields were added), so v4.1.0
-is the minimum supported version.
+| | Coolify |
+|--|---------|
+| **Minimum (hard floor)** | **v4.1.0** |
+| **Recommended for full features** | **≥ v4.3.0** |
 
-| Provider Version | Min Coolify | Key Features |
-|-----------------|-------------|--------------|
-| 0.1.x | 4.1.0 | Core resources: projects, servers, applications, environments |
-| 0.2.x | 4.1.0 | Databases (8 types), services, environment variables, private keys |
-| 0.3.x | 4.1.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
-| 0.4.x | 4.1.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
-| 0.5.x | 4.1.0 | Server `connection_timeout`, `railpack` build pack, versioned API contracts |
+The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
+is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
+Volume backup schedules and some application settings need **≥ v4.3.0**.
+
+For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
+and how version gates behave), see
+**[Coolify Version Support](coolify-version-support)**.
 
 -> **Tip:** Run `data "coolify_version" "current" {}` to check your
 instance version programmatically.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -46,13 +46,15 @@ the raw API communication.
 [DEBUG] reading resource: resource_type=coolify_server uuid=abc-123
 [DEBUG] resource not found, removing from state: resource_type=coolify_server uuid=abc-123
 [DEBUG] withholding Coolify >= v4.2.0 application write fields unsupported on this instance: uuid=app-1 version=4.1.2 fields=[is_gzip_enabled]
+[DEBUG] withholding Coolify >= v4.3.0 application write fields unsupported on this instance: uuid=app-1 version=4.2.0 fields=[is_log_drain_enabled]
 [DEBUG] skipping post-create patch: only Coolify>=4.2.0 write fields, unsupported on this Coolify version: uuid=app-1
 ```
 
-When connected to Coolify older than v4.2.0, the provider may log that it is
-withholding application settings so the PATCH does not 422. See the
-[Common Errors](./common-errors) guide for the plan-time warning and upgrade
-guidance.
+When connected to Coolify older than the version required for a given
+application setting, the provider may log that it is withholding those fields
+so the PATCH does not 422. See the [Common Errors](./common-errors) guide and
+[Coolify Version Support](./coolify-version-support) for the plan-time warning
+and upgrade guidance.
 
 ### At TRACE Level
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Coolify gives you a self-hosted PaaS with a great UI. This provider adds what th
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.6
-- A running [Coolify](https://coolify.io/) instance (v4.x)
+- A running [Coolify](https://coolify.io/) instance (v4.1.0+)
 
 ## Authentication
 
@@ -58,6 +58,7 @@ provider "coolify" {
 
 - **[Quick Start](guides/quickstart)** - Deploy your first application in under 5 minutes
 - **[Installation](guides/installation)** - Detailed setup and configuration options
+- **[Coolify Version Support](guides/coolify-version-support)** - What works on Coolify 4.1, 4.2, and 4.3
 - **[Concepts](guides/concepts)** - How Coolify resources map to Terraform
 - **[Choosing an Application Type](guides/choosing-application-type)** - Pick the right resource for your deployment method
 - **[Connecting Resources](guides/connecting-resources)** - Wire apps to databases using Coolify's Docker networking

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -107,6 +107,9 @@ do not want an immediate deploy; the ordering is intrinsic to Coolify.
 
 ### Coolify version cannot write some application settings
 
+Full matrix of which application attributes need Coolify 4.2 vs 4.3:
+[Coolify Version Support](coolify-version-support).
+
 ```
 Warning: Coolify version cannot write some application settings
 
@@ -115,13 +118,20 @@ is_gzip_enabled, …. The provider will keep these values in Terraform state but
 will not send them to the Coolify API.
 ```
 
-**Cause:** Coolify **v4.1.x** rejects several application write fields (the
-`APPLICATION_SETTING_FIELDS` set, plus `is_preview_deployments_enabled` and
-`use_build_secrets`). The provider withholds them on PATCH so Create does not
-422, but still keeps configured values in state.
+**Cause:** Coolify rejects application write fields that are not on that
+version's allow list. The provider withholds them on PATCH so Create does not
+422, but still keeps configured values in state. The same warning title covers
+both gates:
 
-**Fix:** upgrade Coolify to **v4.2.0** or later, or remove those attributes
-from configuration. The warning is intentional; it is not a hard error.
+- Coolify **v4.1.x**: 4.2 settings (gzip, git LFS, preview deploys, build
+  secrets, and related fields)
+- Coolify **v4.2.x**: 4.3 settings (log drain, GPU, `custom_internal_name`,
+  `noindex_domains`, and related fields)
+
+**Fix:** upgrade Coolify to the version named in the warning (**v4.2.0** or
+**v4.3.0** as listed), or remove those attributes from configuration. The
+warning is intentional; it is not a hard error. Full attribute lists:
+[Coolify Version Support](coolify-version-support).
 
 ### Server has multiple destinations and you do not set destination_uuid
 

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -1,0 +1,183 @@
+---
+page_title: "Coolify Version Support"
+subcategory: "Getting Started"
+description: |-
+  What works on Coolify 4.1, 4.2, and 4.3 with this provider: resources, fields, and version-gate behavior.
+---
+
+# Coolify Version Support
+
+This guide answers: **which Coolify version do I need for each resource and field?**
+
+The provider hard-requires Coolify **v4.1.0 or later** on every `terraform plan` /
+`terraform apply`. Within that floor, some APIs only exist on newer Coolify
+lines. The provider still configures against older supported instances, but it
+**withholds** writes that would 422 and emits a **plan warning** when you set
+those attributes.
+
+-> **Check your instance** (see also [Installation](installation)):
+
+```hcl
+data "coolify_version" "current" {}
+
+output "coolify_version" {
+  value = data.coolify_version.current.version
+}
+```
+
+## Support model at a glance
+
+| Coolify | Provider behavior |
+|---------|-------------------|
+| **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
+| **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
+| **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
+| **≥ 4.3.0** | Full current surface: volume backup schedules, `noindex_domains`, GPU/log-drain application settings, etc. |
+
+Pinned API contract today: Coolify **v4.3.1** (`testdata/contracts/coolify-v4.json`).
+The provider remains usable on 4.1.0+ for the common surface.
+
+## Resources and data sources by Coolify version
+
+### Always available (Coolify ≥ 4.1.0)
+
+Core lifecycle, apps, databases, services, env vars, keys, projects, Hetzner
+cloud tokens, GitHub Apps, scheduled tasks, storage volumes, deployments,
+teams, and most list/single data sources.
+
+| Resource / data source family | Notes |
+|-------------------------------|--------|
+| `coolify_project`, `coolify_environment` | |
+| `coolify_server`, `coolify_server_hetzner`, `coolify_server_validate` | Hetzner provision path |
+| `coolify_application*` (public, docker image, dockerfile, private git, github app) | Some **attributes** need 4.2/4.3 (see below) |
+| `coolify_application_preview` | |
+| Eight database engines + `coolify_database_backup`, `coolify_backup_execution` | Core CRUD works on 4.1+. Some optional settings exist only on newer Coolify lines; omit attributes you do not need so plans stay empty on older instances. |
+| `coolify_service`, `coolify_storage` | |
+| `coolify_environment_variable`, `coolify_envs_bulk` | |
+| `coolify_private_key`, `coolify_github_app` | |
+| `coolify_cloud_token`, `coolify_cloud_token_validate` (Hetzner and generic) | |
+| `coolify_scheduled_task` | |
+| `coolify_deployment`, `coolify_resource_action` | |
+| `coolify_api_settings`, `coolify_team` / teams | |
+| `coolify_version` | Read instance version |
+| Most list/single data sources without a version note in the README | |
+
+### Requires Coolify ≥ 4.2.0
+
+| Resource / data source | Role |
+|------------------------|------|
+| `coolify_destination` / `coolify_destinations` | Docker network destinations |
+| `coolify_server_digitalocean` | Provision DO droplets into Coolify |
+| `coolify_server_vultr` | Provision Vultr instances into Coolify |
+| `coolify_digitalocean_*` data sources | regions, sizes, images, ssh_keys |
+| `coolify_vultr_*` data sources | regions, plans, os, ssh_keys |
+
+`destination_uuid` on app, database, or service create works on Coolify 4.1.0+.
+Managing destinations as `coolify_destination` (and multi-destination servers)
+needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
+
+### Requires Coolify ≥ 4.3.0
+
+| Resource / data source | Role |
+|------------------------|------|
+| `coolify_storage_backup` | Scheduled volume/directory backups (VolumeBackups API, [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946)) |
+
+## Application attributes by Coolify version
+
+Application resources share one schema. Attributes that Coolify only accepts
+from a given version are **version-gated on write**:
+
+1. Values remain in Terraform state if you set them.
+2. The client **omits** them from POST/PATCH when the instance is too old.
+3. Plan/apply emits a warning listing the attributes (see
+   [Common Errors](common-errors#coolify-version-cannot-write-some-application-settings)).
+
+### Writes require Coolify ≥ 4.2.0
+
+| Terraform attribute | API JSON key |
+|---------------------|--------------|
+| `is_preview_deployments_enabled` | `is_preview_deployments_enabled` |
+| `use_build_secrets` | `use_build_secrets` |
+| `is_git_submodules_enabled` | `is_git_submodules_enabled` |
+| `is_git_lfs_enabled` | `is_git_lfs_enabled` |
+| `is_git_shallow_clone_enabled` | `is_git_shallow_clone_enabled` |
+| `disable_build_cache` | `disable_build_cache` |
+| `inject_build_args_to_dockerfile` | `inject_build_args_to_dockerfile` |
+| `include_source_commit_in_build` | `include_source_commit_in_build` |
+| `is_env_sorting_enabled` | `is_env_sorting_enabled` |
+| `is_pr_deployments_public_enabled` | `is_pr_deployments_public_enabled` |
+| `stop_grace_period` | `stop_grace_period` |
+| `docker_images_to_keep` | `docker_images_to_keep` |
+| `is_gzip_enabled` | `is_gzip_enabled` |
+| `is_stripprefix_enabled` | `is_stripprefix_enabled` |
+| `is_raw_compose_deployment_enabled` | `is_raw_compose_deployment_enabled` |
+
+### Writes require Coolify ≥ 4.3.0
+
+| Terraform attribute | API JSON key |
+|---------------------|--------------|
+| `is_log_drain_enabled` | `is_log_drain_enabled` |
+| `is_gpu_enabled` | `is_gpu_enabled` |
+| `gpu_driver` | `gpu_driver` |
+| `gpu_count` | `gpu_count` |
+| `gpu_device_ids` | `gpu_device_ids` |
+| `gpu_options` | `gpu_options` |
+| `is_consistent_container_name_enabled` | `is_consistent_container_name_enabled` |
+| `custom_internal_name` | `custom_internal_name` |
+| `noindex_domains` | `noindex_domains` (list of domain URLs) |
+
+### Matrix (application write gates)
+
+| Attribute group | 4.1.x | 4.2.x | ≥ 4.3.0 |
+|-----------------|-------|-------|---------|
+| Core app fields (name, domains, build, limits, health checks, …) | Yes | Yes | Yes |
+| 4.2 settings / preview / build secrets (table above) | State only; no write | Yes | Yes |
+| 4.3 settings + `noindex_domains` | State only; no write | State only; no write | Yes |
+
+## What "does not work" means in practice
+
+| Situation | What you see |
+|-----------|----------------|
+| Coolify &lt; 4.1.0 | Hard error on configure |
+| Resource missing on that Coolify (e.g. storage backup on 4.2) | API 404/405/422 on apply |
+| Version-gated application attribute on older Coolify | Plan **warning**; attribute not in API payload; no 422 from that field alone |
+| You expected the withheld field to change Coolify | It will not until you upgrade Coolify (or remove the attribute) |
+
+There is no silent "half apply" for whole resources: missing endpoints fail.
+Application settings are special because older Coolify rejects the entire
+PATCH if any disallowed field is present, so the provider strips them.
+
+## Provider version vs Coolify version
+
+| Topic | Guidance |
+|-------|----------|
+| Minimum Coolify for this provider | **4.1.0** |
+| Recommended Coolify for full feature set | **≥ 4.3.0** (matches current pin) |
+| Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
+
+Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned
+provider lines; the published registry line remains **0.1.x** with a **4.1.0**
+floor.
+
+## How this stays accurate
+
+Maintainers track version-dependent API fields with:
+
+- Versioned contracts: `testdata/contracts/coolify-v4.*.json`
+- `make contract-compat` and `KNOWN_VERSION_DEPENDENT` in
+  `scripts/check-contract-compat.py`
+- Write-key lists in `internal/client/version.go`
+  (`ApplicationSettingsWriteJSONKeys`, `ApplicationSettingsV43WriteJSONKeys`)
+- Daily/6-hourly Coolify channel watch (CDN + tip source + tip contract drift)
+
+If a resource or attribute docs say `Requires Coolify >= vX.Y.Z`, that string
+is the operator-facing source of truth for that field; this guide summarizes
+the cross-cutting sets.
+
+## Related guides
+
+- [Installation](installation): install, auth, hard version check
+- [Common Errors](common-errors): plan warning text and fixes
+- [Troubleshooting](troubleshooting): DEBUG logs for withheld writes
+- [Day-2 Operations](day-two-operations): upgrading Coolify safely
+- [API Contract Accuracy](api-contract-accuracy): source-derived contract vs OpenAPI

--- a/templates/guides/day-two-operations.md.tmpl
+++ b/templates/guides/day-two-operations.md.tmpl
@@ -25,7 +25,8 @@ the API may gain new fields, endpoints, or changed defaults.
   it only works if your Coolify instance is v4.1+.
 - **The provider validates the Coolify version.** On every `plan` and
   `apply`, the provider checks `/api/v1/version`. If the version is
-  below v4.1.0, it refuses to continue.
+  below v4.1.0, it refuses to continue. Feature-level support (4.2 / 4.3
+  APIs) is summarized in [Coolify Version Support](coolify-version-support).
 
 ### Before upgrading
 

--- a/templates/guides/installation.md.tmpl
+++ b/templates/guides/installation.md.tmpl
@@ -12,7 +12,9 @@ description: |-
 | Requirement | Minimum Version |
 |-------------|-----------------|
 | Terraform   | 1.6+            |
-| Coolify     | v4.x            |
+| Coolify     | v4.1.0+         |
+
+Instances older than v4.1.0 are rejected on `terraform plan` / `terraform apply`.
 
 ## Install from Terraform Registry
 
@@ -75,20 +77,20 @@ The provider validates the Coolify version on `terraform plan` /
 will return an error and refuse to continue. Upgrade your Coolify instance
 before using the provider.
 
-### Version compatibility matrix
+### Version compatibility
 
-The provider tracks the latest Coolify v4 release. Older Coolify versions
-may work for basic resources, but the API surface changed significantly
-between v4.0.0 and v4.1.0 (69 application fields were added), so v4.1.0
-is the minimum supported version.
+| | Coolify |
+|--|---------|
+| **Minimum (hard floor)** | **v4.1.0** |
+| **Recommended for full features** | **≥ v4.3.0** |
 
-| Provider Version | Min Coolify | Key Features |
-|-----------------|-------------|--------------|
-| 0.1.x | 4.1.0 | Core resources: projects, servers, applications, environments |
-| 0.2.x | 4.1.0 | Databases (8 types), services, environment variables, private keys |
-| 0.3.x | 4.1.0 | Cloud tokens (Hetzner), GitHub Apps, scheduled tasks, storage |
-| 0.4.x | 4.1.0 | Database SSL/TLS (`enable_ssl`, `ssl_mode`), log drain settings, custom TLS CA |
-| 0.5.x | 4.1.0 | Server `connection_timeout`, `railpack` build pack, versioned API contracts |
+The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
+is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
+Volume backup schedules and some application settings need **≥ v4.3.0**.
+
+For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
+and how version gates behave), see
+**[Coolify Version Support](coolify-version-support)**.
 
 -> **Tip:** Run `data "coolify_version" "current" {}` to check your
 instance version programmatically.

--- a/templates/guides/troubleshooting.md.tmpl
+++ b/templates/guides/troubleshooting.md.tmpl
@@ -46,13 +46,15 @@ the raw API communication.
 [DEBUG] reading resource: resource_type=coolify_server uuid=abc-123
 [DEBUG] resource not found, removing from state: resource_type=coolify_server uuid=abc-123
 [DEBUG] withholding Coolify >= v4.2.0 application write fields unsupported on this instance: uuid=app-1 version=4.1.2 fields=[is_gzip_enabled]
+[DEBUG] withholding Coolify >= v4.3.0 application write fields unsupported on this instance: uuid=app-1 version=4.2.0 fields=[is_log_drain_enabled]
 [DEBUG] skipping post-create patch: only Coolify>=4.2.0 write fields, unsupported on this Coolify version: uuid=app-1
 ```
 
-When connected to Coolify older than v4.2.0, the provider may log that it is
-withholding application settings so the PATCH does not 422. See the
-[Common Errors](./common-errors) guide for the plan-time warning and upgrade
-guidance.
+When connected to Coolify older than the version required for a given
+application setting, the provider may log that it is withholding those fields
+so the PATCH does not 422. See the [Common Errors](./common-errors) guide and
+[Coolify Version Support](./coolify-version-support) for the plan-time warning
+and upgrade guidance.
 
 ### At TRACE Level
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,7 +16,7 @@ Coolify gives you a self-hosted PaaS with a great UI. This provider adds what th
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.6
-- A running [Coolify](https://coolify.io/) instance (v4.x)
+- A running [Coolify](https://coolify.io/) instance (v4.1.0+)
 
 ## Authentication
 
@@ -49,6 +49,7 @@ export COOLIFY_CF_ACCESS_CLIENT_SECRET="your-cf-client-secret"
 
 - **[Quick Start](guides/quickstart)** - Deploy your first application in under 5 minutes
 - **[Installation](guides/installation)** - Detailed setup and configuration options
+- **[Coolify Version Support](guides/coolify-version-support)** - What works on Coolify 4.1, 4.2, and 4.3
 - **[Concepts](guides/concepts)** - How Coolify resources map to Terraform
 - **[Choosing an Application Type](guides/choosing-application-type)** - Pick the right resource for your deployment method
 - **[Connecting Resources](guides/connecting-resources)** - Wire apps to databases using Coolify's Docker networking


### PR DESCRIPTION
## Summary

Adds a single operator-facing guide that answers **what works on Coolify 4.1 vs 4.2 vs 4.3**:

- Hard floor: Coolify **v4.1.0**
- Resources needing **4.2** (destinations, DO/Vultr) and **4.3** (`coolify_storage_backup`)
- Application write gates (4.2 settings vs 4.3 settings + `noindex_domains`)
- Soft withhold + plan warning vs hard missing endpoints

Links from Installation, docs index, Common Errors, Day-2, Troubleshooting, and README.

Reviewer pass applied before open (prereq floor, operator wording, 4.3 warning path).

## Test plan

- [x] `make docs` / `make docs-check`
- [x] No em dashes; no banned marketing words
- [ ] CI green
- [ ] Auto-merge after green