### PR TITLE
ci: retry gitleaks install and skip Validate for CHANGELOG-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
               - 'templates/**'
               - 'docs/**'
               - '*.md'
+              # release-please / release override files: not provider docs.
+              # Matching them alone must not force full Validate (fmt, docs gen,
+              # Trivy, Gitleaks) on every version-bump PR.
+              - '!CHANGELOG.md'
+              - '!RELEASE_NOTES.md'
             terraform:
               - 'examples/**/*.tf'
             ci:
@@ -331,6 +336,8 @@ jobs:
             echo "::error::Trivy scan failed (tried fresh download and cached DB)"
             exit 1
           fi
+      # Download can flake (empty archive / socket hang from GitHub releases).
+      # Retry to a temp file before tar; do not pipe curl into tar.
       - name: Gitleaks
         if: ${{ !cancelled() }}
         env:
@@ -339,6 +346,7 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          set -euo pipefail
           VER="8.30.1"
           BIN_DIR="$HOME/.local/bin"
           export PATH="$BIN_DIR:$PATH"
@@ -347,8 +355,24 @@ jobs:
             OS=$(uname -s | tr '[:upper:]' '[:lower:]')
             ARCH=$(uname -m)
             case "$ARCH" in x86_64) ARCH="x64" ;; aarch64|arm64) ARCH="arm64" ;; esac
-            curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_${OS}_${ARCH}.tar.gz" \
-              | tar xz -C "$BIN_DIR" gitleaks
+            URL="https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_${OS}_${ARCH}.tar.gz"
+            TMP="$(mktemp)"
+            ok=0
+            for attempt in 1 2 3; do
+              if curl -sfL --retry 3 --retry-delay 2 --retry-all-errors -o "$TMP" "$URL" \
+                && tar tzf "$TMP" gitleaks >/dev/null 2>&1 \
+                && tar xzf "$TMP" -C "$BIN_DIR" gitleaks; then
+                ok=1
+                break
+              fi
+              echo "::warning::Gitleaks download/extract failed (attempt ${attempt}/3)"
+              sleep $((attempt * 2))
+            done
+            rm -f "$TMP"
+            if [ "$ok" != "1" ]; then
+              echo "::error::Failed to install gitleaks v${VER} after 3 attempts (GitHub releases flake)"
+              exit 1
+            fi
           fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             gitleaks detect --source . --config .gitleaks.toml --log-opts="${PR_BASE_SHA}..HEAD" --exit-code 1


### PR DESCRIPTION
## Summary

- **Gitleaks install:** download to a temp file with curl retries, verify the archive lists `gitleaks`, then extract; up to 3 outer attempts. Avoids `curl | tar` failing with empty/corrupt GitHub releases payloads (what failed Validate on release PR #687).
- **Path filter:** exclude `CHANGELOG.md` and `RELEASE_NOTES.md` from the `docs` filter so release-please / release-notes-only PRs do not trigger full Validate (fmt, docs gen, Trivy, Gitleaks) when nothing else changed.

## Context

PR #687 only changes `CHANGELOG.md` + `.release-please-manifest.json`. Test/Lint/Acc correctly skip, but `*.md` matched `docs` and forced Validate. Gitleaks then flaked on install (`tar: Child returned status 1`).

Also re-ran failed jobs on #687 while this lands.

## Test plan

- [x] Diff limited to `ci.yml`
- [ ] CI green on this PR (Validate path exercises gitleaks install)
- [ ] After merge, release-please re-sync of #687 should skip Validate when only CHANGELOG changes