### PR TITLE
feat: expose Coolify tip docker/compose version probes on servers

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -64,11 +64,15 @@ resource "coolify_server" "example" {
 
 ### Read-Only
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.
 - `delete_unused_volumes` (Boolean) Whether to delete unused Docker volumes during cleanup.
 - `disable_application_image_retention` (Boolean) Whether application image retention is disabled. Read-only (not on public server PATCH allow-list).
 - `docker_cleanup_frequency` (String) Cron expression for Docker cleanup schedule.
 - `docker_cleanup_threshold` (Number) Disk usage percentage threshold for Docker cleanup.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server. Read-only.
 - `force_disabled` (Boolean) Whether the server is force-disabled in Coolify. Read-only (not on public server PATCH allow-list).
 - `force_docker_cleanup` (Boolean) Whether to force Docker cleanup regardless of disk usage.
 - `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers).

--- a/docs/resources/server_digitalocean.md
+++ b/docs/resources/server_digitalocean.md
@@ -73,11 +73,15 @@ variable "digitalocean_token" {
 
 ### Read-Only
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.
 - `delete_unused_volumes` (Boolean) Whether to delete unused Docker volumes during cleanup.
 - `disable_application_image_retention` (Boolean) Whether application image retention is disabled. Read-only (not on public server PATCH allow-list).
 - `docker_cleanup_frequency` (String) Cron expression for Docker cleanup schedule.
 - `docker_cleanup_threshold` (Number) Disk usage percentage threshold for Docker cleanup.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server. Read-only.
 - `force_disabled` (Boolean) Whether the server is force-disabled in Coolify. Read-only (not on public server PATCH allow-list).
 - `force_docker_cleanup` (Boolean) Whether to force Docker cleanup regardless of disk usage.
 - `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers).

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -74,11 +74,15 @@ resource "coolify_server_hetzner" "example" {
 
 ### Read-Only
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.
 - `delete_unused_volumes` (Boolean) Whether to delete unused Docker volumes during cleanup.
 - `disable_application_image_retention` (Boolean) Whether application image retention is disabled. Read-only (not on public server PATCH allow-list).
 - `docker_cleanup_frequency` (String) Cron expression for Docker cleanup schedule.
 - `docker_cleanup_threshold` (Number) Disk usage percentage threshold for Docker cleanup.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server. Read-only.
 - `force_disabled` (Boolean) Whether the server is force-disabled in Coolify. Read-only (not on public server PATCH allow-list).
 - `force_docker_cleanup` (Boolean) Whether to force Docker cleanup regardless of disk usage.
 - `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers).

--- a/docs/resources/server_vultr.md
+++ b/docs/resources/server_vultr.md
@@ -73,11 +73,15 @@ variable "vultr_token" {
 
 ### Read-Only
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.
 - `delete_unused_volumes` (Boolean) Whether to delete unused Docker volumes during cleanup.
 - `disable_application_image_retention` (Boolean) Whether application image retention is disabled. Read-only (not on public server PATCH allow-list).
 - `docker_cleanup_frequency` (String) Cron expression for Docker cleanup schedule.
 - `docker_cleanup_threshold` (Number) Disk usage percentage threshold for Docker cleanup.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server. Read-only.
 - `force_disabled` (Boolean) Whether the server is force-disabled in Coolify. Read-only (not on public server PATCH allow-list).
 - `force_docker_cleanup` (Boolean) Whether to force Docker cleanup regardless of disk usage.
 - `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers).

