### PR TITLE
test: notification destroy/create error coverage and import docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1230+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 56 data sources, 1240+ tests (unit + acceptance), 10 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1230+ tests (unit + acceptance)
+- 1240+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1220+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 56 data sources, 1230+ tests (unit + acceptance), 10 CI jobs.
 17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1220+ tests (unit + acceptance)
+- 1230+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 
 | Area | Coverage |
 |---|---|
-| Managed resources | 41 |
+| Managed resources | 45 |
 | Data sources | 56 |
-| Tests | 1210+ unit and acceptance tests |
+| Tests | 1230+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -315,7 +315,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1220+ tests, race detector enabled)
+make test                                       # Run unit tests (1230+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 45 |
 | Data sources | 56 |
-| Tests | 1230+ unit and acceptance tests |
+| Tests | 1240+ unit and acceptance tests |
 | Scenario examples | 17 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -315,7 +315,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1230+ tests, race detector enabled)
+make test                                       # Run unit tests (1240+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,24 +7,26 @@ Priorities may shift based on community feedback and upstream Coolify API change
 
 The provider covers the core Coolify resource model:
 
-- 38 managed resources (projects, servers, applications, databases, services,
-  backups, environment variables, deployments, and more)
+- 45 managed resources (projects, servers, applications, databases, services,
+  backups, environment variables, deployments, notification channels, S3 storage,
+  and more)
 - 56 data sources for reading existing infrastructure
 - 17 ACME Corp scenario examples with integration tests
 - Full import support for adopting existing Coolify resources
 - Coolify v4.2 surfaces: destinations, DigitalOcean/Vultr server provisioning
