### PR TITLE
fix: S3 docs accuracy, CI scenario path filter, DS error IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,13 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/ci.yml'
             scenarios:
+              # Product + scenario HCL only. Do not include ci.yml alone: every
+              # workflow-only PR was running the full ~45m Coolify scenario
+              # suite (path filter true from the workflow path). Edit the
+              # scenario-tests job via workflow_dispatch or after an internal/
+              # scenarios change when you need that matrix.
               - 'internal/**'
               - 'examples/scenarios/**'
-              - '.github/workflows/ci.yml'
 
   dco:
     name: DCO

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,12 +26,10 @@ Telegram, etc.) once the upstream API supports full CRUD.
 ([#394](https://github.com/coolify-terraform/terraform-provider-coolify/issues/394),
 blocked on upstream)
 
-### S3 storage resource
+### ~~S3 storage resource~~ (shipped)
 
-Add a `coolify_s3_storage` resource for managing S3-compatible backup
-destinations once the upstream API exposes top-level S3 storage endpoints.
-([#393](https://github.com/coolify-terraform/terraform-provider-coolify/issues/393),
-blocked on upstream)
+`coolify_s3_storage` and `coolify_s3_storages` ship for Coolify >= v4.3.0
+(provider v0.1.14+). See the [version support guide](https://registry.terraform.io/providers/coolify-terraform/coolify/latest/docs/guides/coolify-version-support).
 
 ## Medium Term
 

--- a/docs/guides/day-two-operations.md
+++ b/docs/guides/day-two-operations.md
@@ -74,7 +74,7 @@ before upgrading. Breaking changes are listed under the **Breaking Changes**
 section. Common breaking changes include:
 
 - Renamed attributes (e.g., `host` to `endpoint`, `retain_days` to `retain_amount_locally`)
-- Removed resources (e.g., `coolify_s3_storage` was removed because the API endpoint no longer exists)
+- Removed or replaced resources (check the upgrade notes in the release)
 - Changed attribute types or validation rules
 
 After upgrading:

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -30,7 +30,14 @@ terraform import coolify_database_postgresql.db <db-uuid>
 terraform import coolify_service.plausible <service-uuid>
 terraform import coolify_private_key.deploy <key-uuid>
 terraform import coolify_cloud_token.hetzner <token-uuid>
+terraform import coolify_s3_storage.backups <s3-storage-uuid>
 ```
+
+~> **Note:** After importing `coolify_s3_storage`, keep `key` and `secret` in
+your configuration. Coolify may omit those sensitive fields on read unless the
+API token can read sensitive data. When `coolify_database_backup` uses
+`save_s3 = true`, set `s3_storage_uuid` to a managed or existing storage UUID
+(for example `coolify_s3_storage.backups.uuid`).
 
 ### Compound Import Format (Recommended for Applications, Databases, and Services)
 
@@ -60,11 +67,6 @@ is not corrected on refresh. On replace, Terraform would recreate the resource
 on the wrong server. Compound import for applications, databases, and services
 validates membership via `GET /servers/{server_uuid}/resources` and fails if
 the resource is not listed on that server.
-
-~> **Note:** Top-level S3 storages are managed in the Coolify web UI. When
-`coolify_database_backup` uses `save_s3 = true`, set `s3_storage_uuid` to an
-existing storage UUID.
-
 
 The `coolify_github_app` resource uses the **GitHub App ID** (shown as "App Id" in the Coolify UI under Sources), not a UUID or internal database ID:
 

--- a/internal/service/cloudtoken/data_source.go
+++ b/internal/service/cloudtoken/data_source.go
@@ -79,9 +79,10 @@ func (d *cloudTokenDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_cloud_token"})
 
-	ct, err := d.client.GetCloudToken(ctx, config.UUID.ValueString())
+	uuid := config.UUID.ValueString()
+	ct, err := d.client.GetCloudToken(ctx, uuid)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading cloud token", fmt.Sprintf("Could not read cloud token: %s", err))
+		resp.Diagnostics.AddError("Error reading cloud token", fmt.Sprintf("Could not read cloud token %s: %s", uuid, err))
 		return
 	}
 

--- a/internal/service/cloudtoken/data_source_test.go
+++ b/internal/service/cloudtoken/data_source_test.go
@@ -58,7 +58,7 @@ func TestCloudTokenDataSource_NotFound(t *testing.T) {
 data "coolify_cloud_token" "test" {
   uuid = "00000000-0000-4000-8000-000000000000"
 }`,
-				ExpectError: regexp.MustCompile(`Error reading cloud token`),
+				ExpectError: regexp.MustCompile(`(?s)Error reading cloud token.*00000000-0000-4000-8000-000000000000`),
 			},
 		},
 	})

--- a/internal/service/environment/data_source.go
+++ b/internal/service/environment/data_source.go
@@ -79,9 +79,11 @@ func (d *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_environment"})
 
-	env, err := d.client.GetEnvironment(ctx, config.ProjectUUID.ValueString(), config.Name.ValueString())
+	projectUUID := config.ProjectUUID.ValueString()
+	name := config.Name.ValueString()
+	env, err := d.client.GetEnvironment(ctx, projectUUID, name)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading environment", fmt.Sprintf("Could not read environment: %s", err))
+		resp.Diagnostics.AddError("Error reading environment", fmt.Sprintf("Could not read environment %q in project %s: %s", name, projectUUID, err))
 		return
 	}
 

