### PR TITLE
test: require tip Coolify APIs on edge and cover v4.3 app settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,8 @@ jobs:
           COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE: ${{ secrets.COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE }}
           COOLIFY_GITHUB_APP_REPOSITORY: ${{ secrets.COOLIFY_GITHUB_APP_REPOSITORY }}
           COOLIFY_GITHUB_APP_BRANCH: ${{ secrets.COOLIFY_GITHUB_APP_BRANCH }}
+          # PR CI boots edge: tip-only APIs (S3, volume backup) must exist.
+          COOLIFY_REQUIRE_TIP_APIS: "1"
         run: |
           # Load credentials from bootstrap
           set -a

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -190,6 +190,9 @@ jobs:
           COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE: ${{ secrets.COOLIFY_GITHUB_APP_PRIVATE_KEY_FILE }}
           COOLIFY_GITHUB_APP_REPOSITORY: ${{ secrets.COOLIFY_GITHUB_APP_REPOSITORY }}
           COOLIFY_GITHUB_APP_BRANCH: ${{ secrets.COOLIFY_GITHUB_APP_BRANCH }}
+          # tip-edge must expose claimed tip APIs (S3, volume backup, S3 UUID).
+          # stable/floor keep skip-if-missing so older images stay soft.
+          COOLIFY_REQUIRE_TIP_APIS: ${{ matrix.coolify_image == 'edge' && '1' || '0' }}
         run: |
           set -euo pipefail
           set -a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,13 @@ started by hand:
 2. Choose profile `tip-and-stable` (faster) or `all` (includes floor `4.1.2`)
 3. Wait for the **Nightly gate** job to go green
 
-This workflow is not a required status check on pull requests. Tip-only APIs
-(S3 storage, volume backups) skip on older images via `AccTestSkipIf*` helpers.
+This workflow is not a required status check on pull requests.
+
+**Tip vs older images:** on `edge` (PR Acceptance Tests and nightly tip-edge),
+`COOLIFY_REQUIRE_TIP_APIS=1` makes missing tip APIs **fail** (S3 storage
+controller, volume backup controller, bootstrap `COOLIFY_S3_STORAGE_UUID`,
+Coolify ≥ 4.3 for v4.3 application settings acc). On `latest` / `4.1.2`, those
+probes still **skip** so older images remain soft without claiming tip features.
 
 ### Code Quality
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -412,7 +412,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 33/33 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 110
+- **Total acceptance test functions**: 111
 
 ### Testing strategies for edge cases
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -531,12 +531,35 @@ func AccCheckResourceDisappears(resourceAddr, apiDeletePath string) resource.Tes
 	}
 }
 
