### PR TITLE
test: server DS version probes and notification acc version gates

### DIFF
--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -27,10 +27,14 @@ data "coolify_server" "example" {
 
 ### Read-Only
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server.
 - `concurrent_builds` (Number) How many deployments can run in parallel on this server.
 - `connection_timeout` (Number) SSH connection timeout in seconds.
 - `deployment_queue_limit` (Number) Maximum number of queued deployments.
 - `description` (String) A description of the server.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server.
 - `dynamic_timeout` (Number) Timeout in seconds for Docker operations (pull, build, health check) during deployment.
 - `ip` (String) The IP address of the server.
 - `is_build_server` (Boolean) Whether this server is used for building applications.

--- a/docs/data-sources/servers.md
+++ b/docs/data-sources/servers.md
@@ -45,10 +45,14 @@ Required:
 
 Read-Only:
 
+- `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
+- `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server.
 - `concurrent_builds` (Number) How many deployments can run in parallel on this server.
 - `connection_timeout` (Number) SSH connection timeout in seconds.
 - `deployment_queue_limit` (Number) Maximum number of queued deployments.
 - `description` (String) A description of the server.
+- `docker_version` (String) Docker engine version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
+- `docker_version_checked_at` (String) When Coolify last checked the Docker version on this server.
 - `dynamic_timeout` (Number) Timeout in seconds for Docker operations (pull, build, health check) during deployment.
 - `ip` (String) The IP address of the server.
 - `is_build_server` (Boolean) Whether this server is used for building applications.

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -32,7 +32,7 @@ output "coolify_version" {
 | **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
 | **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
-| **≥ 4.3.0** | Full current surface: volume backup schedules, `noindex_domains`, GPU/log-drain application settings, etc. |
+| **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
 
 Pinned API contract today: Coolify **v4.3.2** (`testdata/contracts/coolify-v4.json`).
 The provider remains usable on 4.1.0+ for the common surface.
@@ -85,6 +85,17 @@ needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
 | `coolify_storage_backup` | Scheduled volume/directory backups (VolumeBackups API, [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946)) |
 | `coolify_s3_storage` / `coolify_s3_storages` | Manage and list S3-compatible storage configurations (database backup targets) |
 | `coolify_s3_storage_validate` | POST validate S3 connectivity (after credential rotation) |
+| `coolify_notification_discord` | Team Discord notification settings |
+| `coolify_notification_slack` | Team Slack notification settings |
+| `coolify_notification_email` | Team email (SMTP/Resend) notification settings |
+| `coolify_notification_telegram` | Team Telegram notification settings |
+| `coolify_notification_webhook` | Team generic webhook notification settings |
+| `coolify_notification_pushover` | Team Pushover notification settings |
+
+Server host version probes (`compose_version`, `docker_version`, and `*_checked_at`)
+on `coolify_server` / cloud server resources and `coolify_server` / `coolify_servers`
+data sources are populated on Coolify **≥ 4.3.2** after Coolify probes the host.
+Empty on older instances.
 
 ## Application attributes by Coolify version
 

--- a/internal/client/servers_settings_test.go
+++ b/internal/client/servers_settings_test.go
@@ -1,0 +1,38 @@
+package client_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerSettings_VersionProbeJSON(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"concurrent_builds": 1,
+		"dynamic_timeout": 10,
+		"deployment_queue_limit": 1,
+		"server_disk_usage_notification_threshold": 80,
+		"server_disk_usage_check_frequency": "0 * * * *",
+		"connection_timeout": 10,
+		"compose_version": "2.29.1",
+		"compose_version_checked_at": "2026-08-13T12:00:00.000000Z",
+		"docker_version": "27.0.3",
+		"docker_version_checked_at": "2026-08-13T12:00:01.000000Z"
+	}`)
+	var s client.ServerSettings
+	require.NoError(t, json.Unmarshal(raw, &s))
+	assert.Equal(t, "2.29.1", s.ComposeVersion)
+	assert.Equal(t, "27.0.3", s.DockerVersion)
+	assert.Contains(t, s.ComposeVersionCheckedAt, "2026-08-13")
+
+	out, err := json.Marshal(s)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &m))
+	assert.Equal(t, "2.29.1", m["compose_version"])
+	assert.Equal(t, "27.0.3", m["docker_version"])
+}

--- a/internal/service/notificationdiscord/resource_acc_test.go
+++ b/internal/service/notificationdiscord/resource_acc_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccDiscordNotificationResource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.AccTestSkipIfNoNotificationAPI(t)
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/notificationpushover/resource_acc_test.go
+++ b/internal/service/notificationpushover/resource_acc_test.go
@@ -10,6 +10,7 @@ import (
 func TestAccPushoverNotificationResource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.AccTestSkipIfNoNotificationAPI(t)
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/notificationslack/resource_acc_test.go
+++ b/internal/service/notificationslack/resource_acc_test.go
@@ -12,6 +12,7 @@ import (
 func TestAccSlackNotificationResource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.AccTestSkipIfNoNotificationAPI(t)
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/notificationwebhook/resource_acc_test.go
+++ b/internal/service/notificationwebhook/resource_acc_test.go
@@ -12,6 +12,7 @@ import (
 func TestAccWebhookNotificationResource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.AccTestSkipIfNoNotificationAPI(t)
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/server/data_source.go
+++ b/internal/service/server/data_source.go
@@ -39,6 +39,10 @@ type serverDataSourceModel struct {
 	ConnectionTimeout                    types.Int64  `tfsdk:"connection_timeout"`
 	ServerDiskUsageNotificationThreshold types.Int64  `tfsdk:"server_disk_usage_notification_threshold"`
 	ServerDiskUsageCheckFrequency        types.String `tfsdk:"server_disk_usage_check_frequency"`
+	ComposeVersion                       types.String `tfsdk:"compose_version"`
+	ComposeVersionCheckedAt              types.String `tfsdk:"compose_version_checked_at"`
+	DockerVersion                        types.String `tfsdk:"docker_version"`
+	DockerVersionCheckedAt               types.String `tfsdk:"docker_version_checked_at"`
 }
 
 func serverDataSourceAttributes() map[string]schema.Attribute {
@@ -103,6 +107,24 @@ func serverDataSourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Cron expression for how often disk usage is checked.",
 			Computed:            true,
 		},
+		"compose_version": schema.StringAttribute{
+			MarkdownDescription: "Docker Compose version reported by Coolify for this server (host probe). " +
+				"Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.",
+			Computed: true,
+		},
+		"compose_version_checked_at": schema.StringAttribute{
+			MarkdownDescription: "When Coolify last checked the Compose version on this server.",
+			Computed:            true,
+		},
+		"docker_version": schema.StringAttribute{
+			MarkdownDescription: "Docker engine version reported by Coolify for this server (host probe). " +
+				"Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.",
+			Computed: true,
+		},
+		"docker_version_checked_at": schema.StringAttribute{
+			MarkdownDescription: "When Coolify last checked the Docker version on this server.",
+			Computed:            true,
+		},
 	}
 }
 
@@ -133,6 +155,10 @@ func flattenServerDataSourceModel(srv client.Server) serverDataSourceModel {
 	model.ConnectionTimeout = types.Int64Value(int64(connectionTimeout))
 	model.ServerDiskUsageNotificationThreshold = types.Int64Value(int64(srv.Settings.ServerDiskUsageNotificationThreshold))
 	model.ServerDiskUsageCheckFrequency = flex.StringToFramework(srv.Settings.ServerDiskUsageCheckFrequency)
+	model.ComposeVersion = flex.StringToFramework(srv.Settings.ComposeVersion)
+	model.ComposeVersionCheckedAt = flex.StringToFramework(srv.Settings.ComposeVersionCheckedAt)
+	model.DockerVersion = flex.StringToFramework(srv.Settings.DockerVersion)
+	model.DockerVersionCheckedAt = flex.StringToFramework(srv.Settings.DockerVersionCheckedAt)
 
 	return model
 }

--- a/internal/service/server/data_source_list_test.go
+++ b/internal/service/server/data_source_list_test.go
@@ -31,7 +31,8 @@ func TestServersDataSource(t *testing.T) {
 				DeploymentQueueLimit:                 0,
 				ConnectionTimeout:                    0,
 				ServerDiskUsageNotificationThreshold: 80,
-				ServerDiskUsageCheckFrequency:        "*/5 * * * *",
+				ComposeVersion:                       "2.29.1", DockerVersion: "27.0.3",
+				ServerDiskUsageCheckFrequency: "*/5 * * * *",
 			},
 		},
 		{

--- a/internal/service/server/data_source_test.go
+++ b/internal/service/server/data_source_test.go
@@ -31,7 +31,8 @@ func TestServerDataSource(t *testing.T) {
 			DeploymentQueueLimit:                 0,
 			ConnectionTimeout:                    0,
 			ServerDiskUsageNotificationThreshold: 80,
-			ServerDiskUsageCheckFrequency:        "*/5 * * * *",
+			ComposeVersion:                       "2.29.1", DockerVersion: "27.0.3",
+			ServerDiskUsageCheckFrequency: "*/5 * * * *",
 		},
 	}
 
@@ -73,6 +74,8 @@ data "coolify_server" "test" {
 					resource.TestCheckResourceAttr("data.coolify_server.test", "deployment_queue_limit", "0"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "connection_timeout", "10"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "server_disk_usage_notification_threshold", "80"),
+					resource.TestCheckResourceAttr("data.coolify_server.test", "compose_version", "2.29.1"),
+					resource.TestCheckResourceAttr("data.coolify_server.test", "docker_version", "27.0.3"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "server_disk_usage_check_frequency", "*/5 * * * *"),
 				),
 			},

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -32,7 +32,7 @@ output "coolify_version" {
 | **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
 | **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
-| **≥ 4.3.0** | Full current surface: volume backup schedules, `noindex_domains`, GPU/log-drain application settings, etc. |
+| **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
 
 Pinned API contract today: Coolify **v4.3.2** (`testdata/contracts/coolify-v4.json`).
 The provider remains usable on 4.1.0+ for the common surface.
@@ -85,6 +85,17 @@ needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
 | `coolify_storage_backup` | Scheduled volume/directory backups (VolumeBackups API, [coollabsio/coolify#10946](https://github.com/coollabsio/coolify/pull/10946)) |
 | `coolify_s3_storage` / `coolify_s3_storages` | Manage and list S3-compatible storage configurations (database backup targets) |
 | `coolify_s3_storage_validate` | POST validate S3 connectivity (after credential rotation) |
+| `coolify_notification_discord` | Team Discord notification settings |
+| `coolify_notification_slack` | Team Slack notification settings |
+| `coolify_notification_email` | Team email (SMTP/Resend) notification settings |
+| `coolify_notification_telegram` | Team Telegram notification settings |
+| `coolify_notification_webhook` | Team generic webhook notification settings |
+| `coolify_notification_pushover` | Team Pushover notification settings |
+
+Server host version probes (`compose_version`, `docker_version`, and `*_checked_at`)
+on `coolify_server` / cloud server resources and `coolify_server` / `coolify_servers`
+data sources are populated on Coolify **≥ 4.3.2** after Coolify probes the host.
+Empty on older instances.
 
 ## Application attributes by Coolify version
 


### PR DESCRIPTION
## Summary

MPI cycle polish after the Coolify 4.3.2 pin and server version-probe work.

## Changes

- **QA:** `coolify_server` / `coolify_servers` data sources now return `compose_version`, `docker_version`, and `*_checked_at` (same fields as server resources)
- **QA:** Client JSON round-trip test for the new ServerSettings tags
- **QA:** All six notification acc packages gate with `AccTestSkipIfCoolifyBelow(t, "4.3.0")` in addition to the API probe
- **End User:** Version support guide lists notification resources under Coolify ≥ 4.3.0 and documents host version probes for ≥ 4.3.2

## Test plan

- [x] `go test ./internal/service/server/ ./internal/client/`
- [x] docs regenerated
- [ ] PR CI green