### PR TITLE
feat: drive API_COVERAGE from Coolify contract routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ mismatches, and zero validation rules when we compared it against the source.
 - `internal/flex/` - Type conversion helpers between Go and Terraform Framework types
 - `internal/acctest/` - Shared test utilities (provider factories, mock server wrappers, acceptance test helpers)
 - `internal/validate/` - Input validators (UUID format, FQDN URL)
-- `internal/spectest/` - OpenAPI spec compliance tests, API coverage tracking, and contract coverage tests
+- `internal/spectest/` - Contract field/route coverage (`API_COVERAGE.md` uses contract `routes[]` as inventory; OpenAPI is not the route source of truth), plus optional OpenAPI request validation helpers
 - Contract skip taxonomy (`internal/spectest/skip.go`): `internal` (FK/computed), `deferred` (public field + open issue `#N`), `n/a` (wrong surface). Never label public `$allowedFields` as internal. Schema registry Phase A: EnvironmentVariable; Phase B: Application settings + ScheduledTask (`schema_coverage*.go`). Write-path check: application env `allowed_fields` vs client input (`write_coverage_test.go`). Weekly drift issue body: `.github/contract-freshness-issue.md`. `make contract-check` runs the full coverage suite. Extract aliases private `validate*` helpers that own `$allowedFields` onto public callers (e.g. VolumeBackups `upsert` ← `validateUpsertRequest`).
 - `scripts/` - Contract extraction (`extract-contract.py`), OpenAPI generation (`generate-openapi.py`), contract diff (`diff-contracts.sh`)
 - `testdata/contracts/` - Versioned contract JSON files extracted from Coolify source (source of truth for API field definitions)

--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -3,10 +3,12 @@
 <!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->
 <!-- Run: make api-coverage -->
 
-**Route inventory**: pinned OpenAPI spec in `testdata/specs/coolify-v4.json`  
-**Field source of truth**: source-derived contract in `testdata/contracts/coolify-v4.json`  
-**Coverage**: 142 / 143 endpoints (99.3%)  
-**Planned**: 0 | **Skipped**: 1
+**Route inventory**: source-derived contract `testdata/contracts/coolify-v4.json` (`routes[]`)  
+**Field source of truth**: same contract (`models` / endpoint allow lists)  
+**Not inventory**: OpenAPI under `testdata/specs/` (partial upstream path list; do not treat as Coolify API completeness)  
+**Coverage**: 176 covered / 296 registry entries (59.5%)  
+**Planned**: 12 | **Skipped**: 108  
+**Registry size**: 296 (contract routes + allowlisted extras)
 
 ## Covered
 
@@ -25,9 +27,11 @@
 | `DELETE /databases/{uuid}/envs/{env_uuid}` | `coolify_environment_variable` | v0.2.0 |
 | `DELETE /databases/{uuid}/storages/{storage_uuid}` | `coolify_storage` | v0.2.0 |
 | `DELETE /databases/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
+| `DELETE /destinations/{uuid}` | `coolify_destination` | v0.2.0 |
 | `DELETE /github-apps/{github_app_id}` | `coolify_github_app` | v0.2.0 |
 | `DELETE /projects/{uuid}` | `coolify_project` | v0.1.0 |
 | `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}` | `coolify_environment` | v0.2.0 |
+| `DELETE /s3-storages/{uuid}` | `coolify_s3_storage` | v0.1.13 |
 | `DELETE /security/keys/{uuid}` | `coolify_private_key` | v0.1.0 |
 | `DELETE /servers/{uuid}` | `coolify_server` | v0.1.0 |
 | `DELETE /services/{uuid}` | `coolify_service` | v0.1.0 |
@@ -60,6 +64,12 @@
 | `GET /deployments` | `data.coolify_deployments` | v0.2.0 |
 | `GET /deployments/applications/{uuid}` | `data.coolify_deployments` | v0.2.0 |
 | `GET /deployments/{uuid}` | `coolify_deployment` | v0.1.0 |
+| `GET /destinations` | `data.coolify_destinations` | v0.2.0 |
+| `GET /destinations/{uuid}` | `data.coolify_destination` | v0.2.0 |
+| `GET /digitalocean/images` | `data.coolify_digitalocean_images` | v0.2.0 |
+| `GET /digitalocean/regions` | `data.coolify_digitalocean_regions` | v0.2.0 |
+| `GET /digitalocean/sizes` | `data.coolify_digitalocean_sizes` | v0.2.0 |
+| `GET /digitalocean/ssh-keys` | `data.coolify_digitalocean_ssh_keys` | v0.2.0 |
 | `GET /disable` | `client.DisableAPI` | v0.2.0 |
 | `GET /enable` | `client.EnableAPI` | v0.2.0 |
 | `GET /github-apps` | `data.coolify_github_apps` | v0.2.0 |
@@ -75,9 +85,12 @@
 | `GET /projects/{uuid}/environments` | `data.coolify_environments` | v0.2.0 |
 | `GET /projects/{uuid}/{environment_name_or_uuid}` | `data.coolify_environment` | v0.2.0 |
 | `GET /resources` | `data.coolify_resources` | v0.2.0 |
+| `GET /s3-storages` | `data.coolify_s3_storages` | v0.1.13 |
+| `GET /s3-storages/{uuid}` | `data.coolify_s3_storage` | v0.1.13 |
 | `GET /security/keys` | `data.coolify_private_keys` | v0.1.0 |
 | `GET /security/keys/{uuid}` | `data.coolify_private_key` | v0.1.0 |
 | `GET /servers` | `data.coolify_servers` | v0.1.0 |
+| `GET /servers/{server_uuid}/destinations` | `data.coolify_destinations` | v0.2.0 |
 | `GET /servers/{uuid}` | `data.coolify_server` | v0.1.0 |
 | `GET /servers/{uuid}/domains` | `data.coolify_server_domains` | v0.1.0 |
 | `GET /servers/{uuid}/resources` | `data.coolify_server_resources` | v0.1.0 |
@@ -97,6 +110,10 @@
 | `GET /teams/{id}` | `data.coolify_team` | v0.1.0 |
 | `GET /teams/{id}/members` | `data.coolify_team_members` | v0.2.0 |
 | `GET /version` | `data.coolify_version` | v0.1.0 |
+| `GET /vultr/os` | `data.coolify_vultr_os` | v0.2.0 |
+| `GET /vultr/plans` | `data.coolify_vultr_plans` | v0.2.0 |
+| `GET /vultr/regions` | `data.coolify_vultr_regions` | v0.2.0 |
+| `GET /vultr/ssh-keys` | `data.coolify_vultr_ssh_keys` | v0.2.0 |
 | `PATCH /applications/{uuid}` | `coolify_application + variants` | v0.1.0 |
 | `PATCH /applications/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
 | `PATCH /applications/{uuid}/envs/bulk` | `client.BulkUpdateEnvVars` | v0.2.0 |