+// requireTipAPIs reports whether tip-only Coolify surfaces must be present.
+// Set COOLIFY_REQUIRE_TIP_APIS=1 on jobs that boot coollabsio/coolify:edge
+// (PR Acceptance Tests + Coolify Nightly Acc tip-edge) so missing S3 storage,
+// volume backup, or bootstrap S3 UUID fails the run instead of silently
+// skipping features the version-support guide claims on tip.
+func requireTipAPIs() bool {
+	v := strings.TrimSpace(os.Getenv("COOLIFY_REQUIRE_TIP_APIS"))
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// accTestMissingFeature skips unless COOLIFY_REQUIRE_TIP_APIS is set, in which
+// case it fails the test (tip must expose claimed APIs).
+func accTestMissingFeature(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if requireTipAPIs() {
+		t.Fatalf("tip Coolify is missing a claimed feature (COOLIFY_REQUIRE_TIP_APIS=1): %s", msg)
+	}
+	t.Skip(msg)
+}
+
 // AccTestSkipIfNoVolumeBackupAPI skips when Coolify lacks VolumeBackupsController
 // (PUT/DELETE .../storages/{uuid}/backups from coollabsio/coolify#10946).
 //
 // That API is on Coolify branch v4.x after the merge; it is not in git tag
 // v4.2.0 or stable CDN latest. CI boots coollabsio/coolify:edge (v4.x tip).
 // Locally set LATEST_IMAGE=edge (or a post-#10946 sha-... tag) before compose up.
+//
+// When COOLIFY_REQUIRE_TIP_APIS=1, a missing controller fails instead of skips.
 //
 // Probe strategy: PUT a schedule for non-existent parent/storage UUIDs.
 // Present controller returns 404 resource/storage, 422 validation, or 401/403.
@@ -559,7 +582,8 @@ func AccTestSkipIfNoVolumeBackupAPI(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Skipf("volume backup API probe failed (cannot reach Coolify): %v", err)
+		accTestMissingFeature(t, "volume backup API probe failed (cannot reach Coolify): %v", err)
+		return
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
@@ -588,20 +612,21 @@ func AccTestSkipIfNoVolumeBackupAPI(t *testing.T) {
 			strings.Contains(msg, "page not found") ||
 			strings.TrimSpace(msg) == "" ||
 			strings.Contains(msg, "<html") {
-			t.Skipf("Coolify instance has no VolumeBackupsController (HTTP %d). "+
+			accTestMissingFeature(t, "Coolify instance has no VolumeBackupsController (HTTP %d). "+
 				"Need image tip after coollabsio/coolify#10946 (CI uses coollabsio/coolify:edge; "+
 				"local: set LATEST_IMAGE=edge in Coolify compose .env). Body: %s",
 				resp.StatusCode, truncateForSkip(string(body), 200))
+			return
 		}
 		// Unknown 404 body: treat as present (resource not found variants).
 		return
 	case http.StatusMethodNotAllowed:
-		t.Skipf("Coolify instance has no volume backup PUT route (HTTP 405). " +
+		accTestMissingFeature(t, "Coolify instance has no volume backup PUT route (HTTP 405). "+
 			"Need tip after coollabsio/coolify#10946 (coollabsio/coolify:edge)")
 	default:
 		// 200/201 should not happen for fake UUIDs; other codes still mean a handler ran.
 		if resp.StatusCode >= 500 {
-			t.Skipf("volume backup API probe returned HTTP %d (server error); skipping: %s",
+			accTestMissingFeature(t, "volume backup API probe returned HTTP %d (server error): %s",
 				resp.StatusCode, truncateForSkip(string(body), 200))
 		}
 	}
@@ -617,18 +642,21 @@ func truncateForSkip(s string, n int) string {
 
 // AccTestS3StorageUUID returns the UUID of an S3 storage destination for
 // acceptance tests. Set COOLIFY_S3_STORAGE_UUID to the UUID of an S3
-// storage registered in Coolify. The test is skipped if not set.
+// storage registered in Coolify. The test is skipped if not set (or fails when
+// COOLIFY_REQUIRE_TIP_APIS=1; tip bootstrap must create minio-test).
 func AccTestS3StorageUUID(t *testing.T) string {
 	t.Helper()
 	v := os.Getenv("COOLIFY_S3_STORAGE_UUID")
 	if v == "" {
-		t.Skip("COOLIFY_S3_STORAGE_UUID not set, skipping S3 backup test")
+		accTestMissingFeature(t, "COOLIFY_S3_STORAGE_UUID not set (tip bootstrap should register minio-test S3 storage)")
 	}
 	return v
 }
 
 // AccTestSkipIfNoS3StorageAPI skips when Coolify lacks S3StoragesController
 // (GET/POST /api/v1/s3-storages from Coolify >= v4.3.0).
+//
+// When COOLIFY_REQUIRE_TIP_APIS=1, a missing controller fails instead of skips.
 //
 // Probe strategy: GET /api/v1/s3-storages.
 // Present controller returns 200 (list) or 401/403.
@@ -649,7 +677,8 @@ func AccTestSkipIfNoS3StorageAPI(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Skipf("s3 storage API probe failed (cannot reach Coolify): %v", err)
+		accTestMissingFeature(t, "s3 storage API probe failed (cannot reach Coolify): %v", err)
+		return
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
@@ -664,19 +693,39 @@ func AccTestSkipIfNoS3StorageAPI(t *testing.T) {
 			strings.Contains(msg, "page not found") ||
 			strings.TrimSpace(msg) == "" ||
 			strings.Contains(msg, "<html") {
-			t.Skipf("Coolify instance has no S3StoragesController (HTTP %d). "+
+			accTestMissingFeature(t, "Coolify instance has no S3StoragesController (HTTP %d). "+
 				"Need Coolify >= v4.3.0. Body: %s",
 				resp.StatusCode, truncateForSkip(string(body), 200))
+			return
 		}
 		return
 	case http.StatusMethodNotAllowed:
-		t.Skip("Coolify instance has no S3 storage GET route (HTTP 405). Need Coolify >= v4.3.0")
+		accTestMissingFeature(t, "Coolify instance has no S3 storage GET route (HTTP 405). Need Coolify >= v4.3.0")
 	default:
 		if resp.StatusCode >= 500 {
-			t.Skipf("s3 storage API probe returned HTTP %d (server error); skipping: %s",
+			accTestMissingFeature(t, "s3 storage API probe returned HTTP %d (server error): %s",
 				resp.StatusCode, truncateForSkip(string(body), 200))
 		}
 	}
+}
+
+// AccTestSkipIfCoolifyBelow skips (or fails with COOLIFY_REQUIRE_TIP_APIS=1)
+// when the connected Coolify version is older than min (e.g. "4.3.0").
+func AccTestSkipIfCoolifyBelow(t *testing.T, min string) {
+	t.Helper()
+	TestAccPreCheck(t)
+	c := AccTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ver, err := c.GetVersion(ctx)
+	if err != nil {
+		accTestMissingFeature(t, "could not read Coolify version: %v", err)
+		return
+	}
+	if client.IsVersionAtLeast(ver, min) {
+		return
+	}
+	accTestMissingFeature(t, "Coolify version %s is below required %s", ver, min)
 }
 
 // AccTestDockerfileAppConfig returns a Terraform config for an acceptance test

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -157,6 +157,21 @@ func TestAccTestSkipIfNoVolumeBackupAPI_MissingRoute(t *testing.T) {
 	}
 }
 
+func TestRequireTipAPIs(t *testing.T) {
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+	if requireTipAPIs() {
+		t.Fatal("expected requireTipAPIs false when unset/empty")
+	}
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "1")
+	if !requireTipAPIs() {
+		t.Fatal("expected requireTipAPIs true when COOLIFY_REQUIRE_TIP_APIS=1")
+	}
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "true")
+	if !requireTipAPIs() {
+		t.Fatal("expected requireTipAPIs true when COOLIFY_REQUIRE_TIP_APIS=true")
+	}
+}
+
 func TestAccTestSkipIfNoVolumeBackupAPI_ValidationPresent(t *testing.T) {
 	resetAccTestCaches()
 	defer resetAccTestCaches()

--- a/internal/service/application/resource_dockerfile_acc_test.go
+++ b/internal/service/application/resource_dockerfile_acc_test.go
@@ -142,3 +142,44 @@ data "coolify_application_logs" "test" {
 }
 `
 }
+
+// TestAccDockerfileApplicationResource_V43Settings exercises Coolify >= v4.3.0
+// application write fields (is_log_drain_enabled, noindex_domains) against a
+// real instance. On tip-edge CI (COOLIFY_REQUIRE_TIP_APIS=1) the version probe
+// fails the run if Coolify is older than 4.3.0; elsewhere it skips.
+func TestAccDockerfileApplicationResource_V43Settings(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
+	serverUUID := acctest.AccTestServerUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-dkr-v43")
+
+	// Domain must match noindex entry (Coolify ignores noindex URLs not in domains).
+	extra := `
+  domains              = "http://acc-v43.example.com"
+  is_log_drain_enabled = true
+  noindex_domains      = ["http://acc-v43.example.com"]
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.AccCheckDestroy("coolify_application_dockerfile", "/api/v1/applications/"),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.AccTestDockerfileAppConfig(name, serverUUID, extra),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coolify_application_dockerfile.test", "uuid"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "is_log_drain_enabled", "true"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "noindex_domains.#", "1"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "noindex_domains.0", "http://acc-v43.example.com"),
+				),
+			},
+			{
+				Config:             acctest.AccTestDockerfileAppConfig(name, serverUUID, extra),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Makes tip (`edge`) acceptance **prove** the functionality we document for tip Coolify, instead of quietly skipping when routes are missing.

| Change | Detail |
|--------|--------|
| `COOLIFY_REQUIRE_TIP_APIS=1` | Set on PR Acceptance Tests and nightly **tip-edge** only |
| Soft skip remains | Nightly `latest` and `4.1.2` still skip tip-only APIs |
| Surfaces covered | S3StoragesController, VolumeBackupsController, `COOLIFY_S3_STORAGE_UUID` bootstrap |
| New acc test | `TestAccDockerfileApplicationResource_V43Settings` (`is_log_drain_enabled`, `noindex_domains`) when Coolify ≥ 4.3.0 |

## Why

We claim S3 storage, volume backups, and 4.3 application settings on tip. Skip-if-missing on edge can pass green while tip regressed (false confidence).

## Test plan

- [x] `go test -race ./internal/acctest/`
- [x] compile application package
- [ ] CI Acceptance Tests on edge with require tip APIs