--- a/internal/client/servers.go
+++ b/internal/client/servers.go
@@ -50,6 +50,12 @@ type ServerSettings struct {
 	IsLogdrainNewrelicEnabled            bool   `json:"is_logdrain_newrelic_enabled"`
 	LogdrainNewrelicBaseURI              string `json:"logdrain_newrelic_base_uri,omitempty"`
 	LogdrainNewrelicLicenseKey           string `json:"logdrain_newrelic_license_key,omitempty"`
+	// Docker/Compose version probes written by Coolify (tip/main; not on public PATCH).
+	// Empty on Coolify < tip that lacks the columns; safe omitempty JSON.
+	ComposeVersion          string `json:"compose_version,omitempty"`
+	ComposeVersionCheckedAt string `json:"compose_version_checked_at,omitempty"`
+	DockerVersion           string `json:"docker_version,omitempty"`
+	DockerVersionCheckedAt  string `json:"docker_version_checked_at,omitempty"`
 }
 
 type Server struct {

--- a/internal/service/digitalocean/resource.go
+++ b/internal/service/digitalocean/resource.go
@@ -100,6 +100,10 @@ type digitalOceanServerResourceModel struct {
 	IsLogdrainNewrelicEnabled         types.Bool   `tfsdk:"is_logdrain_newrelic_enabled"`
 	LogdrainNewrelicBaseURI           types.String `tfsdk:"logdrain_newrelic_base_uri"`
 	LogdrainNewrelicLicenseKey        types.String `tfsdk:"logdrain_newrelic_license_key"`
+	ComposeVersion                    types.String `tfsdk:"compose_version"`
+	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
+	DockerVersion                     types.String `tfsdk:"docker_version"`
+	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
 }
 
 // NewResource returns a new DigitalOcean server resource.
@@ -368,6 +372,8 @@ func (m *digitalOceanServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		IsLogdrainHighlightEnabled: &m.IsLogdrainHighlightEnabled, LogdrainHighlightProjectID: &m.LogdrainHighlightProjectID,
 		IsLogdrainNewrelicEnabled: &m.IsLogdrainNewrelicEnabled, LogdrainNewrelicBaseURI: &m.LogdrainNewrelicBaseURI,
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
+		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
+		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
 	}
 }
 

--- a/internal/service/hetzner/resource.go
+++ b/internal/service/hetzner/resource.go
@@ -98,6 +98,10 @@ type hetznerServerResourceModel struct {
 	IsLogdrainNewrelicEnabled         types.Bool   `tfsdk:"is_logdrain_newrelic_enabled"`
 	LogdrainNewrelicBaseURI           types.String `tfsdk:"logdrain_newrelic_base_uri"`
 	LogdrainNewrelicLicenseKey        types.String `tfsdk:"logdrain_newrelic_license_key"`
+	ComposeVersion                    types.String `tfsdk:"compose_version"`
+	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
+	DockerVersion                     types.String `tfsdk:"docker_version"`
+	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
 }
 
 // NewResource returns a new Hetzner server resource.
@@ -361,6 +365,8 @@ func (m *hetznerServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		IsLogdrainHighlightEnabled: &m.IsLogdrainHighlightEnabled, LogdrainHighlightProjectID: &m.LogdrainHighlightProjectID,
 		IsLogdrainNewrelicEnabled: &m.IsLogdrainNewrelicEnabled, LogdrainNewrelicBaseURI: &m.LogdrainNewrelicBaseURI,
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
+		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
+		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
 	}
 }
 

--- a/internal/service/server/common.go
+++ b/internal/service/server/common.go
@@ -174,6 +174,12 @@ func CommonServerAttrs(ctx context.Context, extra map[string]schema.Attribute) m
 
 // addExtendedSettingsAttrs adds read-only extended server settings returned by the API.
 func addExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
+	addCoreExtendedSettingsAttrs(attrs)
+	addLogdrainSettingsAttrs(attrs)
+	addHostProbeVersionAttrs(attrs)
+}
+
+func addCoreExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
 	attrs["wildcard_domain"] = schema.StringAttribute{
 		MarkdownDescription: "Wildcard domain for applications on this server (e.g., `example.com`).",
 		Computed:            true,
@@ -267,6 +273,9 @@ func addExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
 		MarkdownDescription: "Custom Sentinel push URL. Read-only (not on public server PATCH allow-list).",
 		Computed:            true,
 	}