@@ -110,6 +127,7 @@
 | `PATCH /databases/{uuid}/storages` | `coolify_storage` | v0.2.0 |
 | `PATCH /github-apps/{github_app_id}` | `coolify_github_app` | v0.2.0 |
 | `PATCH /projects/{uuid}` | `coolify_project` | v0.1.0 |
+| `PATCH /s3-storages/{uuid}` | `coolify_s3_storage` | v0.1.13 |
 | `PATCH /security/keys/{uuid}` | `coolify_private_key` | v0.1.0 |
 | `PATCH /servers/{uuid}` | `coolify_server` | v0.1.0 |
 | `PATCH /services/{uuid}` | `coolify_service` | v0.1.0 |
@@ -123,7 +141,10 @@
 | `POST /applications/private-github-app` | `coolify_application_github_app` | v0.2.0 |
 | `POST /applications/public` | `coolify_application` | v0.1.0 |
 | `POST /applications/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
+| `POST /applications/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
 | `POST /applications/{uuid}/scheduled-tasks` | `coolify_scheduled_task` | v0.2.0 |
+| `POST /applications/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
+| `POST /applications/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
 | `POST /applications/{uuid}/storages` | `coolify_storage` | v0.2.0 |
 | `POST /cloud-tokens` | `coolify_cloud_token` | v0.2.0 |
 | `POST /cloud-tokens/{uuid}/validate` | `client.ValidateCloudToken` | v0.2.0 |
@@ -137,19 +158,34 @@
 | `POST /databases/redis` | `coolify_database_redis` | v0.1.0 |
 | `POST /databases/{uuid}/backups` | `coolify_database_backup` | v0.1.0 |
 | `POST /databases/{uuid}/envs` | `coolify_environment_variable` | v0.2.0 |
+| `POST /databases/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
+| `POST /databases/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
+| `POST /databases/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
 | `POST /databases/{uuid}/storages` | `coolify_storage` | v0.2.0 |
+| `POST /deploy` | `client.Deploy` | v0.2.0 |
 | `POST /deployments/{uuid}/cancel` | `client.CancelDeployment` | v0.2.0 |
+| `POST /disable` | `coolify_api_settings` | v0.2.0 |
+| `POST /enable` | `coolify_api_settings` | v0.2.0 |
 | `POST /github-apps` | `coolify_github_app` | v0.2.0 |
 | `POST /mcp/disable` | `coolify_api_settings (mcp_enabled)` | v0.4.0 |
 | `POST /mcp/enable` | `coolify_api_settings (mcp_enabled)` | v0.4.0 |
 | `POST /projects` | `coolify_project` | v0.1.0 |
 | `POST /projects/{uuid}/environments` | `coolify_environment` | v0.2.0 |
+| `POST /s3-storages` | `coolify_s3_storage` | v0.1.13 |
+| `POST /s3-storages/{uuid}/validate` | `coolify_s3_storage_validate` | v0.1.14 |
 | `POST /security/keys` | `coolify_private_key` | v0.1.0 |
 | `POST /servers` | `coolify_server` | v0.1.0 |
+| `POST /servers/digitalocean` | `coolify_server_digitalocean` | v0.2.0 |
 | `POST /servers/hetzner` | `coolify_server_hetzner` | v0.2.0 |
+| `POST /servers/vultr` | `coolify_server_vultr` | v0.2.0 |
+| `POST /servers/{server_uuid}/destinations` | `coolify_destination` | v0.2.0 |
+| `POST /servers/{uuid}/validate` | `coolify_server_validate` | v0.2.0 |
 | `POST /services` | `coolify_service` | v0.1.0 |
 | `POST /services/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
