### PR TITLE
ci: shard unit tests and cache tooling for faster CI

### DIFF
--- a/.github/actions/setup-coolify/action.yml
+++ b/.github/actions/setup-coolify/action.yml
@@ -98,13 +98,26 @@ runs:
           sleep 5
         done
 
+    - name: Cache Playwright browsers
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      id: playwright-cache
+      with:
+        # Playwright stores browsers under this path on Linux CI.
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('.github/requirements/playwright.txt') }}
+
     - name: Bootstrap Coolify test fixtures
       shell: bash
       env:
         COOLIFY_ENV_FILE: ${{ inputs.coolify-env-file }}
       run: |
         pip install --require-hashes -r .github/requirements/playwright.txt
-        playwright install --with-deps chromium
+        if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+          # Browsers cached; still need OS deps (not in the browser cache).
+          playwright install-deps chromium
+        else
+          playwright install --with-deps chromium
+        fi
         ./scripts/setup-coolify-test.sh
 
     - name: Verify Coolify API health

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,12 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Sharded wall clock is ~max(heaviest package) plus sibling work, not full suite.
     timeout-minutes: 20
     permissions:
       contents: read
-      code-quality: write
+      # gotestsum binary cache save
+      actions: write
     needs: changes
     if: >-
       always() &&
@@ -130,6 +132,14 @@ jobs:
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        # Three shards: pins multi-minute packages (application/service/redis)
+        # onto separate runners so the critical path drops from ~14m to ~8-9m.
+        shard: [0, 1, 2]
+    env:
+      UNIT_SHARD_COUNT: "3"
     steps:
       - name: Harden runner
         if: runner.os == 'Linux'
@@ -148,31 +158,127 @@ jobs:
         with:
           terraform_wrapper: false
           terraform_version: "1.15.x"
+      # Binary release is faster than `go install` (~8s) and cache hits are ~0s.
+      - name: Cache gotestsum
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/gotestsum
+          key: gotestsum-1.13.0-${{ runner.os }}-${{ runner.arch }}
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        env:
+          GOTESTSUM_VERSION: "1.13.0"
+        run: |
+          set -euo pipefail
+          BIN_DIR="${HOME}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          if [ -x "$BIN_DIR/gotestsum" ] && "$BIN_DIR/gotestsum" --version 2>/dev/null | grep -q "$GOTESTSUM_VERSION"; then
+            echo "gotestsum ${GOTESTSUM_VERSION} restored from cache"
+            exit 0
+          fi
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+          esac
+          URL="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_${OS}_${ARCH}.tar.gz"
+          TMP="$(mktemp)"
+          curl -sfL --retry 3 --retry-delay 2 --retry-all-errors -o "$TMP" "$URL"
+          tar xzf "$TMP" -C "$BIN_DIR" gotestsum
+          rm -f "$TMP"
+          gotestsum --version
       - name: Run tests
         run: |
-          mkdir -p test-results
+          set -euo pipefail
+          mkdir -p test-results coverage
+          # -parallel=1 is required for packages that fork terraform under -race
+          # (TSAN + fork/exec). See commit 39f893d. -p 4 still runs packages
+          # concurrently within the shard.
+          mapfile -t pkgs < <(bash scripts/ci-unit-packages.sh "${{ matrix.shard }}" "${UNIT_SHARD_COUNT}")
+          echo "Shard ${{ matrix.shard }}/${UNIT_SHARD_COUNT}: ${#pkgs[@]} packages"
+          printf '  %s\n' "${pkgs[@]}"
+          # gotestsum --packages wants a space-separated list (not commas).
+          pkg_list="${pkgs[*]}"
           gotestsum \
             --format pkgname \
-            --junitfile test-results/unit.xml \
+            --junitfile "test-results/unit-shard-${{ matrix.shard }}.xml" \
             --rerun-fails \
             --rerun-fails-max-failures=5 \
-            --packages ./... \
-            -- -race -cover -coverprofile=coverage.out -count=1 -p 4 -parallel=1 -timeout=15m
-      - name: Coverage summary
-        run: go tool cover -func=coverage.out | tail -1
-      - name: Convert coverage to Cobertura XML
-        run: |
-          go install github.com/boumenot/gocover-cobertura@v1.5.0
-          gocover-cobertura < coverage.out > coverage.xml
+            --packages "$pkg_list" \
+            -- -race -cover -coverprofile="coverage/coverage-shard-${{ matrix.shard }}.out" -count=1 -p 4 -parallel=1 -timeout=15m
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-results
+          name: test-results-shard-${{ matrix.shard }}
           path: test-results/
           retention-days: 14