+- Coolify v4.3 surfaces: notification channels, S3 storage, docker/compose version probes
 - Published on both [Terraform Registry](https://registry.terraform.io/providers/coolify-terraform/coolify)
   and [OpenTofu Registry](https://search.opentofu.org/provider/coolify-terraform/coolify)
   ([#414](https://github.com/coolify-terraform/terraform-provider-coolify/issues/414))
 
 ## Near Term
 
-### Notification channel resources
+### ~~Notification channel resources~~ (shipped)
 
-Add resources for managing Coolify notification channels (Slack, Discord, email,
-Telegram, etc.) once the upstream API supports full CRUD.
+Team-scoped notification resources ship for Coolify >= v4.3.0 (provider v0.1.14+):
+email, Discord, Slack, Telegram, Pushover, and generic webhook
 ([#394](https://github.com/coolify-terraform/terraform-provider-coolify/issues/394),
-blocked on upstream)
+[#704](https://github.com/coolify-terraform/terraform-provider-coolify/issues/704)).
 
 ### ~~S3 storage resource~~ (shipped)
 

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -39,6 +39,25 @@ API token can read sensitive data. When `coolify_database_backup` uses
 `save_s3 = true`, set `s3_storage_uuid` to a managed or existing storage UUID
 (for example `coolify_s3_storage.backups.uuid`).
 
+### Team Singleton Resources (Notification Channels)
+
+Notification channel resources are **team-scoped singletons**: one configuration
+per Coolify team (selected by the API token). There is no UUID. Import with the
+literal id `current`:
+
+```bash
+terraform import coolify_notification_discord.main current
+terraform import coolify_notification_slack.main current
+terraform import coolify_notification_email.main current
+terraform import coolify_notification_telegram.main current
+terraform import coolify_notification_webhook.main current
+terraform import coolify_notification_pushover.main current
+```
+
+Requires Coolify >= v4.3.0. On destroy, these resources **disable** the channel
+(`enabled = false` or email SMTP/Resend off); they do not delete Coolify-side
+webhook URLs or secrets. Keep secrets in configuration after import (see table below).
+
 ### Compound Import Format (Recommended for Applications, Databases, and Services)
 
 Applications, databases, and services support an extended compound import format
@@ -140,6 +159,10 @@ must be set in your `.tf` configuration before running `terraform plan`:
 | `coolify_github_app` | `client_secret`, `webhook_secret`, `private_key_uuid` (`client_secret` and `private_key_uuid` are write-only, and `webhook_secret` is not reliably returned after create/import, including provider-generated values when omitted on create) |
 | `coolify_cloud_token` | `token` (write-only, may not be returned by the API) |
 | `coolify_private_key` | `private_key` (requires API token with `root` or `read:sensitive` permission; hidden otherwise) |
+| `coolify_notification_discord`, `coolify_notification_slack`, `coolify_notification_webhook` | `webhook_url` (Coolify may omit unless the token has `read:sensitive` or root; preserve in configuration) |
+| `coolify_notification_telegram` | `token`, `chat_id`, thread id fields (sensitive; may be omitted without `read:sensitive`) |
+| `coolify_notification_pushover` | `user_key`, `api_token` (sensitive; may be omitted without `read:sensitive`) |
+| `coolify_notification_email` | SMTP/Resend passwords and API keys (sensitive; may be omitted without `read:sensitive`) |
 | Database backups | `database_uuid`, `s3_storage_uuid` when `save_s3 = true` |
 
 If these fields are missing, `terraform plan` will either show a diff

--- a/docs/resources/notification_pushover.md
+++ b/docs/resources/notification_pushover.md
@@ -17,6 +17,7 @@ On destroy, Pushover notifications are disabled (`enabled = false`); user key an
 
 ```terraform
 # Team Pushover notification settings (Coolify >= v4.3.0).
+# Import: terraform import coolify_notification_pushover.main current
 resource "coolify_notification_pushover" "main" {
   enabled   = true
   user_key  = "replace-with-pushover-user-key"

--- a/docs/resources/notification_webhook.md
+++ b/docs/resources/notification_webhook.md
@@ -17,6 +17,7 @@ On destroy, Webhook notifications are disabled (`enabled = false`); the webhook 
 
 ```terraform
 # Team generic webhook notification settings (Coolify >= v4.3.0).
+# Import: terraform import coolify_notification_webhook.main current
 resource "coolify_notification_webhook" "main" {
   enabled     = true
   webhook_url = "https://example.com/coolify-webhook"

--- a/examples/resources/coolify_notification_pushover/resource.tf
+++ b/examples/resources/coolify_notification_pushover/resource.tf
@@ -1,4 +1,5 @@
 # Team Pushover notification settings (Coolify >= v4.3.0).
+# Import: terraform import coolify_notification_pushover.main current
 resource "coolify_notification_pushover" "main" {
   enabled   = true
   user_key  = "replace-with-pushover-user-key"

--- a/examples/resources/coolify_notification_webhook/resource.tf
+++ b/examples/resources/coolify_notification_webhook/resource.tf
@@ -1,4 +1,5 @@
 # Team generic webhook notification settings (Coolify >= v4.3.0).
+# Import: terraform import coolify_notification_webhook.main current
 resource "coolify_notification_webhook" "main" {
   enabled     = true
   webhook_url = "https://example.com/coolify-webhook"

--- a/internal/client/notifications.go
+++ b/internal/client/notifications.go
@@ -233,6 +233,7 @@ type UpdatePushoverNotificationInput struct {
 }
 
 // GetWebhookNotifications returns the current team's webhook settings.
+// Requires Coolify >= v4.3.0.
 func (c *Client) GetWebhookNotifications(ctx context.Context) (*WebhookNotificationSettings, error) {
 	var r WebhookNotificationSettings
 	if err := c.do(ctx, http.MethodGet, "/api/v1/notifications/webhook", nil, &r); err != nil {
@@ -242,6 +243,7 @@ func (c *Client) GetWebhookNotifications(ctx context.Context) (*WebhookNotificat
 }
 
 // UpdateWebhookNotifications updates the current team's webhook settings.
+// Requires Coolify >= v4.3.0.
 func (c *Client) UpdateWebhookNotifications(ctx context.Context, input UpdateWebhookNotificationInput) (*WebhookNotificationSettings, error) {
 	var r WebhookNotificationSettings
 	if err := c.do(ctx, http.MethodPatch, "/api/v1/notifications/webhook", input, &r); err != nil {
@@ -251,6 +253,7 @@ func (c *Client) UpdateWebhookNotifications(ctx context.Context, input UpdateWeb
 }
 
 // GetPushoverNotifications returns the current team's Pushover settings.
+// Requires Coolify >= v4.3.0.
 func (c *Client) GetPushoverNotifications(ctx context.Context) (*PushoverNotificationSettings, error) {
 	var r PushoverNotificationSettings
 	if err := c.do(ctx, http.MethodGet, "/api/v1/notifications/pushover", nil, &r); err != nil {
@@ -260,6 +263,7 @@ func (c *Client) GetPushoverNotifications(ctx context.Context) (*PushoverNotific
 }
 
 // UpdatePushoverNotifications updates the current team's Pushover settings.
+// Requires Coolify >= v4.3.0.
 func (c *Client) UpdatePushoverNotifications(ctx context.Context, input UpdatePushoverNotificationInput) (*PushoverNotificationSettings, error) {
 	var r PushoverNotificationSettings
 	if err := c.do(ctx, http.MethodPatch, "/api/v1/notifications/pushover", input, &r); err != nil {

--- a/internal/client/notifications_test.go
+++ b/internal/client/notifications_test.go
@@ -243,3 +243,26 @@ func TestClient_PushoverNotifications_GetUpdate(t *testing.T) {
 	assert.Equal(t, "new-user", lastPatch["pushover_user_key"])
 	assert.Equal(t, "new-token", lastPatch["pushover_api_token"])
 }
+
+func TestNotificationUpdateJSONTags(t *testing.T) {
+	t.Parallel()
+	for _, ch := range []string{"email", "discord", "slack", "telegram", "pushover", "webhook"} {
+		ch := ch
+		t.Run(ch, func(t *testing.T) {
+			t.Parallel()
+			tags := client.NotificationUpdateJSONTags(ch)
+			require.NotEmpty(t, tags, "channel %s should expose update JSON tags", ch)
+			// Every channel uses an enabled-style field (discord_enabled, smtp_enabled, …).
+			hasEnabled := false
+			for k := range tags {
+				if len(k) >= 7 && (k[len(k)-7:] == "enabled" || k == "smtp_enabled" || k == "resend_enabled" || k == "use_instance_email_settings") {
+					hasEnabled = true
+					break
+				}
+			}
+			assert.True(t, hasEnabled, "tags for %s: %v", ch, tags)
+		})
+	}
+	assert.Nil(t, client.NotificationUpdateJSONTags("unknown-channel"))
+	assert.Nil(t, client.NotificationUpdateJSONTags(""))
+}

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -276,3 +276,30 @@ func TestDiscordNotificationResource_DestroyDisables(t *testing.T) {
 		},
 	})
 }
+
+func TestDiscordNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring Discord notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -2,6 +2,7 @@ package notificationdiscord_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -239,6 +240,38 @@ func TestDiscordNotificationResource_InvalidImport(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "not-current",
 				ExpectError:   regexp.MustCompile(`team singleton|import with id "current"`),
+			},
+		},
+	})
+}
+
+func TestDiscordNotificationResource_DestroyDisables(t *testing.T) {
+	t.Parallel()
+	store := &mockDiscord{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			if store.Enabled {
+				return fmt.Errorf("expected discord_enabled false after destroy")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/123/abc"
+  deployment_failure = true
+`),
+				Check: resource.TestCheckResourceAttr("coolify_notification_discord.test", "enabled", "true"),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL),
 			},
 		},
 	})

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -285,7 +285,7 @@ func TestDiscordNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -310,7 +310,7 @@ func TestEmailNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -301,3 +301,30 @@ func TestEmailNotificationResource_InvalidImport(t *testing.T) {
 		},
 	})
 }
+
+func TestEmailNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled = true
+  smtp_host    = "smtp.example.com"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring email notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -192,7 +192,7 @@ func TestPushoverNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -183,3 +183,31 @@ func TestPushoverNotificationResource_DestroyDisables(t *testing.T) {
 		},
 	})
 }
+
+func TestPushoverNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled   = true
+  user_key  = "u"
+  api_token = "t"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring Pushover notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -2,6 +2,7 @@ package notificationpushover_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -145,6 +146,39 @@ func TestPushoverNotificationResource_InvalidImport(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "not-current",
 				ExpectError:   regexp.MustCompile(`team singleton|import with id "current"`),
+			},
+		},
+	})
+}
+
+func TestPushoverNotificationResource_DestroyDisables(t *testing.T) {
+	t.Parallel()
+	store := &mockPushover{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			if store.Enabled {
+				return fmt.Errorf("expected pushover_enabled false after destroy")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled   = true
+  user_key  = "u-test-user-key"
+  api_token = "a-test-api-token"
+  deployment_failure = true
+`),
+				Check: resource.TestCheckResourceAttr("coolify_notification_pushover.test", "enabled", "true"),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL),
 			},
 		},
 	})

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -2,6 +2,7 @@ package notificationslack_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -180,6 +181,38 @@ func TestSlackNotificationResource_InvalidImport(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "not-current",
 				ExpectError:   regexp.MustCompile(`team singleton|import with id "current"`),
+			},
+		},
+	})
+}
+
+func TestSlackNotificationResource_DestroyDisables(t *testing.T) {
+	t.Parallel()
+	store := &mockSlack{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			if store.Enabled {
+				return fmt.Errorf("expected slack_enabled false after destroy")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/coolify-slack-webhook"
+  deployment_failure = true
+`),
+				Check: resource.TestCheckResourceAttr("coolify_notification_slack.test", "enabled", "true"),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL),
 			},
 		},
 	})

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -226,7 +226,7 @@ func TestSlackNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -217,3 +217,30 @@ func TestSlackNotificationResource_DestroyDisables(t *testing.T) {
 		},
 	})
 }
+
+func TestSlackNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/slack"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring Slack notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -253,7 +253,7 @@ func TestTelegramNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -2,6 +2,7 @@ package notificationtelegram_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -206,6 +207,39 @@ func TestTelegramNotificationResource_InvalidImport(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "not-current",
 				ExpectError:   regexp.MustCompile(`team singleton|import with id "current"`),
+			},
+		},
+	})
+}
+
+func TestTelegramNotificationResource_DestroyDisables(t *testing.T) {
+	t.Parallel()
+	store := &mockTelegram{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			if store.Enabled {
+				return fmt.Errorf("expected telegram_enabled false after destroy")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled = true
+  token   = "123456:ABC-DEF"
+  chat_id = "-100123"
+  deployment_failure = true
+`),
+				Check: resource.TestCheckResourceAttr("coolify_notification_telegram.test", "enabled", "true"),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL),
 			},
 		},
 	})

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -244,3 +244,31 @@ func TestTelegramNotificationResource_DestroyDisables(t *testing.T) {
 		},
 	})
 }