--- a/internal/service/environment/data_source_test.go
+++ b/internal/service/environment/data_source_test.go
@@ -60,7 +60,7 @@ data "coolify_environment" "test" {
   project_uuid = "00000000-0000-4000-8000-000000000000"
   name         = "nonexistent"
 }`,
-				ExpectError: regexp.MustCompile(`Error reading environment`),
+				ExpectError: regexp.MustCompile(`(?s)Error reading environment.*"nonexistent".*00000000-0000-4000-8000-000000000000`),
 			},
 		},
 	})

--- a/internal/service/project/data_source.go
+++ b/internal/service/project/data_source.go
@@ -74,9 +74,10 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_project"})
 
-	project, err := d.client.GetProject(ctx, config.UUID.ValueString())
+	uuid := config.UUID.ValueString()
+	project, err := d.client.GetProject(ctx, uuid)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading project", fmt.Sprintf("Could not read project: %s", err))
+		resp.Diagnostics.AddError("Error reading project", fmt.Sprintf("Could not read project %s: %s", uuid, err))
 		return
 	}
 

--- a/internal/service/project/data_source_test.go
+++ b/internal/service/project/data_source_test.go
@@ -57,7 +57,7 @@ func TestProjectDataSource_NotFound(t *testing.T) {
 data "coolify_project" "test" {
   uuid = "00000000-0000-4000-8000-000000000000"
 }`,
-				ExpectError: regexp.MustCompile(`Error reading project`),
+				ExpectError: regexp.MustCompile(`(?s)Error reading project.*00000000-0000-4000-8000-000000000000`),
 			},
 		},
 	})

--- a/internal/service/s3storage/data_source.go
+++ b/internal/service/s3storage/data_source.go
@@ -95,9 +95,10 @@ func (d *s3StorageDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": "coolify_s3_storage"})
 
-	s, err := d.client.GetS3Storage(ctx, config.UUID.ValueString())
+	uuid := config.UUID.ValueString()
+	s, err := d.client.GetS3Storage(ctx, uuid)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading S3 storage", fmt.Sprintf("Could not read s3 storage: %s", err))
+		resp.Diagnostics.AddError("Error reading S3 storage", fmt.Sprintf("Could not read s3 storage %s: %s", uuid, err))
 		return
 	}
 

--- a/internal/service/s3storage/data_source_test.go
+++ b/internal/service/s3storage/data_source_test.go
@@ -63,7 +63,7 @@ func TestS3StorageDataSource_NotFound(t *testing.T) {
 data "coolify_s3_storage" "test" {
   uuid = "00000000-0000-4000-8000-000000000000"
 }`,
-				ExpectError: regexp.MustCompile(`Error reading S3 storage`),
+				ExpectError: regexp.MustCompile(`(?s)Error reading S3 storage.*00000000-0000-4000-8000-000000000000`),
 			},
 		},
 	})

--- a/templates/guides/day-two-operations.md.tmpl
+++ b/templates/guides/day-two-operations.md.tmpl
@@ -74,7 +74,7 @@ before upgrading. Breaking changes are listed under the **Breaking Changes**
 section. Common breaking changes include:
 
 - Renamed attributes (e.g., `host` to `endpoint`, `retain_days` to `retain_amount_locally`)
-- Removed resources (e.g., `coolify_s3_storage` was removed because the API endpoint no longer exists)
+- Removed or replaced resources (check the upgrade notes in the release)
 - Changed attribute types or validation rules
 
 After upgrading:

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -30,7 +30,14 @@ terraform import coolify_database_postgresql.db <db-uuid>
 terraform import coolify_service.plausible <service-uuid>
 terraform import coolify_private_key.deploy <key-uuid>
 terraform import coolify_cloud_token.hetzner <token-uuid>
+terraform import coolify_s3_storage.backups <s3-storage-uuid>
 ```
+
+~> **Note:** After importing `coolify_s3_storage`, keep `key` and `secret` in
+your configuration. Coolify may omit those sensitive fields on read unless the
+API token can read sensitive data. When `coolify_database_backup` uses
+`save_s3 = true`, set `s3_storage_uuid` to a managed or existing storage UUID
+(for example `coolify_s3_storage.backups.uuid`).
 
 ### Compound Import Format (Recommended for Applications, Databases, and Services)
 
@@ -60,11 +67,6 @@ is not corrected on refresh. On replace, Terraform would recreate the resource
 on the wrong server. Compound import for applications, databases, and services
 validates membership via `GET /servers/{server_uuid}/resources` and fails if
 the resource is not listed on that server.
-
-~> **Note:** Top-level S3 storages are managed in the Coolify web UI. When
-`coolify_database_backup` uses `save_s3 = true`, set `s3_storage_uuid` to an
-existing storage UUID.
-
 
 The `coolify_github_app` resource uses the **GitHub App ID** (shown as "App Id" in the Coolify UI under Sources), not a UUID or internal database ID:
 


### PR DESCRIPTION
## Summary

MPI batch after CI flake work:

1. **Docs:** remove false claim that `coolify_s3_storage` was removed; document
   import; mark ROADMAP S3 item shipped (v4.3.0 / provider v0.1.14+).
2. **CI:** stop treating `.github/workflows/ci.yml` alone as a Scenario Tests
   trigger so workflow-only PRs do not force the full Coolify scenario suite.
3. **Observability:** include resource IDs in data source read errors for
   `coolify_s3_storage`, `coolify_cloud_token`, `coolify_project`, and
   `coolify_environment`; strengthen NotFound unit tests.

## Test plan

- [x] `go test -race` on s3storage, cloudtoken, project, environment
- [x] `make docs` regenerated guides
- [ ] CI green

Closes nothing (docs/CI/error-message hygiene). Related issues filed for
s3 validate action and shared read-back helpers.