+      - name: Upload coverage shard
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: coverage/
+          retention-days: 3
+          if-no-files-found: ignore
+
+  # Merge sharded coverage and publish once (avoids three competing uploads).
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes, test]
+    if: >-
+      always() &&
+      needs.test.result == 'success' &&
+      (
+        needs.changes.outputs.go == 'true' ||
+        needs.changes.outputs.ci == 'true' ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch'
+      )
+    permissions:
+      contents: read
+      actions: read
+      code-quality: write
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Download coverage shards
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-shard-*
+          path: coverage-shards
+          merge-multiple: true
+      - name: Merge coverage and summarize
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(coverage-shards/coverage-shard-*.out)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No coverage shard files found"
+            ls -laR coverage-shards || true
+            exit 1
+          fi
+          echo "mode: atomic" > coverage.out
+          for f in "${files[@]}"; do
+            # Drop the mode line from each shard profile.
+            tail -n +2 "$f" >> coverage.out || true
+          done
+          go tool cover -func=coverage.out | tail -1
+          go install github.com/boumenot/gocover-cobertura@v1.5.0
+          gocover-cobertura < coverage.out > coverage.xml
       - name: Upload coverage
         if: >-
           always() &&
@@ -469,6 +575,10 @@ jobs:
         needs.changes.outputs.scenarios == 'true' ||
         github.event_name == 'workflow_dispatch'
       )
+    permissions:
+      contents: read
+      # Playwright browser cache save in setup-coolify.
+      actions: write
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
@@ -600,6 +710,10 @@ jobs:
         needs.changes.outputs.scripts == 'true' ||
         github.event_name == 'workflow_dispatch'
       )
+    permissions:
+      contents: read
+      # Playwright browser cache save in setup-coolify.
+      actions: write
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
@@ -623,8 +737,35 @@ jobs:
       - name: Setup Coolify
         uses: ./.github/actions/setup-coolify
 
+      - name: Cache gotestsum
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/gotestsum
+          key: gotestsum-1.13.0-${{ runner.os }}-${{ runner.arch }}
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        env:
+          GOTESTSUM_VERSION: "1.13.0"
+        run: |
+          set -euo pipefail
+          BIN_DIR="${HOME}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          if [ -x "$BIN_DIR/gotestsum" ] && "$BIN_DIR/gotestsum" --version 2>/dev/null | grep -q "$GOTESTSUM_VERSION"; then
+            echo "gotestsum ${GOTESTSUM_VERSION} restored from cache"
+            exit 0
+          fi
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+          esac
+          URL="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_${OS}_${ARCH}.tar.gz"
+          TMP="$(mktemp)"
+          curl -sfL --retry 3 --retry-delay 2 --retry-all-errors -o "$TMP" "$URL"
+          tar xzf "$TMP" -C "$BIN_DIR" gotestsum
+          rm -f "$TMP"
+          gotestsum --version
       - name: Run acceptance tests
         env:
           # External secrets for tests that need real cloud APIs
@@ -678,6 +819,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # coverage is best-effort for the GitHub code-quality upload; do not gate
+    # merge on it (upload already uses fail-on-error: false).
     needs: [dco, test, lint, validate, scenario-tests, acceptance-tests]
     steps:
       - name: Harden runner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1210+ tests (unit + acceptance), 9 CI jobs.
+45 resources, 56 data sources, 1210+ tests (unit + acceptance), 10 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -228,8 +228,9 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 
 ## CI
 
-9 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
-Detect Changes, DCO (PR only), Test, Lint (includes Govulncheck + GoReleaser Check),
+10 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
+Detect Changes, DCO (PR only), Test (3 package shards), Coverage (merge shards),
+Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
 Acceptance Tests, Scenario Tests, Contract Freshness (weekly only), CI (gate).
 Acceptance Tests bootstrap a fresh Coolify instance on ubuntu-latest and run the full suite.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,8 +12,17 @@ default: help
 build: ## Compile the provider
 	GOFIPS140=latest go build -v ./...
 
