### PR TITLE
test: MPI polish for s3 validate, errors, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-39 resources, 56 data sources, 1180+ tests (unit + acceptance), 9 CI jobs.
+39 resources, 56 data sources, 1190+ tests (unit + acceptance), 9 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1180+ tests (unit + acceptance)
+- 1190+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1180+ tests, race detector enabled)
+make test                                       # Run unit tests (1190+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/TESTING.md
+++ b/TESTING.md
@@ -354,7 +354,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 | `coolify_backup_execution` | Yes | Yes | N/A | N/A | Trigger resource |
 | `coolify_cloud_token_validate` | Yes | Yes | N/A | N/A | Trigger resource, needs `COOLIFY_HETZNER_TOKEN` |
 | `coolify_resource_action` | Yes | Yes | N/A | N/A | Start/stop/restart trigger with force-replace |
-| `coolify_s3_storage_validate` | Yes | Yes | N/A | N/A | Trigger resource, needs `COOLIFY_S3_STORAGE_UUID` |
+| `coolify_s3_storage_validate` | Yes | Yes | N/A | N/A | Trigger resource; creates disposable S3 storage (does not use bootstrap minio-test UUID) |
 | `coolify_server_validate` | Yes | Yes | N/A | N/A | Trigger resource |
 | `coolify_envs_bulk` | Yes | Yes | N/A | N/A | Atomic env var set management |
 

--- a/docs/resources/s3_storage_validate.md
+++ b/docs/resources/s3_storage_validate.md
@@ -14,6 +14,15 @@ Validates an S3-compatible storage configuration against the remote endpoint (PO
 
 ```terraform
 # Re-test S3 connectivity after credential rotation (Coolify >= v4.3.0).
+resource "coolify_s3_storage" "backups" {
+  name     = "backups"
+  endpoint = "https://s3.us-east-1.amazonaws.com"
+  bucket   = "my-coolify-backups"
+  region   = "us-east-1"
+  key      = "AKIA..."
+  secret   = "change-me-in-production"
+}
+
 resource "coolify_s3_storage_validate" "backups" {
   s3_storage_uuid = coolify_s3_storage.backups.uuid
 

--- a/examples/resources/coolify_s3_storage_validate/resource.tf
+++ b/examples/resources/coolify_s3_storage_validate/resource.tf
@@ -1,4 +1,13 @@
 # Re-test S3 connectivity after credential rotation (Coolify >= v4.3.0).
+resource "coolify_s3_storage" "backups" {
+  name     = "backups"
+  endpoint = "https://s3.us-east-1.amazonaws.com"
+  bucket   = "my-coolify-backups"
+  region   = "us-east-1"
+  key      = "AKIA..."
+  secret   = "change-me-in-production"
+}
+
 resource "coolify_s3_storage_validate" "backups" {
   s3_storage_uuid = coolify_s3_storage.backups.uuid
 

--- a/internal/service/application/resource_docker_image_acc_test.go
+++ b/internal/service/application/resource_docker_image_acc_test.go
@@ -148,5 +148,5 @@ resource "coolify_application_docker_image" "test" {
 func TestAccDockerImageApplicationResource_ClearDomains(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
-	t.Skip("Coolify ignores empty domains on update ($request->has + ConvertEmptyStringsToNull); provider unit test covers wire format")
+	t.Skip("Coolify ignores empty domains on update ($request->has + ConvertEmptyStringsToNull); tracked in #647; provider unit test covers wire format")
 }

--- a/internal/service/destination/resource.go
+++ b/internal/service/destination/resource.go
@@ -124,9 +124,10 @@ func (r *destinationResource) Create(ctx context.Context, req resource.CreateReq
 
 	got, err := r.client.GetDestination(ctx, created.UUID)
 	if err != nil {
+		// Detail uses lower-case "destination" for historical wording; summary is title case.
 		resp.Diagnostics.AddError(
-			"Destination created but refresh failed",
-			fmt.Sprintf("Coolify created destination %s, but the provider could not read it back: %s. The partial Terraform state was saved, so rerun terraform apply or terraform refresh after the API becomes reachable again.", created.UUID, err),
+			flex.CreateReadBackFailedSummary("Destination"),
+			flex.CreateReadBackFailedDetail("destination", created.UUID, err),
 		)
 		return
 	}

--- a/internal/service/githubapp/resource.go
+++ b/internal/service/githubapp/resource.go
@@ -232,7 +232,14 @@ func (r *gitHubAppResource) Read(ctx context.Context, req resource.ReadRequest, 
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error reading GitHub App", fmt.Sprintf("Could not read GitHub App: %s", err))
+		id := state.ID.ValueInt64()
+		if state.ID.IsNull() || state.ID.IsUnknown() {
+			resp.Diagnostics.AddError("Error reading GitHub App",
+				fmt.Sprintf("Could not read GitHub App (app_id %d): %s", state.AppID.ValueInt64(), err))
+		} else {
+			resp.Diagnostics.AddError("Error reading GitHub App",
+				fmt.Sprintf("Could not read GitHub App %d: %s", id, err))
+		}
 		return
 	}
 

--- a/internal/service/s3storagevalidate/resource_test.go
+++ b/internal/service/s3storagevalidate/resource_test.go
@@ -34,6 +34,25 @@ func TestS3StorageValidateResource_Success(t *testing.T) {
 	})
 }
 
+func TestS3StorageValidateResource_InvalidUUID(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_s3_storage_validate", "test", `
+					s3_storage_uuid = "not-a-valid-uuid"
+				`),
+				ExpectError: regexp.MustCompile(`(?i)uuid|invalid|must`),
+			},
+		},
+	})
+}
+
 func TestS3StorageValidateResource_Failure(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary

Multi-perspective improve batch after the pre-rotation gate.

### Pre-rotation gate

- Main CI green
- Open PRs: only release-please **#687** (`chore(main): release 0.1.14`) — **needs explicit OK to merge** (not touched)
- **#699** (Coolify tip 4.3.2): re-extracted tip contract; **0 API drift** vs pin 4.3.1; comment added; left open for channel job
- Blocked: #647, #445
- Large backlog (not this PR): #394 notifications, #475 community promo

### Changes

- Completer `coolify_s3_storage_validate` example (includes companion `coolify_s3_storage`)
- Invalid UUID unit test for the validate resource
- GitHub App Read diagnostics include id / app_id
- Destination create-read-back uses shared flex formatters
- Acc empty-domains skip cites #647
- TESTING.md: validate Acc does not need bootstrap minio UUID
- Documented test floor 1190+

### Filed

- **#700** OpenAPI pin omits `/s3-storages` routes present in contract

## Test plan

- [x] `go test` on touched packages
- [x] `make ci`
- [ ] PR CI green