+}
+
+func addLogdrainSettingsAttrs(attrs map[string]schema.Attribute) {
 	attrs["is_logdrain_axiom_enabled"] = schema.BoolAttribute{
 		MarkdownDescription: "Whether Axiom log drain is enabled. Read-only (not on public server PATCH allow-list).",
 		Computed:            true,
@@ -314,6 +323,10 @@ func addExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
 		Computed:            true,
 		Sensitive:           true,
 	}
+}
+
+// addHostProbeVersionAttrs adds Coolify tip/main host probe fields (expected >= 4.3.2).
+func addHostProbeVersionAttrs(attrs map[string]schema.Attribute) {
 	attrs["compose_version"] = schema.StringAttribute{
 		MarkdownDescription: "Docker Compose version reported by Coolify for this server (host probe). " +
 			"Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.",

--- a/internal/service/server/common.go
+++ b/internal/service/server/common.go
@@ -63,6 +63,10 @@ type ServerCommonPtrs struct {
 	IsLogdrainNewrelicEnabled         *types.Bool
 	LogdrainNewrelicBaseURI           *types.String
 	LogdrainNewrelicLicenseKey        *types.String
+	ComposeVersion                    *types.String
+	ComposeVersionCheckedAt           *types.String
+	DockerVersion                     *types.String
+	DockerVersionCheckedAt            *types.String
 }
 
 // CommonServerAttrs returns the schema attributes shared by all server
@@ -310,6 +314,24 @@ func addExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
 		Computed:            true,
 		Sensitive:           true,
 	}
+	attrs["compose_version"] = schema.StringAttribute{
+		MarkdownDescription: "Docker Compose version reported by Coolify for this server (host probe). " +
+			"Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.",
+		Computed: true,
+	}
+	attrs["compose_version_checked_at"] = schema.StringAttribute{
+		MarkdownDescription: "When Coolify last checked the Compose version on this server. Read-only.",
+		Computed:            true,
+	}
+	attrs["docker_version"] = schema.StringAttribute{
+		MarkdownDescription: "Docker engine version reported by Coolify for this server (host probe). " +
+			"Read-only; populated by Coolify tip/main (expected in Coolify >= 4.3.2). Empty on older instances.",
+		Computed: true,
+	}
+	attrs["docker_version_checked_at"] = schema.StringAttribute{
+		MarkdownDescription: "When Coolify last checked the Docker version on this server. Read-only.",
+		Computed:            true,
+	}
 }
 
 // FlattenServerCommon sets the fields shared by all server resource types
@@ -382,6 +404,10 @@ func flattenExtendedSettings(s *client.ServerSettings, f ServerCommonPtrs) {
 	setBoolPtr(f.IsLogdrainNewrelicEnabled, s.IsLogdrainNewrelicEnabled)
 	setStringPtr(f.LogdrainNewrelicBaseURI, s.LogdrainNewrelicBaseURI)
 	setStringPtr(f.LogdrainNewrelicLicenseKey, s.LogdrainNewrelicLicenseKey)
+	setStringPtr(f.ComposeVersion, s.ComposeVersion)
+	setStringPtr(f.ComposeVersionCheckedAt, s.ComposeVersionCheckedAt)
+	setStringPtr(f.DockerVersion, s.DockerVersion)
+	setStringPtr(f.DockerVersionCheckedAt, s.DockerVersionCheckedAt)
 }
 
 func setBoolPtr(dst *types.Bool, v bool) {

--- a/internal/service/server/common_test.go
+++ b/internal/service/server/common_test.go
@@ -32,6 +32,8 @@ func newTestPtrs() (ServerCommonPtrs, *testModel) {
 		DockerCleanupFrequency:      &m.DockerCleanupFrequency, DockerCleanupThreshold: &m.DockerCleanupThreshold,
 		ForceDockerCleanup: &m.ForceDockerCleanup, DeleteUnusedVolumes: &m.DeleteUnusedVolumes,
 		DeleteUnusedNetworks: &m.DeleteUnusedNetworks, GenerateExactLabels: &m.GenerateExactLabels,
+		ComposeVersion: &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
+		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
 	}, m
 }
 