+# Unit tests:
+# - Packages that fork terraform under resource.UnitTest must use -parallel=1 with
+#   -race (TSAN + fork/exec segfaults otherwise; see commit 39f893d).
+# - Pure packages (client/flex/filter/validate/spectest/acctest) can use higher
+#   in-package parallelism safely; CI shards the suite across runners instead.
+PURE_TEST_PKGS ?= ./internal/client/... ./internal/flex/... ./internal/filter/... ./internal/validate/... ./internal/spectest/... ./internal/acctest/...
+PLUGIN_TEST_PKGS ?= ./internal/provider/... ./internal/service/...
+
 test: ## Run unit tests (race detector, coverage)
-	go test -race -cover -count=1 -p 4 -parallel=1 -timeout=15m ./...
+	go test -race -cover -count=1 -p 8 -parallel=8 -timeout=10m $(PURE_TEST_PKGS)
+	go test -race -cover -count=1 -p 4 -parallel=1 -timeout=15m $(PLUGIN_TEST_PKGS)
 
 testacc: ## Run acceptance tests (needs COOLIFY_ENDPOINT + COOLIFY_TOKEN)
 	TF_ACC=1 go test -race -v -cover -count=1 -timeout=120m -p 1 -parallel=1 -run 'TestAcc' ./...

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,6 +15,16 @@ make test
 
 All unit tests run with `-race` detection and must pass in CI.
 
+`make test` runs pure packages (client, flex, filter, validate, spectest,
+acctest) with higher in-package parallelism, then plugin packages
+(`internal/provider`, `internal/service/...`) with `-parallel=1`. Plugin
+packages fork the Terraform binary under `resource.UnitTest`; higher
+in-package parallelism under `-race` has caused TSAN segfaults.
+
+CI shards unit tests across 3 runners (`scripts/ci-unit-packages.sh`) so
+the heaviest packages (application, service, redis) do not serialize the
+critical path.
+
 ### Writing a unit test
 
 1. Create `resource_test.go` in the resource's package

--- a/scripts/ci-unit-packages.sh
+++ b/scripts/ci-unit-packages.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Emit go package import paths for one CI unit-test shard.
+#
+# Usage:
+#   scripts/ci-unit-packages.sh <shard_index> <shard_count>
+#
+# Design:
+# - Pin the heaviest packages (from CI timings) onto different shards first so
+#   the wall-clock critical path is closer to max(package) than sum(packages).
+# - Round-robin the remaining packages for balance as the suite grows.
+# - Pure packages (no terraform-plugin-testing fork) may run with higher
+#   -parallel; callers decide flags. This script only selects packages.
+#
+# Exit non-zero if a shard would be empty (misconfiguration).
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <shard_index> <shard_count>" >&2
+  exit 2
+fi
+
+shard="$1"
+count="$2"
+
+if ! [[ "$shard" =~ ^[0-9]+$ && "$count" =~ ^[0-9]+$ ]]; then
+  echo "error: shard_index and shard_count must be non-negative integers" >&2
+  exit 2
+fi
+if (( count < 1 || shard < 0 || shard >= count )); then
+  echo "error: need 0 <= shard_index < shard_count (got shard=$shard count=$count)" >&2
+  exit 2
+fi
+
+# Heaviest UnitTest packages by recent CI package wall time.
+# Keep the three multi-minute packages on separate shards when count>=3.
+heavy_pins=(
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/redis"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/scheduledtask"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/githubapp"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/environmentvariable"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/storage"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/volumebackup"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/project"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/deployment"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/backup"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/privatekey"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/server"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/s3storage"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/cloudtoken"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/environment"
+)
+
+all_pkgs_file="$(mktemp)"
+selected_file="$(mktemp)"
+assigned_file="$(mktemp)"
+trap 'rm -f "$all_pkgs_file" "$selected_file" "$assigned_file"' EXIT
+
+go list ./... | grep -v '/tools' | LC_ALL=C sort >"$all_pkgs_file"
+
+pkg_in_module() {
+  grep -Fxq "$1" "$all_pkgs_file"
+}
+
+# 1) Place heavy pins round-robin so application→0, service→1, redis→2.
+pin_i=0
+for pkg in "${heavy_pins[@]}"; do
+  if ! pkg_in_module "$pkg"; then
+    continue
+  fi
+  target=$((pin_i % count))
+  pin_i=$((pin_i + 1))
+  printf '%s\n' "$pkg" >>"$assigned_file"
+  if (( target == shard )); then
+    printf '%s\n' "$pkg" >>"$selected_file"
+  fi
+done
+
+# 2) Remaining packages: stable sorted order, round-robin into shards.
+rest_i=0
+while IFS= read -r pkg; do
+  if grep -Fxq "$pkg" "$assigned_file" 2>/dev/null; then
+    continue
+  fi
+  target=$((rest_i % count))
+  rest_i=$((rest_i + 1))
+  if (( target == shard )); then
+    printf '%s\n' "$pkg" >>"$selected_file"
+  fi
+done <"$all_pkgs_file"
+
+if [[ ! -s "$selected_file" ]]; then
+  echo "error: shard $shard of $count selected zero packages" >&2
+  exit 1
+fi
+
+cat "$selected_file"