+| `POST /services/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
 | `POST /services/{uuid}/scheduled-tasks` | `coolify_scheduled_task` | v0.2.0 |
+| `POST /services/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
+| `POST /services/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
 | `POST /services/{uuid}/storages` | `coolify_storage` | v0.2.0 |
 | `PUT /applications/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
 | `PUT /databases/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
@@ -161,6 +197,18 @@ Ordered by priority (1 = most needed by users).
 
 | Priority | Endpoint | Notes |
 |----------|----------|-------|
+| 2 | `GET /notifications/discord` | Notification channel resources (#394) |
+| 2 | `GET /notifications/email` | Notification channel resources (#394) |
+| 2 | `GET /notifications/pushover` | Notification channel resources (#394) |
+| 2 | `GET /notifications/slack` | Notification channel resources (#394) |
+| 2 | `GET /notifications/telegram` | Notification channel resources (#394) |
+| 2 | `GET /notifications/webhook` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/discord` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/email` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/pushover` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/slack` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/telegram` | Notification channel resources (#394) |
+| 2 | `PATCH /notifications/webhook` | Notification channel resources (#394) |
 
 ## Intentionally Skipped
 
@@ -168,12 +216,118 @@ These endpoints are intentionally not modeled directly in Terraform.
 
 | Endpoint | Reason |
 |----------|--------|
+| `DELETE /applications/{uuid}/destinations/{destination_uuid}` | Application multi-destination attach/detach; primary TF surface is coolify_destination |
+| `DELETE /applications/{uuid}/tags/{tag_uuid}` | Resource tags API; not modeled as first-class TF resources |
+| `DELETE /cloud-init-scripts/{uuid}` | Cloud-init script library; not a TF resource |
+| `DELETE /databases/{uuid}/tags/{tag_uuid}` | Resource tags API; not modeled as first-class TF resources |
+| `DELETE /gitlab-apps/{gitlab_app_id}` | GitLab App integration; provider covers GitHub Apps only today |
+| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `DELETE /projects/{uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `DELETE /servers/{uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `DELETE /services/{uuid}/tags/{tag_uuid}` | Resource tags API; not modeled as first-class TF resources |
+| `DELETE /tags/{uuid}` | Resource tags API; not modeled as first-class TF resources |
+| `DELETE /team/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `GET /applications/{uuid}/destinations` | Application multi-destination attach/detach; primary TF surface is coolify_destination |
+| `GET /applications/{uuid}/rollback-images` | Application rollback/images; operational, not TF lifecycle |
+| `GET /applications/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `GET /cloud-init-scripts` | Cloud-init script library; not a TF resource |
+| `GET /cloud-init-scripts/{uuid}` | Cloud-init script library; not a TF resource |
+| `GET /databases/{uuid}/logs` | Resource logs streaming; not durable TF state |
+| `GET /databases/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `GET /gitlab-apps` | GitLab App integration; provider covers GitHub Apps only today |
+| `GET /hetzner/firewalls` | Hetzner firewalls/networks list; not required for coolify_server_hetzner |
+| `GET /hetzner/networks` | Hetzner firewalls/networks list; not required for coolify_server_hetzner |
+| `GET /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `GET /projects/{uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `GET /servers/{uuid}/cloudflare-tunnel` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/docker-cleanup` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/docker-cleanup/executions` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `GET /servers/{uuid}/export` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/log-drains` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/proxy` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /servers/{uuid}/sentinel` | Server operational/control-plane API; not modeled as TF resources |
+| `GET /services/{uuid}/applications` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/applications/{app_uuid}` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/applications/{app_uuid}/logs` | Resource logs streaming; not durable TF state |
+| `GET /services/{uuid}/applications/{app_uuid}/restart` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/applications/{app_uuid}/start` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/applications/{app_uuid}/stop` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/databases` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/databases/{database_uuid}` | Nested service components; coolify_service manages the compose service unit |
+| `GET /services/{uuid}/databases/{database_uuid}/logs` | Resource logs streaming; not durable TF state |
+| `GET /services/{uuid}/logs` | Resource logs streaming; not durable TF state |
+| `GET /services/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `GET /tags` | Resource tags API; not modeled as first-class TF resources |
+| `GET /team` | Alias of /teams/current*; use data.coolify_team / team_members |
+| `GET /team/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `GET /team/members` | Alias of /teams/current*; use data.coolify_team / team_members |
+| `PATCH /cloud-init-scripts/{uuid}` | Cloud-init script library; not a TF resource |
+| `PATCH /destinations/{uuid}` | Destination fields RequireReplace; provider does not call PATCH |
+| `PATCH /gitlab-apps/{gitlab_app_id}` | GitLab App integration; provider covers GitHub Apps only today |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}` | Environment description is TF state-only today; client has no Update call |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `PATCH /projects/{uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `PATCH /servers/{uuid}/cloudflare-tunnel` | Server operational/control-plane API; not modeled as TF resources |
+| `PATCH /servers/{uuid}/docker-cleanup` | Server operational/control-plane API; not modeled as TF resources |
+| `PATCH /servers/{uuid}/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `PATCH /servers/{uuid}/log-drains` | Server operational/control-plane API; not modeled as TF resources |
+| `PATCH /servers/{uuid}/proxy` | Server operational/control-plane API; not modeled as TF resources |
+| `PATCH /servers/{uuid}/sentinel` | Server operational/control-plane API; not modeled as TF resources |
+| `PATCH /services/{uuid}/applications/{app_uuid}` | Nested service components; coolify_service manages the compose service unit |
+| `PATCH /services/{uuid}/databases/{database_uuid}` | Nested service components; coolify_service manages the compose service unit |
+| `PATCH /tags/{uuid}` | Resource tags API; not modeled as first-class TF resources |
+| `PATCH /team/envs/{env_id}` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
 | `POST /applications/dockercompose` | Deprecated alias: use POST /services instead because this flow creates a Service, not an Application |
+| `POST /applications/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /applications/{uuid}/destinations` | Application multi-destination attach/detach; primary TF surface is coolify_destination |
+| `POST /applications/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /applications/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /applications/{uuid}/rollback` | Application rollback/images; operational, not TF lifecycle |
+| `POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute` | One-shot task execute; coolify_scheduled_task manages definition only |
+| `POST /applications/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
+| `POST /applications/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `POST /cloud-init-scripts` | Cloud-init script library; not a TF resource |
+| `POST /databases/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /databases/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /databases/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /databases/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
+| `POST /databases/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `POST /feedback` | Coolify product feedback endpoint; not TF |
+| `POST /gitlab-apps` | GitLab App integration; provider covers GitHub Apps only today |
+| `POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `POST /projects/{uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `POST /sentinel/push` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/import` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/claim` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/cloudflare-tunnel/disable` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/cloudflare-tunnel/enable` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/docker-cleanup/run` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `POST /servers/{uuid}/export/mailbox` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /servers/{uuid}/proxy/restart` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /servers/{uuid}/transfer/complete` | Server operational/control-plane API; not modeled as TF resources |
+| `POST /services/{uuid}/applications/{app_uuid}/logs` | Resource logs streaming; not durable TF state |
+| `POST /services/{uuid}/applications/{app_uuid}/restart` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/applications/{app_uuid}/start` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/applications/{app_uuid}/stop` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /services/{uuid}/databases/{database_uuid}/restart` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/databases/{database_uuid}/start` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/databases/{database_uuid}/stop` | Nested service app/DB lifecycle; manage via parent coolify_service |
+| `POST /services/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /services/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
+| `POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute` | One-shot task execute; coolify_scheduled_task manages definition only |
+| `POST /services/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
+| `POST /services/{uuid}/tags` | Resource tags API; not modeled as first-class TF resources |
+| `POST /tags` | Resource tags API; not modeled as first-class TF resources |
+| `POST /team/envs` | Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service) |
+| `PUT /servers/{uuid}/proxy/configuration` | Server operational/control-plane API; not modeled as TF resources |
 
-## New in Spec (Unclassified)
+## Unclassified contract routes
 
-_None. All spec endpoints are classified._
+_None. All pin contract routes are classified in `coveredEndpoints()`._
 
-This section appears when the pinned spec is updated with new endpoints
-that haven't been added to the coverage registry yet. The
-`TestSpecCoverage_Completeness` test also fails in this case.
+When `make contract-extract` adds routes, classify them in
+`internal/spectest/coverage_test.go` or `TestSpecCoverage_Completeness` fails.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ internal/
   acctest/      Shared test utilities
   validate/     Input validators (UUID format, FQDN URL, cron)
   filter/       Generic data source filtering helpers
-  spectest/     OpenAPI spec compliance and contract coverage tests
+  spectest/     Contract field/route coverage (API_COVERAGE.md) and optional OpenAPI helpers
 ```
 
 ## Adding a New Resource
@@ -176,7 +176,7 @@ and run `make ci`.
 6. Add client methods in `internal/client/`
 7. Register the resource in `internal/provider/provider.go`
 8. Add examples in `examples/resources/coolify_<type>/`: both `resource.tf` and `import.sh`
-9. Add endpoint(s) to `coveredEndpoints()` in `internal/spectest/coverage_test.go`
+9. Classify new contract routes in `coveredEndpoints()` (`internal/spectest/coverage_test.go`); inventory is contract `routes[]`, not OpenAPI
 10. Run `make api-coverage` to regenerate API_COVERAGE.md
 11. Update resource/data source/test counts in AGENTS.md and README.md
 12. Run `make docs` to generate documentation

--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -9,7 +9,10 @@ description: "Comparison of Coolify OpenAPI spec vs real source code contract."
 This page compares the pinned reusable OpenAPI schemas with the source-derived
 Coolify contract extracted from the real application code.
 
-> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
+> The source-derived contract is the source of truth for fields **and** routes
+> (`API_COVERAGE.md` inventories contract `routes[]`). The pinned OpenAPI spec is
+> useful only for reusable public schemas and optional request-shape checks; it is
+> **not** a complete Coolify route inventory.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -57,7 +57,7 @@ and maintainers. End users do not need to read this; see the
 | `internal/acctest/` | Shared test utilities: provider factories, mock server wrappers (`WithVersionEndpoint`), acceptance test helpers |
 | `internal/validate/` | Custom validators: UUID format, FQDN URL, cron syntax |
 | `internal/filter/` | Generic filtering helpers for plural data sources |
-| `internal/spectest/` | OpenAPI spec compliance tests, API coverage tracking, contract coverage verification |
+| `internal/spectest/` | Contract field/route coverage, API_COVERAGE.md generation, optional OpenAPI request checks |
 | `scripts/` | Python tooling: contract extraction from Coolify source, OpenAPI spec generation, contract diffing |
 | `testdata/contracts/` | Versioned contract JSON extracted from Coolify PHP source (source of truth for field definitions) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Define your entire [Coolify](https://coolify.io/) infrastructure as code. Deploy
 
 Coolify gives you a self-hosted PaaS with a great UI. This provider adds what the UI cannot: reproducible environments, pull-request-based infrastructure reviews, disaster recovery from state, and CI/CD integration. Whether you run a single VPS or manage Coolify for a team, Terraform turns your infrastructure into a reviewable, testable, git-tracked configuration.
 
-**39 resources, 56 data sources, 99%+ Coolify API coverage.**
+**39 resources, 56 data sources.** Route coverage is tracked against the Coolify source contract (not upstream OpenAPI).
 
 ## Requirements
 

--- a/internal/spectest/coverage_contract_test.go
+++ b/internal/spectest/coverage_contract_test.go
@@ -1,0 +1,61 @@
+package spectest
+
+import (
+	"testing"
+)
+
+func TestCoveredEndpoints_HasS3AndDestinations(t *testing.T) {
+	t.Parallel()
+	cov := coveredEndpoints()
+	for _, op := range []string{
+		"GET /s3-storages",
+		"POST /s3-storages/{uuid}/validate",
+		"GET /destinations",
+		"POST /servers/{server_uuid}/destinations",
+		"GET /digitalocean/regions",
+		"GET /vultr/plans",
+	} {
+		s, ok := cov[op]
+		if !ok {
+			t.Errorf("missing registry entry %s", op)
+			continue
+		}
+		if s.category != "covered" {
+			t.Errorf("%s: want covered, got %s (%s)", op, s.category, s.resource)
+		}
+	}
+}
+
+func TestCoveredEndpoints_NotificationsPlanned(t *testing.T) {
+	t.Parallel()
+	cov := coveredEndpoints()
+	s, ok := cov["GET /notifications/slack"]
+	if !ok {
+		t.Fatal("missing GET /notifications/slack")
+	}
+	if s.category != "planned" {
+		t.Fatalf("want planned, got %s", s.category)
+	}
+	if s.priority != 2 {
+		t.Fatalf("priority: got %d", s.priority)
+	}
+}
+
+func TestCoveredEndpoints_FalseCoveredGuards(t *testing.T) {
+	t.Parallel()
+	cov := coveredEndpoints()
+	// These Coolify routes exist but the provider does not call them today.
+	for _, op := range []string{
+		"PATCH /destinations/{uuid}",
+		"PATCH /projects/{uuid}/environments/{environment_name_or_uuid}",
+	} {
+		s, ok := cov[op]
+		if !ok {
+			t.Errorf("missing registry entry %s", op)
+			continue
+		}
+		if s.category == "covered" {
+			t.Errorf("%s must not be covered (no client call path)", op)
+		}
+	}
+}

--- a/internal/spectest/coverage_test.go
+++ b/internal/spectest/coverage_test.go
@@ -1,14 +1,13 @@
 package spectest
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
-
-	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 // coverageStatus tracks a single API endpoint's provider coverage.
@@ -20,15 +19,35 @@ type coverageStatus struct {
 	notes    string // human-readable context
 }
 
+// contractRoutePin is the pin contract whose routes[] define the coverage inventory.
+const contractRoutePin = "coolify-v4.json"
+
+// registryExtrasNotInContract are registry keys kept for historical OpenAPI-only
+// aliases that Coolify no longer lists as first-class routes (or never did in
+// the extract). Completeness still requires them to be classified.
+var registryExtrasNotInContract = map[string]bool{
+	// Deprecated Coolify alias: creates a Service, not an Application.
+	"POST /applications/dockercompose": true,
+}
+
 // coveredEndpoints returns the provider's route coverage registry.
-// The pinned OpenAPI spec is the route inventory for completeness checks.
-// The source-derived contract remains the field-level source of truth.
-// TestSpecCoverage_Completeness fails if the pinned route inventory and
-// this registry drift. TestSpecCoverage_GenerateDoc generates API_COVERAGE.md
-// from this data.
+//
+// Route inventory for completeness is the source-extracted contract
+// (testdata/contracts/coolify-v4.json routes[]), not the partial OpenAPI
+// path list. Field-level truth is the same contract. OpenAPI under
+// testdata/specs/ is not authoritative for routes.
+//
+// TestSpecCoverage_Completeness fails if contract routes and this registry
+// drift. TestSpecCoverage_GenerateDoc generates API_COVERAGE.md from this data.
 func coveredEndpoints() map[string]coverageStatus {
 	covered := func(resource, since string) coverageStatus {
 		return coverageStatus{category: "covered", resource: resource, since: since}
+	}
+	skipped := func(reason string) coverageStatus {
+		return coverageStatus{category: "skipped", resource: reason}
+	}
+	planned := func(priority int, notes string) coverageStatus {
+		return coverageStatus{category: "planned", priority: priority, notes: notes}
 	}
 
 	return map[string]coverageStatus{
@@ -198,54 +217,232 @@ func coveredEndpoints() map[string]coverageStatus {
 		"GET /disable":      covered("client.DisableAPI", "v0.2.0"),
 		"POST /mcp/enable":  covered("coolify_api_settings (mcp_enabled)", "v0.4.0"),
 		"POST /mcp/disable": covered("coolify_api_settings (mcp_enabled)", "v0.4.0"),
+
+		// ── Contract routes not present in legacy OpenAPI inventory ──
+		// (classified so API_COVERAGE reflects Coolify source, not OpenAPI)
+		"DELETE /applications/{uuid}/destinations/{destination_uuid}":                   skipped("Application multi-destination attach/detach; primary TF surface is coolify_destination"),
+		"DELETE /applications/{uuid}/tags/{tag_uuid}":                                   skipped("Resource tags API; not modeled as first-class TF resources"),
+		"DELETE /cloud-init-scripts/{uuid}":                                             skipped("Cloud-init script library; not a TF resource"),
+		"DELETE /databases/{uuid}/tags/{tag_uuid}":                                      skipped("Resource tags API; not modeled as first-class TF resources"),
+		"DELETE /destinations/{uuid}":                                                   covered("coolify_destination", "v0.2.0"),
+		"DELETE /gitlab-apps/{gitlab_app_id}":                                           skipped("GitLab App integration; provider covers GitHub Apps only today"),
+		"DELETE /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}": skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"DELETE /projects/{uuid}/envs/{env_id}":                                         skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"DELETE /s3-storages/{uuid}":                                                    covered("coolify_s3_storage", "v0.1.13"),
+		"DELETE /servers/{uuid}/envs/{env_id}":                                          skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"DELETE /services/{uuid}/tags/{tag_uuid}":                                       skipped("Resource tags API; not modeled as first-class TF resources"),
+		"DELETE /tags/{uuid}":                                                           skipped("Resource tags API; not modeled as first-class TF resources"),
+		"DELETE /team/envs/{env_id}":                                                    skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"GET /applications/{uuid}/destinations":                                         skipped("Application multi-destination attach/detach; primary TF surface is coolify_destination"),
+		"GET /applications/{uuid}/rollback-images":                                      skipped("Application rollback/images; operational, not TF lifecycle"),
+		"GET /applications/{uuid}/tags":                                                 skipped("Resource tags API; not modeled as first-class TF resources"),
+		"GET /cloud-init-scripts":                                                       skipped("Cloud-init script library; not a TF resource"),
+		"GET /cloud-init-scripts/{uuid}":                                                skipped("Cloud-init script library; not a TF resource"),
+		"GET /databases/{uuid}/logs":                                                    skipped("Resource logs streaming; not durable TF state"),
+		"GET /databases/{uuid}/tags":                                                    skipped("Resource tags API; not modeled as first-class TF resources"),
+		"GET /destinations":                                                             covered("data.coolify_destinations", "v0.2.0"),
+		"GET /destinations/{uuid}":                                                      covered("data.coolify_destination", "v0.2.0"),
+		"GET /digitalocean/images":                                                      covered("data.coolify_digitalocean_images", "v0.2.0"),
+		"GET /digitalocean/regions":                                                     covered("data.coolify_digitalocean_regions", "v0.2.0"),
+		"GET /digitalocean/sizes":                                                       covered("data.coolify_digitalocean_sizes", "v0.2.0"),
+		"GET /digitalocean/ssh-keys":                                                    covered("data.coolify_digitalocean_ssh_keys", "v0.2.0"),
+		"GET /gitlab-apps":                                                              skipped("GitLab App integration; provider covers GitHub Apps only today"),
+		"GET /hetzner/firewalls":                                                        skipped("Hetzner firewalls/networks list; not required for coolify_server_hetzner"),
+		"GET /hetzner/networks":                                                         skipped("Hetzner firewalls/networks list; not required for coolify_server_hetzner"),
+		"GET /notifications/discord":                                                    planned(2, "Notification channel resources (#394)"),
+		"GET /notifications/email":                                                      planned(2, "Notification channel resources (#394)"),
+		"GET /notifications/pushover":                                                   planned(2, "Notification channel resources (#394)"),
+		"GET /notifications/slack":                                                      planned(2, "Notification channel resources (#394)"),
+		"GET /notifications/telegram":                                                   planned(2, "Notification channel resources (#394)"),
+		"GET /notifications/webhook":                                                    planned(2, "Notification channel resources (#394)"),
+		"GET /projects/{uuid}/environments/{environment_name_or_uuid}/envs":             skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"GET /projects/{uuid}/envs":                                                     skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"GET /s3-storages":                                                              covered("data.coolify_s3_storages", "v0.1.13"),
+		"GET /s3-storages/{uuid}":                                                       covered("data.coolify_s3_storage", "v0.1.13"),
+		"GET /servers/{server_uuid}/destinations":                                       covered("data.coolify_destinations", "v0.2.0"),
+		"GET /servers/{uuid}/cloudflare-tunnel":                                         skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/docker-cleanup":                                            skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/docker-cleanup/executions":                                 skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/envs":                                                      skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"GET /servers/{uuid}/export":                                                    skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/log-drains":                                                skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/proxy":                                                     skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/sentinel":                                                  skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /services/{uuid}/applications":                                             skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/applications/{app_uuid}":                                  skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/applications/{app_uuid}/logs":                             skipped("Resource logs streaming; not durable TF state"),
+		"GET /services/{uuid}/applications/{app_uuid}/restart":                          skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/applications/{app_uuid}/start":                            skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/applications/{app_uuid}/stop":                             skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/databases":                                                skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/databases/{database_uuid}":                                skipped("Nested service components; coolify_service manages the compose service unit"),
+		"GET /services/{uuid}/databases/{database_uuid}/logs":                           skipped("Resource logs streaming; not durable TF state"),
+		"GET /services/{uuid}/logs":                                                     skipped("Resource logs streaming; not durable TF state"),
+		"GET /services/{uuid}/tags":                                                     skipped("Resource tags API; not modeled as first-class TF resources"),
+		"GET /tags":                                                                     skipped("Resource tags API; not modeled as first-class TF resources"),
+		"GET /team":                                                                     skipped("Alias of /teams/current*; use data.coolify_team / team_members"),
+		"GET /team/envs":                                                                skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"GET /team/members":                                                             skipped("Alias of /teams/current*; use data.coolify_team / team_members"),
+		"GET /vultr/os":                                                                 covered("data.coolify_vultr_os", "v0.2.0"),
+		"GET /vultr/plans":                                                              covered("data.coolify_vultr_plans", "v0.2.0"),
+		"GET /vultr/regions":                                                            covered("data.coolify_vultr_regions", "v0.2.0"),
+		"GET /vultr/ssh-keys":                                                           covered("data.coolify_vultr_ssh_keys", "v0.2.0"),
+		"PATCH /cloud-init-scripts/{uuid}":                                              skipped("Cloud-init script library; not a TF resource"),
+		"PATCH /destinations/{uuid}":                                                    skipped("Destination fields RequireReplace; provider does not call PATCH"),
+		"PATCH /gitlab-apps/{gitlab_app_id}":                                            skipped("GitLab App integration; provider covers GitHub Apps only today"),
+		"PATCH /notifications/discord":                                                  planned(2, "Notification channel resources (#394)"),
+		"PATCH /notifications/email":                                                    planned(2, "Notification channel resources (#394)"),
+		"PATCH /notifications/pushover":                                                 planned(2, "Notification channel resources (#394)"),
+		"PATCH /notifications/slack":                                                    planned(2, "Notification channel resources (#394)"),
+		"PATCH /notifications/telegram":                                                 planned(2, "Notification channel resources (#394)"),
+		"PATCH /notifications/webhook":                                                  planned(2, "Notification channel resources (#394)"),
+		"PATCH /projects/{uuid}/environments/{environment_name_or_uuid}":                skipped("Environment description is TF state-only today; client has no Update call"),
+		"PATCH /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}": skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"PATCH /projects/{uuid}/envs/{env_id}":                                         skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"PATCH /s3-storages/{uuid}":                                                    covered("coolify_s3_storage", "v0.1.13"),
+		"PATCH /servers/{uuid}/cloudflare-tunnel":                                      skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"PATCH /servers/{uuid}/docker-cleanup":                                         skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"PATCH /servers/{uuid}/envs/{env_id}":                                          skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"PATCH /servers/{uuid}/log-drains":                                             skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"PATCH /servers/{uuid}/proxy":                                                  skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"PATCH /servers/{uuid}/sentinel":                                               skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"PATCH /services/{uuid}/applications/{app_uuid}":                               skipped("Nested service components; coolify_service manages the compose service unit"),
+		"PATCH /services/{uuid}/databases/{database_uuid}":                             skipped("Nested service components; coolify_service manages the compose service unit"),
+		"PATCH /tags/{uuid}":                                                           skipped("Resource tags API; not modeled as first-class TF resources"),
+		"PATCH /team/envs/{env_id}":                                                    skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"POST /applications/{uuid}/clone":                                              skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /applications/{uuid}/destinations":                                       skipped("Application multi-destination attach/detach; primary TF surface is coolify_destination"),
+		"POST /applications/{uuid}/migrate":                                            skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /applications/{uuid}/move":                                               skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /applications/{uuid}/restart":                                            covered("coolify_resource_action", "v0.3.0"),
+		"POST /applications/{uuid}/rollback":                                           skipped("Application rollback/images; operational, not TF lifecycle"),
+		"POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute":                skipped("One-shot task execute; coolify_scheduled_task manages definition only"),
+		"POST /applications/{uuid}/start":                                              covered("coolify_resource_action", "v0.3.0"),
+		"POST /applications/{uuid}/stop":                                               covered("coolify_resource_action", "v0.3.0"),
+		"POST /applications/{uuid}/storages/{storage_uuid}/backups/run":                skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /applications/{uuid}/tags":                                               skipped("Resource tags API; not modeled as first-class TF resources"),
+		"POST /cloud-init-scripts":                                                     skipped("Cloud-init script library; not a TF resource"),
+		"POST /databases/{uuid}/clone":                                                 skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /databases/{uuid}/migrate":                                               skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /databases/{uuid}/move":                                                  skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /databases/{uuid}/restart":                                               covered("coolify_resource_action", "v0.3.0"),
+		"POST /databases/{uuid}/start":                                                 covered("coolify_resource_action", "v0.3.0"),
+		"POST /databases/{uuid}/stop":                                                  covered("coolify_resource_action", "v0.3.0"),
+		"POST /databases/{uuid}/storages/{storage_uuid}/backups/run":                   skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /databases/{uuid}/tags":                                                  skipped("Resource tags API; not modeled as first-class TF resources"),
+		"POST /deploy":                                                                 covered("client.Deploy", "v0.2.0"),
+		"POST /disable":                                                                covered("coolify_api_settings", "v0.2.0"),
+		"POST /enable":                                                                 covered("coolify_api_settings", "v0.2.0"),
+		"POST /feedback":                                                               skipped("Coolify product feedback endpoint; not TF"),
+		"POST /gitlab-apps":                                                            skipped("GitLab App integration; provider covers GitHub Apps only today"),
+		"POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs":           skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"POST /projects/{uuid}/envs":                                                   skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"POST /s3-storages":                                                            covered("coolify_s3_storage", "v0.1.13"),
+		"POST /s3-storages/{uuid}/validate":                                            covered("coolify_s3_storage_validate", "v0.1.14"),
+		"POST /sentinel/push":                                                          skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/digitalocean":                                                   covered("coolify_server_digitalocean", "v0.2.0"),
+		"POST /servers/import":                                                         skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/vultr":                                                          covered("coolify_server_vultr", "v0.2.0"),
+		"POST /servers/{server_uuid}/destinations":                                     covered("coolify_destination", "v0.2.0"),
+		"POST /servers/{uuid}/claim":                                                   skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/cloudflare-tunnel/disable":                               skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/cloudflare-tunnel/enable":                                skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/docker-cleanup/run":                                      skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/envs":                                                    skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"POST /servers/{uuid}/export/mailbox":                                          skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/migrate":                                                 skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /servers/{uuid}/proxy/restart":                                           skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/transfer/complete":                                       skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/validate":                                                covered("coolify_server_validate", "v0.2.0"),
+		"POST /services/{uuid}/applications/{app_uuid}/logs":                           skipped("Resource logs streaming; not durable TF state"),
+		"POST /services/{uuid}/applications/{app_uuid}/restart":                        skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/applications/{app_uuid}/start":                          skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/applications/{app_uuid}/stop":                           skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/clone":                                                  skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /services/{uuid}/databases/{database_uuid}/restart":                      skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/databases/{database_uuid}/start":                        skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/databases/{database_uuid}/stop":                         skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
+		"POST /services/{uuid}/migrate":                                                skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /services/{uuid}/move":                                                   skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /services/{uuid}/restart":                                                covered("coolify_resource_action", "v0.3.0"),
+		"POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute":                    skipped("One-shot task execute; coolify_scheduled_task manages definition only"),
+		"POST /services/{uuid}/start":                                                  covered("coolify_resource_action", "v0.3.0"),
+		"POST /services/{uuid}/stop":                                                   covered("coolify_resource_action", "v0.3.0"),
+		"POST /services/{uuid}/storages/{storage_uuid}/backups/run":                    skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /services/{uuid}/tags":                                                   skipped("Resource tags API; not modeled as first-class TF resources"),
+		"POST /tags":                                                                   skipped("Resource tags API; not modeled as first-class TF resources"),
+		"POST /team/envs":                                                              skipped("Shared/project/server/team env vars; provider models resource-scoped envs (app/db/service)"),
+		"PUT /servers/{uuid}/proxy/configuration":                                      skipped("Server operational/control-plane API; not modeled as TF resources"),
 	}
 }
 
-// TestSpecCoverage_Completeness verifies that every endpoint in the OpenAPI
-// spec is tracked in coveredEndpoints(). Fails if the spec has new endpoints
-// not yet classified, or if the registry has stale entries removed from the spec.
+// TestSpecCoverage_Completeness verifies every contract route is classified in
+// coveredEndpoints(), and the registry has no unexpected keys outside the
+// contract (except registryExtrasNotInContract).
 func TestSpecCoverage_Completeness(t *testing.T) {
 	t.Parallel()
 
-	doc, err := LoadSpec("coolify-v4")
-	if err != nil {
-		t.Fatalf("loading spec: %v", err)
-	}
-
-	model, errs := (*doc).BuildV3Model()
-	if errs != nil {
-		t.Fatalf("building model: %v", errs)
-	}
-
 	coverage := coveredEndpoints()
-	specOps := extractSpecOperations(model.Model)
+	contractOps, err := loadContractRoutes(contractRoutePin)
+	if err != nil {
+		t.Fatalf("loading contract routes: %v", err)
+	}
 
 	var missing []string
-	for _, op := range specOps {
+	for _, op := range contractOps {
 		if _, ok := coverage[op]; !ok {
 			missing = append(missing, op)
 		}
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		t.Errorf("spec has %d endpoints not tracked in coveredEndpoints():\n  %s",
+		t.Errorf("contract has %d routes not tracked in coveredEndpoints():\n  %s",
 			len(missing), strings.Join(missing, "\n  "))
 	}
 
-	specSet := make(map[string]bool, len(specOps))
-	for _, op := range specOps {
-		specSet[op] = true
+	contractSet := make(map[string]bool, len(contractOps))
+	for _, op := range contractOps {
+		contractSet[op] = true
 	}
 	var stale []string
 	for op := range coverage {
-		if !specSet[op] {
-			stale = append(stale, op)
+		if contractSet[op] || registryExtrasNotInContract[op] {
+			continue
 		}
+		stale = append(stale, op)
 	}
 	if len(stale) > 0 {
 		sort.Strings(stale)
-		t.Errorf("coveredEndpoints() has %d entries not in the spec (stale?):\n  %s",
+		t.Errorf("coveredEndpoints() has %d entries not in the contract and not allowlisted:\n  %s",
 			len(stale), strings.Join(stale, "\n  "))
+	}
+}
+
+// TestLoadContractRoutes_Pin loads the pin and expects a non-empty route set.
+func TestLoadContractRoutes_Pin(t *testing.T) {
+	t.Parallel()
+	ops, err := loadContractRoutes(contractRoutePin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ops) < 100 {
+		t.Fatalf("expected many contract routes, got %d", len(ops))
+	}
+	// Sanity: known Coolify routes from source extract
+	want := []string{
+		"GET /s3-storages",
+		"POST /s3-storages/{uuid}/validate",
+		"POST /servers/{uuid}/validate",
+		"GET /destinations",
+	}
+	set := make(map[string]bool, len(ops))
+	for _, o := range ops {
+		set[o] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("pin contract missing expected route %s", w)
+		}
 	}
 }
 
@@ -323,10 +520,12 @@ func TestSpecCoverage_GenerateDoc(t *testing.T) {
 	b.WriteString("# API Coverage\n\n")
 	b.WriteString("<!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->\n")
 	b.WriteString("<!-- Run: make api-coverage -->\n\n")
-	b.WriteString("**Route inventory**: pinned OpenAPI spec in `testdata/specs/coolify-v4.json`  \n")
-	b.WriteString("**Field source of truth**: source-derived contract in `testdata/contracts/coolify-v4.json`  \n")
-	fmt.Fprintf(&b, "**Coverage**: %d / %d endpoints (%.1f%%)  \n", len(coveredList), total, pct)
-	fmt.Fprintf(&b, "**Planned**: %d | **Skipped**: %d\n", len(plannedList), len(skippedList))
+	b.WriteString("**Route inventory**: source-derived contract `testdata/contracts/coolify-v4.json` (`routes[]`)  \n")
+	b.WriteString("**Field source of truth**: same contract (`models` / endpoint allow lists)  \n")
+	b.WriteString("**Not inventory**: OpenAPI under `testdata/specs/` (partial upstream path list; do not treat as Coolify API completeness)  \n")
+	fmt.Fprintf(&b, "**Coverage**: %d covered / %d registry entries (%.1f%%)  \n", len(coveredList), total, pct)
+	fmt.Fprintf(&b, "**Planned**: %d | **Skipped**: %d  \n", len(plannedList), len(skippedList))
+	fmt.Fprintf(&b, "**Registry size**: %d (contract routes + allowlisted extras)\n", total)
 
 	// Covered
 	b.WriteString("\n## Covered\n\n")
@@ -354,11 +553,10 @@ func TestSpecCoverage_GenerateDoc(t *testing.T) {
 		fmt.Fprintf(&b, "| `%s` | %s |\n", e.endpoint, e.status.resource)
 	}
 
-	b.WriteString("\n## New in Spec (Unclassified)\n\n")
-	b.WriteString("_None. All spec endpoints are classified._\n\n")
-	b.WriteString("This section appears when the pinned spec is updated with new endpoints\n")
-	b.WriteString("that haven't been added to the coverage registry yet. The\n")
-	b.WriteString("`TestSpecCoverage_Completeness` test also fails in this case.\n")
+	b.WriteString("\n## Unclassified contract routes\n\n")
+	b.WriteString("_None. All pin contract routes are classified in `coveredEndpoints()`._\n\n")
+	b.WriteString("When `make contract-extract` adds routes, classify them in\n")
+	b.WriteString("`internal/spectest/coverage_test.go` or `TestSpecCoverage_Completeness` fails.\n")
 
 	outPath := filepath.Join(testdataDir(), "..", "API_COVERAGE.md")
 	if err := os.WriteFile(outPath, []byte(b.String()), 0644); err != nil {
@@ -367,28 +565,41 @@ func TestSpecCoverage_GenerateDoc(t *testing.T) {
 	t.Logf("Generated %s (%d bytes)", outPath, len(b.String()))
 }
 
-// extractSpecOperations returns all "METHOD /path" strings from the spec.
-func extractSpecOperations(model v3high.Document) []string {
-	var ops []string
-	if model.Paths == nil {
-		return ops
+// loadContractRoutes returns sorted unique "METHOD /path" keys from a contract JSON file
+// under testdata/contracts/.
+func loadContractRoutes(filename string) ([]string, error) {
+	path := filepath.Join(testdataDir(), "contracts", filename)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
-	for pair := model.Paths.PathItems.Oldest(); pair != nil; pair = pair.Next() {
-		path := pair.Key
-		item := pair.Value
-
-		for method, op := range map[string]*v3high.Operation{
-			"GET":    item.Get,
-			"POST":   item.Post,
-			"PUT":    item.Put,
-			"PATCH":  item.Patch,
-			"DELETE": item.Delete,
-		} {
-			if op != nil {
-				ops = append(ops, fmt.Sprintf("%s %s", method, path))
-			}
+	var doc struct {
+		Routes []struct {
+			Method string `json:"method"`
+			Path   string `json:"path"`
+		} `json:"routes"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filename, err)
+	}
+	seen := make(map[string]bool, len(doc.Routes))
+	var ops []string
+	for _, r := range doc.Routes {
+		method := strings.ToUpper(strings.TrimSpace(r.Method))
+		p := strings.TrimSpace(r.Path)
+		if method == "" || p == "" {
+			return nil, fmt.Errorf("%s: route entry with empty method or path", filename)
 		}
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		key := method + " " + p
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ops = append(ops, key)
 	}
 	sort.Strings(ops)
-	return ops
+	return ops, nil
 }

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -9,7 +9,10 @@ description: "Comparison of Coolify OpenAPI spec vs real source code contract."
 This page compares the pinned reusable OpenAPI schemas with the source-derived
 Coolify contract extracted from the real application code.
 
-> The source-derived contract is the field-level source of truth. The pinned OpenAPI spec is useful for reusable public schemas and route inventory, but some contract models only exist as internal implementation details or inline request bodies.
+> The source-derived contract is the source of truth for fields **and** routes
+> (`API_COVERAGE.md` inventories contract `routes[]`). The pinned OpenAPI spec is
+> useful only for reusable public schemas and optional request-shape checks; it is
+> **not** a complete Coolify route inventory.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -57,7 +57,7 @@ and maintainers. End users do not need to read this; see the
 | `internal/acctest/` | Shared test utilities: provider factories, mock server wrappers (`WithVersionEndpoint`), acceptance test helpers |
 | `internal/validate/` | Custom validators: UUID format, FQDN URL, cron syntax |
 | `internal/filter/` | Generic filtering helpers for plural data sources |
-| `internal/spectest/` | OpenAPI spec compliance tests, API coverage tracking, contract coverage verification |
+| `internal/spectest/` | Contract field/route coverage, API_COVERAGE.md generation, optional OpenAPI request checks |
 | `scripts/` | Python tooling: contract extraction from Coolify source, OpenAPI spec generation, contract diffing |
 | `testdata/contracts/` | Versioned contract JSON extracted from Coolify PHP source (source of truth for field definitions) |
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,7 +11,7 @@ Define your entire [Coolify](https://coolify.io/) infrastructure as code. Deploy
 
 Coolify gives you a self-hosted PaaS with a great UI. This provider adds what the UI cannot: reproducible environments, pull-request-based infrastructure reviews, disaster recovery from state, and CI/CD integration. Whether you run a single VPS or manage Coolify for a team, Terraform turns your infrastructure into a reviewable, testable, git-tracked configuration.
 
-**39 resources, 56 data sources, 99%+ Coolify API coverage.**
+**39 resources, 56 data sources.** Route coverage is tracked against the Coolify source contract (not upstream OpenAPI).
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Makes `API_COVERAGE.md` honest about Coolify API surface.

**Before:** route inventory = partial upstream OpenAPI (~143 ops) → marketing-style **~99%** covered while S3, destinations, DO/Vultr, notifications, etc. never entered the scoreboard.

**After:** route inventory = pin contract `routes[]` from Coolify source extract (~295 unique routes) → **~59.5% covered**, 12 planned (notifications / #394), rest intentionally skipped.

This does **not** change how features are implemented (still Coolify source → contract → client/resources). It only fixes the coverage **scoreboard**.

## Changes

- `TestSpecCoverage_Completeness` compares `coveredEndpoints()` to contract routes
- `loadContractRoutes()` loads pin contract; empty method/path fails loud
- Classify 153 contract-only routes (S3, destinations, DO/Vultr covered; notifications planned; ops/logs/tags/etc. skipped)
- Honest false-negative fixes after review: destination PATCH and environment PATCH are **not** covered (client has no call)
- Drop “99%+ API coverage” marketing line; docs/CONTRIBUTING/AGENTS point at contract inventory
- Tests: pin load, S3/destinations covered, notifications planned, false-covered guards

## Reviewer

Local review found 2 false “covered” PATCH routes + doc nits; all addressed before push.

## Test plan

- [x] `go test ./internal/spectest/ -run 'TestSpecCoverage_|TestLoadContract|TestCoveredEndpoints'`
- [x] `make docs-check api-coverage-check counts-check`
- [x] `make ci`
- [ ] PR CI green