### PR TITLE
test(acctest): skip 4.2+/4.3+ APIs on floor Coolify 4.1.2

### DIFF
--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -48,7 +48,7 @@ teams, and most list/single data sources.
 | Resource / data source family | Notes |
 |-------------------------------|--------|
 | `coolify_project`, `coolify_environment` | |
-| `coolify_server`, `coolify_server_hetzner`, `coolify_server_validate` | Hetzner provision path |
+| `coolify_server`, `coolify_server_hetzner` | Hetzner provision path (`coolify_server_validate` needs 4.2+) |
 | `coolify_application*` (public, docker image, dockerfile, private git, github app) | Some **attributes** need 4.2/4.3 (see below) |
 | `coolify_application_preview` | |
 | Eight database engines + `coolify_database_backup`, `coolify_backup_execution` | Core CRUD works on 4.1+. Some optional settings exist only on newer Coolify lines; omit attributes you do not need so plans stay empty on older instances. |
@@ -58,7 +58,7 @@ teams, and most list/single data sources.
 | `coolify_cloud_token`, `coolify_cloud_token_validate` (Hetzner and generic) | |
 | `coolify_scheduled_task` | |
 | `coolify_deployment`, `coolify_resource_action` | |
-| `coolify_api_settings`, `coolify_team` / teams | |
+| `coolify_team` / teams | |
 | `coolify_version` | Read instance version |
 | Most list/single data sources without a version note in the README | |
 
@@ -67,6 +67,8 @@ teams, and most list/single data sources.
 | Resource / data source | Role |
 |------------------------|------|
 | `coolify_destination` / `coolify_destinations` | Docker network destinations |