--- a/scripts/test_ci_unit_packages.py
+++ b/scripts/test_ci_unit_packages.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ci-unit-packages.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci-unit-packages.sh"
+
+
+def run_shard(shard: int, count: int) -> list[str]:
+    env = os.environ.copy()
+    # Ensure go is on PATH in minimal CI python-test environments.
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), str(shard), str(count)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    lines = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+    return lines
+
+
+class TestCIUnitPackages(unittest.TestCase):
+    def test_three_shards_partition_all_packages(self) -> None:
+        shards = [run_shard(i, 3) for i in range(3)]
+        union: list[str] = []
+        for s in shards:
+            self.assertGreater(len(s), 0, "shard must not be empty")
+            union.extend(s)
+
+        all_pkgs = subprocess.run(
+            ["go", "list", "./..."],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        all_pkgs = sorted(p for p in all_pkgs if "/tools" not in p)
+
+        self.assertEqual(sorted(union), all_pkgs)
+        self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
+
+    def test_heavy_packages_land_on_distinct_shards(self) -> None:
+        heavy = {
+            "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application": 0,
+            "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service": 1,
+            "github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/redis": 2,
+        }
+        for pkg, want_shard in heavy.items():
+            got = run_shard(want_shard, 3)
+            self.assertIn(pkg, got, f"{pkg} should be on shard {want_shard}")
+            for other in range(3):
+                if other == want_shard:
+                    continue
+                self.assertNotIn(pkg, run_shard(other, 3))
+
+    def test_bad_args(self) -> None:
+        bad = [
+            [],
+            ["0"],
+            ["0", "0"],
+            ["3", "3"],
+            ["x", "3"],
+        ]
+        for args in bad:
+            with self.subTest(args=args):
+                proc = subprocess.run(
+                    ["bash", str(SCRIPT), *args],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(proc.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR CI wall clock was dominated by the single **Test** job (~14-15 minutes of unit tests). Package timings showed three multi-minute outliers (`application` ~7.5m, `service` ~4.7m, `redis` ~4.2m) that could not finish sooner under one runner even with `-p 4`.

This change:

- **Shards unit tests across 3 runners** via `scripts/ci-unit-packages.sh`, pinning the heaviest packages onto different shards so the critical path tracks roughly `max(package)` plus sibling work (~8-9m expected) instead of the full suite sum.
- **Merges coverage** in a separate Coverage job (one upload instead of three).
- **Caches gotestsum** release binaries (replaces `go install` ~8s) and **Playwright browsers** in Coolify bootstrap.
- **Local `make test`**: pure packages run with higher `-parallel`; plugin `UnitTest` packages stay at `-parallel=1` (TSAN + terraform fork/exec safety from 39f893d).

In-package `-parallel=1` for plugin tests is unchanged on purpose. Raising it under `-race` has caused segfaults when multiple tests fork Terraform at once.

## Expected impact

| Job | Before | After (expected) |
|-----|--------|------------------|
| Test (critical path) | ~14-15m | ~8-9m |
| Acceptance / Scenario bootstrap | Playwright install every run | cache hit on browsers |
| gotestsum install | `go install` ~8s | binary cache ~0-1s |

## Test plan

- [x] `scripts/test_ci_unit_packages.py` (partition + heavy pin checks)
- [x] `make counts-check` (10 CI jobs)
- [x] `actionlint` on `ci.yml`
- [ ] CI green on this PR; compare Test shard durations to prior ~14m single job