@@ -58,6 +60,10 @@ type testModel struct {
 	DeleteUnusedVolumes               types.Bool
 	DeleteUnusedNetworks              types.Bool
 	GenerateExactLabels               types.Bool
+	ComposeVersion                    types.String
+	ComposeVersionCheckedAt           types.String
+	DockerVersion                     types.String
+	DockerVersionCheckedAt            types.String
 }
 
 var readOnlyExtendedSettingNames = []string{
@@ -76,6 +82,10 @@ var readOnlyExtendedSettingNames = []string{
 	"delete_unused_volumes",
 	"delete_unused_networks",
 	"generate_exact_labels",
+	"compose_version",
+	"compose_version_checked_at",
+	"docker_version",
+	"docker_version_checked_at",
 }
 
 var expectedWritableServerUpdateKeys = []string{
@@ -811,5 +821,26 @@ func TestHasNonDefaultSettings_NullFields(t *testing.T) {
 	plan := serverResourceModel{}
 	if hasNonDefaultSettings(plan) {
 		t.Error("expected false when all fields are null/zero-value")
+	}
+}
+
+func TestFlattenExtendedSettings_DockerComposeVersions(t *testing.T) {
+	t.Parallel()
+	ptrs, m := newTestPtrs()
+	s := &client.ServerSettings{
+		ComposeVersion:          "2.29.1",
+		ComposeVersionCheckedAt: "2026-08-13T12:00:00.000000Z",
+		DockerVersion:           "27.0.3",
+		DockerVersionCheckedAt:  "2026-08-13T12:00:01.000000Z",
+	}
+	flattenExtendedSettings(s, ptrs)
+	if m.ComposeVersion.ValueString() != "2.29.1" {
+		t.Fatalf("compose_version=%q", m.ComposeVersion.ValueString())
+	}
+	if m.DockerVersion.ValueString() != "27.0.3" {
+		t.Fatalf("docker_version=%q", m.DockerVersion.ValueString())
+	}
+	if m.ComposeVersionCheckedAt.IsNull() || m.DockerVersionCheckedAt.IsNull() {
+		t.Fatal("checked_at fields should be set")
 	}
 }

--- a/internal/service/server/resource.go
+++ b/internal/service/server/resource.go
@@ -79,6 +79,10 @@ type serverResourceModel struct {
 	IsLogdrainNewrelicEnabled         types.Bool   `tfsdk:"is_logdrain_newrelic_enabled"`
 	LogdrainNewrelicBaseURI           types.String `tfsdk:"logdrain_newrelic_base_uri"`
 	LogdrainNewrelicLicenseKey        types.String `tfsdk:"logdrain_newrelic_license_key"`
+	ComposeVersion                    types.String `tfsdk:"compose_version"`
+	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
+	DockerVersion                     types.String `tfsdk:"docker_version"`
+	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
 }
 
 // NewResource returns a new server resource.
@@ -305,6 +309,8 @@ func (m *serverResourceModel) commonPtrs() ServerCommonPtrs {
 		IsLogdrainHighlightEnabled: &m.IsLogdrainHighlightEnabled, LogdrainHighlightProjectID: &m.LogdrainHighlightProjectID,
 		IsLogdrainNewrelicEnabled: &m.IsLogdrainNewrelicEnabled, LogdrainNewrelicBaseURI: &m.LogdrainNewrelicBaseURI,
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
+		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
+		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
 	}
 }
 

--- a/internal/service/vultr/resource.go
+++ b/internal/service/vultr/resource.go
@@ -100,6 +100,10 @@ type vultrServerResourceModel struct {
 	IsLogdrainNewrelicEnabled         types.Bool   `tfsdk:"is_logdrain_newrelic_enabled"`
 	LogdrainNewrelicBaseURI           types.String `tfsdk:"logdrain_newrelic_base_uri"`
 	LogdrainNewrelicLicenseKey        types.String `tfsdk:"logdrain_newrelic_license_key"`
+	ComposeVersion                    types.String `tfsdk:"compose_version"`
+	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
+	DockerVersion                     types.String `tfsdk:"docker_version"`
+	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
 }
 
 // NewResource returns a new Vultr server resource.
@@ -370,6 +374,8 @@ func (m *vultrServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		IsLogdrainHighlightEnabled: &m.IsLogdrainHighlightEnabled, LogdrainHighlightProjectID: &m.LogdrainHighlightProjectID,
 		IsLogdrainNewrelicEnabled: &m.IsLogdrainNewrelicEnabled, LogdrainNewrelicBaseURI: &m.LogdrainNewrelicBaseURI,
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
+		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
+		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses tip API drift from coolify-channel **#699** (4 ServerSetting field additions on Coolify tip/main vs pin v4.3.1).

## Changes

Coolify tip writes host probe fields on `ServerSetting`:

- `compose_version` / `compose_version_checked_at`
- `docker_version` / `docker_version_checked_at`

These are **not** on the public server PATCH allow-list (`ServersController`), so the provider exposes them as **computed read-only** attributes on:

- `coolify_server`
- `coolify_server_hetzner`
- `coolify_server_digitalocean`
- `coolify_server_vultr`

On Coolify <= 4.3.1 (pin) the API omits them and Terraform state stays empty/null. On tip / upcoming 4.3.2+ GET settings populate them when Coolify has probed the host.

## Version note

Does **not** promote the contract pin to 4.3.2 (no Git tag/CDN yet). Prepares the provider so pin promotion is a smaller step when stable ships.

## Test plan

- [x] Unit test flatten for the four fields
- [x] `go test` server/hetzner/do/vultr packages
- [x] `make contract-check` (pin unchanged)
- [ ] PR CI green

Ref #699