### PR TITLE
ci: harden lychee and GoReleaser against GitHub flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,12 +218,21 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
+      # goreleaser-action downloads the binary from GitHub releases; CDN
+      # flakes (socket hang up) should not fail the whole Lint job. Real
+      # .goreleaser.yml breakage still surfaces on the release workflow.
       - name: GoReleaser check
         if: ${{ !cancelled() && (needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch') }}
+        id: goreleaser-check
+        continue-on-error: true
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: "~> 2"
           args: check
+      - name: Warn if GoReleaser check failed
+        if: ${{ steps.goreleaser-check.outcome == 'failure' }}
+        run: |
+          echo "::warning::GoReleaser check failed (often a GitHub releases download flake). Config is still validated on the release workflow."
 
   validate:
     name: Validate

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -41,4 +41,7 @@ jobs:
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --no-progress --exclude-path docs --config lychee.toml '**/*.md'
-          fail: true
+          # External hosts flake (GitHub HTTP/2, CDN). Soft-fail on PRs so
+          # release-please and docs PRs are not blocked; hard-fail on main
+          # and the weekly schedule so real doc rot still surfaces.
+          fail: ${{ github.event_name != 'pull_request' }}

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,13 @@
+# Retries help with intermittent GitHub transport errors on remaining links.
+max_retries = 5
+retry_wait_time = 3
+
+# release-please CHANGELOG is dense with commit/issue/PR URLs. Concurrent
+# checks against github.com produce HTTP/2 protocol errors in CI (not real
+# 404s). Link value there is low vs README/docs; compare/tag race is already
+# excluded below. See PR #687 / lychee skill lesson on CHANGELOG load.
+exclude_path = ["CHANGELOG.md"]
+
 exclude = [
   "localhost",
   "127\\.0\\.0\\.1",


### PR DESCRIPTION
## Summary

- **Link check / PR #687:** exclude `CHANGELOG.md` from lychee (release-please commit/issue density triggers GitHub HTTP/2 protocol errors, not real 404s); add retries; soft-fail link check on pull requests while hard-failing on main and the weekly schedule.
- **Main Lint:** make GoReleaser check `continue-on-error` with a warning, matching the OpenTofu install hardening from #689. The failure mode was `socket hang up` downloading the goreleaser binary from GitHub releases.

## Why

| Failure | Cause |
|---------|--------|
| PR #687 Check Links | 137× HTTP/2 protocol errors on CHANGELOG GitHub URLs |
| Main Lint after #689 | GoReleaser action download `socket hang up` |

Neither is product code. Tests, Validate, Acc, and Scenarios were green.

## Test plan

- [x] Local `lychee --config lychee.toml --offline README.md` → 0 errors (CHANGELOG excluded)
- [x] actionlint on changed workflows (only pre-existing `code-quality` permission note)
- [ ] CI green on this PR (Lint + Link Check)
- [ ] After merge, release-please PR #687 can re-run Check Links without CHANGELOG noise