+| `coolify_server_validate`, `coolify_server_validation` | Provider uses POST validate; 4.1.x only exposes GET |
+| `coolify_api_settings` | Provider uses POST `/enable`; 4.1.x only exposes GET (MCP enable alone is older) |
 | `coolify_server_digitalocean` | Provision DO droplets into Coolify |
 | `coolify_server_vultr` | Provision Vultr instances into Coolify |
 | `coolify_digitalocean_*` data sources | regions, sizes, images, ssh_keys |

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -562,8 +562,9 @@ func accTestMissingFeature(t *testing.T, format string, args ...interface{}) {
 // When COOLIFY_REQUIRE_TIP_APIS=1, a missing controller fails instead of skips.
 //
 // Probe strategy: PUT a schedule for non-existent parent/storage UUIDs.
-// Present controller returns 404 resource/storage, 422 validation, or 401/403.
-// Missing route returns Laravel "route ... could not be found" (or similar).
+// Present controller: named resource 404 (see isControllerResourceNotFound),
+// 422 validation, or 401/403. Missing route: plain {"message":"Not found."}
+// (Coolify catch-all), empty body, or HTML (floor 4.1.2 regression).
 func AccTestSkipIfNoVolumeBackupAPI(t *testing.T) {
 	t.Helper()
 	TestAccPreCheck(t)
@@ -597,28 +598,15 @@ func AccTestSkipIfNoVolumeBackupAPI(t *testing.T) {
 		// Validation ran on the volume backup controller.
 		return
 	case http.StatusNotFound:
-		// Controller-style 404s mean the route exists.
-		if strings.Contains(msg, "application not found") ||
-			strings.Contains(msg, "resource not found") ||
-			strings.Contains(msg, "storage not found") ||
-			strings.Contains(msg, "database not found") ||
-			strings.Contains(msg, "service not found") {
+		// Controller-style 404s (named resource) mean the route exists.
+		// Plain "Not found." / empty / Laravel unmatched means no controller.
+		if isControllerResourceNotFound(msg) {
 			return
 		}
-		// Laravel unmatched route, Go net/http default 404, or HTML without
-		// controller message. Controller 404s always name the resource.
-		if strings.Contains(msg, "could not be found") ||
-			strings.Contains(msg, "route ") ||
-			strings.Contains(msg, "page not found") ||
-			strings.TrimSpace(msg) == "" ||
-			strings.Contains(msg, "<html") {
-			accTestMissingFeature(t, "Coolify instance has no VolumeBackupsController (HTTP %d). "+
-				"Need image tip after coollabsio/coolify#10946 (CI uses coollabsio/coolify:edge; "+
-				"local: set LATEST_IMAGE=edge in Coolify compose .env). Body: %s",
-				resp.StatusCode, truncateForSkip(string(body), 200))
-			return
-		}
-		// Unknown 404 body: treat as present (resource not found variants).
+		accTestMissingFeature(t, "Coolify instance has no VolumeBackupsController (HTTP %d). "+
+			"Need image tip after coollabsio/coolify#10946 (CI uses coollabsio/coolify:edge; "+
+			"local: set LATEST_IMAGE=edge in Coolify compose .env). Body: %s",
+			resp.StatusCode, truncateForSkip(string(body), 200))
 		return
 	case http.StatusMethodNotAllowed:
 		accTestMissingFeature(t, "Coolify instance has no volume backup PUT route (HTTP 405). "+
@@ -640,6 +628,28 @@ func truncateForSkip(s string, n int) string {
 	return s[:n] + "..."
 }
 
+// isControllerResourceNotFound reports whether a lowercased 404 body looks like
+// a Coolify controller response for a missing parent/resource (route present).
+// Unmatched routes typically return plain "Not found." without naming a resource.
+func isControllerResourceNotFound(msgLower string) bool {
+	for _, s := range []string{
+		"application not found",
+		"resource not found",
+		"storage not found",
+		"database not found",
+		"service not found",
+		"server not found",
+		"s3 storage not found",
+		"destination not found",
+		"backup not found",
+	} {
+		if strings.Contains(msgLower, s) {
+			return true
+		}
+	}
+	return false
+}
+
 // AccTestS3StorageUUID returns the UUID of an S3 storage destination for
 // acceptance tests. Set COOLIFY_S3_STORAGE_UUID to the UUID of an S3
 // storage registered in Coolify. The test is skipped if not set (or fails when
@@ -659,8 +669,8 @@ func AccTestS3StorageUUID(t *testing.T) string {
 // When COOLIFY_REQUIRE_TIP_APIS=1, a missing controller fails instead of skips.
 //
 // Probe strategy: GET /api/v1/s3-storages.
-// Present controller returns 200 (list) or 401/403.
-// Missing route returns Laravel "could not be found" style 404.
+// Present controller returns 200 (list) or 401/403. Any 404 means no route
+// (index never 404s when registered), including Coolify plain Not found.
 func AccTestSkipIfNoS3StorageAPI(t *testing.T) {
 	t.Helper()
 	TestAccPreCheck(t)
@@ -682,22 +692,16 @@ func AccTestSkipIfNoS3StorageAPI(t *testing.T) {
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
-	msg := strings.ToLower(string(body))
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusUnauthorized, http.StatusForbidden:
 		return
 	case http.StatusNotFound:
-		if strings.Contains(msg, "could not be found") ||
-			strings.Contains(msg, "route ") ||
-			strings.Contains(msg, "page not found") ||
-			strings.TrimSpace(msg) == "" ||
-			strings.Contains(msg, "<html") {
-			accTestMissingFeature(t, "Coolify instance has no S3StoragesController (HTTP %d). "+
-				"Need Coolify >= v4.3.0. Body: %s",
-				resp.StatusCode, truncateForSkip(string(body), 200))
-			return
-		}
+		// Index endpoint never 404s when the controller is registered; any 404
+		// (including Coolify's plain {"message":"Not found."}) means no route.
+		accTestMissingFeature(t, "Coolify instance has no S3StoragesController (HTTP %d). "+
+			"Need Coolify >= v4.3.0. Body: %s",
+			resp.StatusCode, truncateForSkip(string(body), 200))
 		return
 	case http.StatusMethodNotAllowed:
 		accTestMissingFeature(t, "Coolify instance has no S3 storage GET route (HTTP 405). Need Coolify >= v4.3.0")

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -198,3 +198,79 @@ func TestAccTestSkipIfNoVolumeBackupAPI_ValidationPresent(t *testing.T) {
 
 	AccTestSkipIfNoVolumeBackupAPI(t)
 }
+
+// Coolify unmatched routes return {"message":"Not found."} (no resource name).
+// That must skip, not treat the volume-backup controller as present (floor 4.1.2).
+func TestAccTestSkipIfNoVolumeBackupAPI_PlainNotFound(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.1.2"})
+	})
+	mux.HandleFunc("PUT /api/v1/applications/{app}/storages/{stor}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not found."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoVolumeBackupAPI(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoVolumeBackupAPI to skip on plain Not found. body")
+	}
+}
+
+func TestAccTestSkipIfNoS3StorageAPI_PlainNotFound(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.1.2"})
+	})
+	mux.HandleFunc("GET /api/v1/s3-storages", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not found."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoS3StorageAPI(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoS3StorageAPI to skip on plain Not found. body")
+	}
+}
+
+func TestIsControllerResourceNotFound(t *testing.T) {
+	if !isControllerResourceNotFound("application not found.") {
+		t.Fatal("expected application not found to be controller-style")
+	}
+	if isControllerResourceNotFound(`{"message":"not found."}`) {
+		t.Fatal("plain not found must not look like controller resource 404")
+	}
+	if isControllerResourceNotFound("not found.") {
+		t.Fatal("plain not found. must not look like controller resource 404")
+	}
+}

--- a/internal/service/apisettings/resource_acc_test.go
+++ b/internal/service/apisettings/resource_acc_test.go
@@ -11,6 +11,8 @@ import (
 func TestAccAPISettings_Enable(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// POST /api/v1/enable is Coolify >= v4.2.0 (4.1.x only has GET post_required).
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
@@ -42,6 +44,8 @@ resource "coolify_api_settings" "test" {
 func TestAccAPISettings_MCPEnableDisable(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// POST /api/v1/enable (API on) needs Coolify >= v4.2.0; MCP enable alone is older.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/destination/data_source_acc_test.go
+++ b/internal/service/destination/data_source_acc_test.go
@@ -12,6 +12,8 @@ func TestAccDestinationDataSource(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// DestinationsController: Coolify >= v4.2.0.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 
 	serverUUID := acctest.AccTestServerUUID(t)
 	name := acctest.RandomWithPrefix("tf-acc-dest-ds")
@@ -37,6 +39,8 @@ func TestAccDestinationsDataSource(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// DestinationsController: Coolify >= v4.2.0.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 
 	serverUUID := acctest.AccTestServerUUID(t)
 	name := acctest.RandomWithPrefix("tf-acc-dests")

--- a/internal/service/destination/resource_acc_test.go
+++ b/internal/service/destination/resource_acc_test.go
@@ -12,6 +12,8 @@ func TestAccDestinationResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// DestinationsController create: Coolify >= v4.2.0 (POST .../servers/{uuid}/destinations).
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 
 	serverUUID := acctest.AccTestServerUUID(t)
 	name := acctest.RandomWithPrefix("tf-acc-dest")

--- a/internal/service/server/data_source_acc_test.go
+++ b/internal/service/server/data_source_acc_test.go
@@ -103,6 +103,8 @@ func TestAccServerValidationDataSource(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// POST /api/v1/servers/{uuid}/validate is Coolify >= v4.2.0.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 	serverUUID := acctest.AccTestServerUUID(t)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/servervalidate/resource_acc_test.go
+++ b/internal/service/servervalidate/resource_acc_test.go
@@ -11,6 +11,8 @@ import (
 func TestAccServerValidate_Basic(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// POST /api/v1/servers/{uuid}/validate is Coolify >= v4.2.0.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.2.0")
 	serverUUID := acctest.AccTestServerUUID(t)
 
 	resource.Test(t, resource.TestCase{

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -48,7 +48,7 @@ teams, and most list/single data sources.
 | Resource / data source family | Notes |
 |-------------------------------|--------|
 | `coolify_project`, `coolify_environment` | |
-| `coolify_server`, `coolify_server_hetzner`, `coolify_server_validate` | Hetzner provision path |
+| `coolify_server`, `coolify_server_hetzner` | Hetzner provision path (`coolify_server_validate` needs 4.2+) |
 | `coolify_application*` (public, docker image, dockerfile, private git, github app) | Some **attributes** need 4.2/4.3 (see below) |
 | `coolify_application_preview` | |
 | Eight database engines + `coolify_database_backup`, `coolify_backup_execution` | Core CRUD works on 4.1+. Some optional settings exist only on newer Coolify lines; omit attributes you do not need so plans stay empty on older instances. |
@@ -58,7 +58,7 @@ teams, and most list/single data sources.
 | `coolify_cloud_token`, `coolify_cloud_token_validate` (Hetzner and generic) | |
 | `coolify_scheduled_task` | |
 | `coolify_deployment`, `coolify_resource_action` | |
-| `coolify_api_settings`, `coolify_team` / teams | |
+| `coolify_team` / teams | |
 | `coolify_version` | Read instance version |
 | Most list/single data sources without a version note in the README | |
 
@@ -67,6 +67,8 @@ teams, and most list/single data sources.
 | Resource / data source | Role |
 |------------------------|------|
 | `coolify_destination` / `coolify_destinations` | Docker network destinations |
+| `coolify_server_validate`, `coolify_server_validation` | Provider uses POST validate; 4.1.x only exposes GET |
+| `coolify_api_settings` | Provider uses POST `/enable`; 4.1.x only exposes GET (MCP enable alone is older) |
 | `coolify_server_digitalocean` | Provision DO droplets into Coolify |
 | `coolify_server_vultr` | Provision Vultr instances into Coolify |
 | `coolify_digitalocean_*` data sources | regions, sizes, images, ssh_keys |


### PR DESCRIPTION
## Summary

Coolify Nightly full matrix (`profile=all`) failed **Acc (floor-4.1.2)** with 11 failures. Tip edge Acc, stable-latest Acc, and tip scenarios were green.

Root causes:

1. **Probe false-positives** — Coolify unmatched routes return plain `{"message":"Not found."}`. Volume-backup and S3 probes treated unknown 404 bodies as “controller present,” so tests ran and failed on apply.
2. **Missing version gates** — Destinations, `coolify_api_settings` (POST `/enable`), and server validate (POST) are Coolify **>= 4.2.0** per contracts. Floor 4.1.2 only has GET placeholders for enable/validate and no destinations controller.

## Changes

- Fail closed on volume-backup 404 unless the body is a named controller resource not-found (`isControllerResourceNotFound`)
- Treat **any** 404 on `GET /api/v1/s3-storages` as missing API
- `AccTestSkipIfCoolifyBelow(t, "4.2.0")` on destination, api_settings, and server validate/validation acc tests
- Unit tests for plain `Not found.` bodies
- Version support guide: move `coolify_server_validate` / `coolify_api_settings` to 4.2+

## Test plan

- [x] `go test ./internal/acctest/`
- [x] `make ci`
- [x] Local reviewer (approve with nits; nits fixed)
- [ ] PR CI green
- [ ] Re-run Coolify Nightly Acc `floor-only` (or full matrix) after merge

## Reviewer

Local review: no correctness bugs; godoc/guide wording nits applied.