+
+func TestTelegramNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled = true
+  token   = "tok"
+  chat_id = "1"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring Telegram notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -2,6 +2,7 @@ package notificationwebhook_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -180,6 +181,38 @@ func TestWebhookNotificationResource_InvalidImport(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "not-current",
 				ExpectError:   regexp.MustCompile(`team singleton|import with id "current"`),
+			},
+		},
+	})
+}
+
+func TestWebhookNotificationResource_DestroyDisables(t *testing.T) {
+	t.Parallel()
+	store := &mockWebhook{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			if store.Enabled {
+				return fmt.Errorf("expected webhook_enabled false after destroy")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/coolify-webhook"
+  deployment_failure = true
+`),
+				Check: resource.TestCheckResourceAttr("coolify_notification_webhook.test", "enabled", "true"),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL),
 			},
 		},
 	})

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -217,3 +217,30 @@ func TestWebhookNotificationResource_DestroyDisables(t *testing.T) {
 		},
 	})
 }
+
+func TestWebhookNotificationResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":false}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+`),
+				ExpectError: regexp.MustCompile(`Error configuring Webhook notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -226,7 +226,7 @@ func TestWebhookNotificationResource_CreateAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":false}`))
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
 	defer srv.Close()

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -39,6 +39,25 @@ API token can read sensitive data. When `coolify_database_backup` uses
 `save_s3 = true`, set `s3_storage_uuid` to a managed or existing storage UUID
 (for example `coolify_s3_storage.backups.uuid`).
 
+### Team Singleton Resources (Notification Channels)
+
+Notification channel resources are **team-scoped singletons**: one configuration
+per Coolify team (selected by the API token). There is no UUID. Import with the
+literal id `current`:
+
+```bash
+terraform import coolify_notification_discord.main current
+terraform import coolify_notification_slack.main current
+terraform import coolify_notification_email.main current
+terraform import coolify_notification_telegram.main current
+terraform import coolify_notification_webhook.main current
+terraform import coolify_notification_pushover.main current
+```
+
+Requires Coolify >= v4.3.0. On destroy, these resources **disable** the channel
+(`enabled = false` or email SMTP/Resend off); they do not delete Coolify-side
+webhook URLs or secrets. Keep secrets in configuration after import (see table below).
+
 ### Compound Import Format (Recommended for Applications, Databases, and Services)
 
 Applications, databases, and services support an extended compound import format
@@ -140,6 +159,10 @@ must be set in your `.tf` configuration before running `terraform plan`:
 | `coolify_github_app` | `client_secret`, `webhook_secret`, `private_key_uuid` (`client_secret` and `private_key_uuid` are write-only, and `webhook_secret` is not reliably returned after create/import, including provider-generated values when omitted on create) |
 | `coolify_cloud_token` | `token` (write-only, may not be returned by the API) |
 | `coolify_private_key` | `private_key` (requires API token with `root` or `read:sensitive` permission; hidden otherwise) |
+| `coolify_notification_discord`, `coolify_notification_slack`, `coolify_notification_webhook` | `webhook_url` (Coolify may omit unless the token has `read:sensitive` or root; preserve in configuration) |
+| `coolify_notification_telegram` | `token`, `chat_id`, thread id fields (sensitive; may be omitted without `read:sensitive`) |
+| `coolify_notification_pushover` | `user_key`, `api_token` (sensitive; may be omitted without `read:sensitive`) |
+| `coolify_notification_email` | SMTP/Resend passwords and API keys (sensitive; may be omitted without `read:sensitive`) |
 | Database backups | `database_uuid`, `s3_storage_uuid` when `save_s3 = true` |
 
 If these fields are missing, `terraform plan` will either show a diff


### PR DESCRIPTION
## Summary

MPI cycle focused on the newly shipped notification surface (Coolify >= v4.3.0).

- Add destroy-disables `CheckDestroy` unit tests for Discord, Slack, Webhook, Telegram, and Pushover (email already covered)
- Add `CreateAPIError` unit tests (422) for all six notification channels so configure failures surface clear diagnostics
- Direct unit coverage for `client.NotificationUpdateJSONTags` (all channels + unknown)
- Refresh README/AGENTS/ROADMAP counts: **45** resources, **1240+** tests; mark notification channels as shipped
- Document team-singleton import (`id = current`) and secret field limitations in the import guide

### Related issues (not closed; backlog)

- #712 tech-debt: share notification event schema/CRUD helpers
- #713 enhancement: ACME scenario for team notification channels

## Test plan

- [x] `go test` for all six `internal/service/notification*` packages
- [x] `make counts-check`
- [x] `make ci` (local)
- [ ] CI green on this PR