### PR TITLE
feat: shared notification helpers and acme-notifications scenario

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for release
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
 45 resources, 56 data sources, 1240+ tests (unit + acceptance), 10 CI jobs.
-17 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
+18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
 
@@ -203,7 +203,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 - Run `terraform fmt -recursive examples/` before committing HCL changes
 - **Scenario and resource counts live in 5+ files.** When adding a scenario, resource, or data source, grep for the old count across all docs before committing:
   ```bash
-  grep -rn '17 ACME\|17 tested\|17 scenario\|16 ACME\|16 tested\|16 scenario' AGENTS.md README.md ROADMAP.md templates/ docs/
+  grep -rn '18 ACME\|18 tested\|18 scenario\|17 ACME\|17 tested\|17 scenario' AGENTS.md README.md ROADMAP.md templates/ docs/
   ```
   Known locations for scenario counts: `AGENTS.md` (Project section), `README.md` (feature table + body text), `ROADMAP.md`, `templates/guides/architecture.md.tmpl` (ASCII diagram). Also check if a table row is missing in `README.md` for the new scenario.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 | Managed resources | 45 |
 | Data sources | 56 |
 | Tests | 1240+ unit and acceptance tests |
-| Scenario examples | 17 ACME Corp setups |
+| Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
 ## Demo
@@ -187,13 +187,14 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 
 Deploy a full stack (app, database, backups, env vars) in a single `terraform apply`, or adopt the provider incrementally by importing your existing Coolify resources.
 
-**Real-world scenarios included** -- 17 tested ACME Corp examples cover common patterns:
+**Real-world scenarios included** -- 18 tested ACME Corp examples cover common patterns:
 
 | Scenario | What it deploys |
 |---|---|
 | [acme-website](examples/scenarios/acme-website) | Project + PostgreSQL + web app + env vars |
 | [acme-api](examples/scenarios/acme-api) | Dockerfile + Docker image apps + Redis + scheduled tasks + backups |
 | [acme-backups](examples/scenarios/acme-backups) | Backup scheduling, S3 off-site storage, execution monitoring |
+| [acme-notifications](examples/scenarios/acme-notifications) | Team Discord/email/webhook channels (Coolify >= 4.3) |
 | [acme-multi-env](examples/scenarios/acme-multi-env) | Terraform modules for dev/staging environments |
 | [acme-databases](examples/scenarios/acme-databases) | All 8 database engines side by side |
 | [acme-platform](examples/scenarios/acme-platform) | Private keys, environments, storage, data sources |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ The provider covers the core Coolify resource model:
   backups, environment variables, deployments, notification channels, S3 storage,
   and more)
 - 56 data sources for reading existing infrastructure
-- 17 ACME Corp scenario examples with integration tests
+- 18 ACME Corp scenario examples with integration tests
 - Full import support for adopting existing Coolify resources
 - Coolify v4.2 surfaces: destinations, DigitalOcean/Vultr server provisioning
 - Coolify v4.3 surfaces: notification channels, S3 storage, docker/compose version probes

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 17 ACME Corp scenarios                │
+│  - 18 ACME Corp scenarios                │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐

--- a/docs/guides/scenario-testing.md
+++ b/docs/guides/scenario-testing.md
@@ -372,4 +372,5 @@ server validation (see Step 4), then rerun `terraform apply`.
 | `acme-multi-env` | Advanced | Terraform module composition for dev + staging environments |
 | `acme-platform` | Intermediate | Private keys, environments, storage, data sources |
 | `acme-backups` | Beginner | Full backup lifecycle: schedule, trigger, monitor execution status |
+| `acme-notifications` | Intermediate | Team Discord/email/webhook channels (Coolify >= 4.3; destroy disables) |
 | `acme-private-repo` | Intermediate | Private SSH key + private Git repo app + env vars + deployment with wait |

--- a/docs/resources/notification_pushover.md
+++ b/docs/resources/notification_pushover.md
@@ -4,14 +4,14 @@ page_title: "coolify_notification_pushover Resource - coolify"
 subcategory: ""
 description: |-
   Manages the current team's Pushover notification settings in Coolify. This is a team-scoped singleton (one configuration per team, selected by the API token). Requires Coolify >= v4.3.0.
-  On destroy, Pushover notifications are disabled (enabled = false); user key and API token are left unchanged. Import with id current.
+  On destroy, Pushover notifications are disabled (enabled = false); credentials are left unchanged. Import with id current.
 ---
 
 # coolify_notification_pushover (Resource)
 
 Manages the current team's Pushover notification settings in Coolify. This is a team-scoped singleton (one configuration per team, selected by the API token). Requires Coolify >= v4.3.0.
 
-On destroy, Pushover notifications are disabled (`enabled = false`); user key and API token are left unchanged. Import with id `current`.
+On destroy, Pushover notifications are disabled (`enabled = false`); credentials are left unchanged. Import with id `current`.
 
 ## Example Usage
 

--- a/docs/resources/notification_webhook.md
+++ b/docs/resources/notification_webhook.md
@@ -49,7 +49,7 @@ resource "coolify_notification_webhook" "main" {
 - `server_unreachable` (Boolean) Whether to send Webhook notifications for server unreachable events.
 - `status_change` (Boolean) Whether to send Webhook notifications for status change events.
 - `traefik_outdated` (Boolean) Whether to send Webhook notifications for Traefik outdated events.
-- `webhook_url` (String, Sensitive) Webhook incoming webhook URL. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).
+- `webhook_url` (String, Sensitive) Generic webhook URL. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).
 
 ### Read-Only
 

--- a/examples/scenarios/acme-notifications/README.md
+++ b/examples/scenarios/acme-notifications/README.md
@@ -1,0 +1,50 @@
+# ACME Corp: Team Notification Channels
+
+Configures Coolify **team-scoped** notification settings for Discord, email
+(SMTP), and a generic webhook. Channels default to **disabled** so
+`terraform apply` does not send real traffic.
+
+## Prerequisites
+
+- Coolify **>= v4.3.0** (notification API routes)
+- API token with permission to manage team notification settings
+
+## What this demonstrates
+
+| Resource | Pattern |
+|----------|---------|
+| `coolify_notification_discord` | Team singleton, webhook URL, event flags |
+| `coolify_notification_email` | SMTP settings + event flags |
+| `coolify_notification_webhook` | Generic webhook channel |
+
+### Import
+
+There is no UUID. Import with literal id `current`:
+
+```bash
+terraform import coolify_notification_discord.alerts current
+terraform import coolify_notification_email.ops current
+terraform import coolify_notification_webhook.hooks current
+```
+
+### Destroy behavior
+
+Destroy **disables** the channel (`enabled = false` / `smtp_enabled = false`).
+It does **not** delete Coolify-side webhook URLs or SMTP credentials. Keep
+secrets in configuration if you re-import.
+
+## Usage
+
+```bash
+export TF_VAR_coolify_endpoint="https://your-coolify.example.com"
+export TF_VAR_coolify_token="your-token"
+
+terraform init
+terraform apply
+# or: terraform test
+```
+
+## Related
+
+- [Import guide](../../../docs/guides/import.md) (team singleton section)
+- Resource docs under `docs/resources/notification_*.md`

--- a/examples/scenarios/acme-notifications/README.md
+++ b/examples/scenarios/acme-notifications/README.md
@@ -4,6 +4,11 @@ Configures Coolify **team-scoped** notification settings for Discord, email
 (SMTP), and a generic webhook. Channels default to **disabled** so
 `terraform apply` does not send real traffic.
 
+> **Caution:** Apply replaces the API token's current team notification
+> settings (webhook URLs, SMTP fields, event flags). Do not run against a
+> production Coolify team that already has live channels unless you intend
+> to overwrite them.
+
 ## Prerequisites
 
 - Coolify **>= v4.3.0** (notification API routes)

--- a/examples/scenarios/acme-notifications/acme-notifications.tftest.hcl
+++ b/examples/scenarios/acme-notifications/acme-notifications.tftest.hcl
@@ -61,7 +61,12 @@ run "update_discord_events" {
   command = apply
 
   variables {
-    discord_enabled = false
+    discord_status_change = true
+  }
+
+  assert {
+    condition     = coolify_notification_discord.alerts.status_change == true
+    error_message = "Discord status_change should become true after update"
   }
 
   assert {

--- a/examples/scenarios/acme-notifications/acme-notifications.tftest.hcl
+++ b/examples/scenarios/acme-notifications/acme-notifications.tftest.hcl
@@ -1,0 +1,80 @@
+# Acceptance test for ACME Corp team notification channels.
+#
+# Tests: coolify_notification_discord, coolify_notification_email,
+# coolify_notification_webhook (team singletons; import id "current").
+#
+# Requires Coolify >= v4.3.0. Required variables via TF_VAR_*:
+#   TF_VAR_coolify_endpoint, TF_VAR_coolify_token
+#
+# Channels default to disabled so the scenario does not send real alerts.
+
+run "configure_channels" {
+  command = apply
+
+  assert {
+    condition     = data.coolify_version.current.version != ""
+    error_message = "Coolify version is empty"
+  }
+
+  assert {
+    condition     = coolify_notification_discord.alerts.id == "current"
+    error_message = "Discord id should be current, got ${coolify_notification_discord.alerts.id}"
+  }
+
+  assert {
+    condition     = coolify_notification_discord.alerts.enabled == false
+    error_message = "Discord should stay disabled by default for safe demos"
+  }
+
+  assert {
+    condition     = coolify_notification_discord.alerts.deployment_failure == true
+    error_message = "Discord deployment_failure should be true"
+  }
+
+  assert {
+    condition     = coolify_notification_email.ops.id == "current"
+    error_message = "Email id should be current, got ${coolify_notification_email.ops.id}"
+  }
+
+  assert {
+    condition     = coolify_notification_email.ops.smtp_enabled == false
+    error_message = "SMTP should stay disabled by default for safe demos"
+  }
+
+  assert {
+    condition     = coolify_notification_email.ops.smtp_encryption == "starttls"
+    error_message = "SMTP encryption mismatch: got ${coolify_notification_email.ops.smtp_encryption}"
+  }
+
+  assert {
+    condition     = coolify_notification_webhook.hooks.id == "current"
+    error_message = "Webhook id should be current"
+  }
+
+  assert {
+    condition     = coolify_notification_webhook.hooks.enabled == false
+    error_message = "Webhook should stay disabled by default"
+  }
+}
+
+run "update_discord_events" {
+  command = apply
+
+  variables {
+    discord_enabled = false
+  }
+
+  assert {
+    condition     = coolify_notification_discord.alerts.backup_failure == true
+    error_message = "Discord backup_failure should remain true after re-apply"
+  }
+}
+
+run "idempotency" {
+  command = plan
+
+  assert {
+    condition     = coolify_notification_discord.alerts.id == "current"
+    error_message = "Discord id changed after re-plan"
+  }
+}

--- a/examples/scenarios/acme-notifications/main.tf
+++ b/examples/scenarios/acme-notifications/main.tf
@@ -1,0 +1,64 @@
+# ACME Corp team notification channels
+#
+# Configures Coolify team-scoped notification settings for Discord webhooks
+# and email (SMTP). Channels start disabled so apply does not send real
+# traffic to external endpoints. Use terraform import with id "current" to
+# adopt an existing team configuration.
+#
+# Requires Coolify >= v4.3.0.
+#
+# Destroy disables the channels (enabled = false / smtp_enabled = false)
+# without deleting Coolify-side webhook URLs or SMTP credentials.
+
+terraform {
+  required_providers {
+    coolify = {
+      source = "coolify-terraform/coolify"
+    }
+  }
+}
+
+provider "coolify" {
+  endpoint = var.coolify_endpoint
+  token    = var.coolify_token
+}
+
+data "coolify_version" "current" {}
+
+# Discord: placeholder webhook; keep enabled=false for safe demos.
+resource "coolify_notification_discord" "alerts" {
+  enabled     = var.discord_enabled
+  webhook_url = var.discord_webhook_url
+
+  deployment_failure = true
+  backup_failure     = true
+  server_disk_usage  = true
+  server_unreachable = true
+}
+
+# Email: SMTP placeholders; smtp_enabled=false by default.
+resource "coolify_notification_email" "ops" {
+  smtp_enabled      = var.smtp_enabled
+  smtp_host         = var.smtp_host
+  smtp_port         = var.smtp_port
+  smtp_encryption   = var.smtp_encryption
+  smtp_from_address = var.smtp_from_address
+  smtp_from_name    = var.smtp_from_name
+  smtp_recipients   = var.smtp_recipients
+  smtp_username     = var.smtp_username
+  smtp_password     = var.smtp_password
+
+  deployment_failure = true
+  backup_failure     = true
+  server_disk_usage  = true
+  server_unreachable = true
+}
+
+# Generic webhook as a third channel example (also disabled by default).
+resource "coolify_notification_webhook" "hooks" {
+  enabled     = var.webhook_enabled
+  webhook_url = var.webhook_url
+
+  deployment_failure = true
+  status_change      = true
+}

--- a/examples/scenarios/acme-notifications/main.tf
+++ b/examples/scenarios/acme-notifications/main.tf
@@ -1,11 +1,15 @@
 # ACME Corp team notification channels
 #
-# Configures Coolify team-scoped notification settings for Discord webhooks
-# and email (SMTP). Channels start disabled so apply does not send real
-# traffic to external endpoints. Use terraform import with id "current" to
-# adopt an existing team configuration.
+# Configures Coolify team-scoped notification settings for Discord, email
+# (SMTP), and a generic webhook. Channels start disabled so apply does not
+# send real traffic to external endpoints. Use terraform import with id
+# "current" to adopt an existing team configuration.
 #
 # Requires Coolify >= v4.3.0.
+#
+# Caution: apply overwrites the API token's team notification settings
+# (including webhook URLs and SMTP fields). Do not point this at a
+# production team with live channels unless that is intentional.
 #
 # Destroy disables the channels (enabled = false / smtp_enabled = false)
 # without deleting Coolify-side webhook URLs or SMTP credentials.
@@ -32,6 +36,7 @@ resource "coolify_notification_discord" "alerts" {
 
   deployment_failure = true
   backup_failure     = true
+  status_change      = var.discord_status_change
   server_disk_usage  = true
   server_unreachable = true
 }

--- a/examples/scenarios/acme-notifications/outputs.tf
+++ b/examples/scenarios/acme-notifications/outputs.tf
@@ -1,0 +1,19 @@
+output "coolify_version" {
+  description = "Coolify instance version"
+  value       = data.coolify_version.current.version
+}
+
+output "discord_id" {
+  description = "Discord notification resource id (always current)"
+  value       = coolify_notification_discord.alerts.id
+}
+
+output "email_id" {
+  description = "Email notification resource id (always current)"
+  value       = coolify_notification_email.ops.id
+}
+
+output "webhook_id" {
+  description = "Webhook notification resource id (always current)"
+  value       = coolify_notification_webhook.hooks.id
+}

--- a/examples/scenarios/acme-notifications/terraform.tfvars.example
+++ b/examples/scenarios/acme-notifications/terraform.tfvars.example
@@ -1,0 +1,7 @@
+coolify_endpoint = "https://coolify.example.com"
+coolify_token    = "your-api-token"
+
+# Optional: leave defaults (disabled) for safe demos.
+# discord_enabled = false
+# smtp_enabled    = false
+# webhook_enabled = false

--- a/examples/scenarios/acme-notifications/variables.tf
+++ b/examples/scenarios/acme-notifications/variables.tf
@@ -1,0 +1,91 @@
+variable "coolify_endpoint" {
+  description = "Coolify API endpoint URL"
+  type        = string
+}
+
+variable "coolify_token" {
+  description = "Coolify API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "discord_enabled" {
+  description = "Whether Discord notifications are enabled (default false for safe demos)"
+  type        = bool
+  default     = false
+}
+
+variable "discord_webhook_url" {
+  description = "Discord incoming webhook URL (placeholder OK for demos)"
+  type        = string
+  sensitive   = true
+  default     = "https://example.com/coolify-acme-discord-webhook"
+}
+
+variable "smtp_enabled" {
+  description = "Whether SMTP delivery is enabled (default false for safe demos)"
+  type        = bool
+  default     = false
+}
+
+variable "smtp_host" {
+  description = "SMTP host"
+  type        = string
+  default     = "smtp.example.com"
+}
+
+variable "smtp_port" {
+  description = "SMTP port"
+  type        = number
+  default     = 587
+}
+
+variable "smtp_encryption" {
+  description = "SMTP encryption: starttls, tls, or none"
+  type        = string
+  default     = "starttls"
+}
+
+variable "smtp_from_address" {
+  description = "SMTP From address"
+  type        = string
+  default     = "alerts@example.com"
+}
+
+variable "smtp_from_name" {
+  description = "SMTP From display name"
+  type        = string
+  default     = "ACME Coolify"
+}
+
+variable "smtp_recipients" {
+  description = "Comma-separated recipient addresses"
+  type        = string
+  default     = "ops@example.com"
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+  type        = string
+  default     = "smtp-user"
+}
+
+variable "smtp_password" {
+  description = "SMTP password (placeholder)"
+  type        = string
+  sensitive   = true
+  default     = "change-me-in-production"
+}
+
+variable "webhook_enabled" {
+  description = "Whether generic webhook notifications are enabled"
+  type        = bool
+  default     = false
+}
+
+variable "webhook_url" {
+  description = "Generic webhook URL (placeholder OK for demos)"
+  type        = string
+  sensitive   = true
+  default     = "https://example.com/coolify-acme-webhook"
+}

--- a/examples/scenarios/acme-notifications/variables.tf
+++ b/examples/scenarios/acme-notifications/variables.tf
@@ -89,3 +89,9 @@ variable "webhook_url" {
   sensitive   = true
   default     = "https://example.com/coolify-acme-webhook"
 }
+
+variable "discord_status_change" {
+  description = "Whether Discord status_change notifications are enabled (scenario update step)"
+  type        = bool
+  default     = false
+}

--- a/internal/service/notificationcommon/common.go
+++ b/internal/service/notificationcommon/common.go
@@ -1,0 +1,127 @@
+// Package notificationcommon holds shared schema and import helpers for
+// team-scoped Coolify notification channel resources (Discord, Slack, email,
+// Telegram, webhook, Pushover).
+package notificationcommon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// ImportIDCurrent is the only valid terraform import id for team-singleton
+// notification resources. The team is implied by the API token.
+const ImportIDCurrent = "current"
+
+// eventNames is the ordered list of shared event bool attributes on Coolify
+// notification channels (must stay aligned with Coolify channelConfig).
+var eventNames = []struct {
+	attr  string
+	label string
+}{
+	{"deployment_success", "deployment success"},
+	{"deployment_failure", "deployment failure"},
+	{"status_change", "status change"},
+	{"backup_success", "backup success"},
+	{"backup_failure", "backup failure"},
+	{"scheduled_task_success", "scheduled task success"},
+	{"scheduled_task_failure", "scheduled task failure"},
+	{"docker_cleanup_success", "Docker cleanup success"},
+	{"docker_cleanup_failure", "Docker cleanup failure"},
+	{"server_disk_usage", "server disk usage"},
+	{"server_reachable", "server reachable"},
+	{"server_unreachable", "server unreachable"},
+	{"server_patch", "server patch"},
+	{"traefik_outdated", "Traefik outdated"},
+}
+
+// EventAttributeNames returns the 14 shared event attribute names in stable order.
+func EventAttributeNames() []string {
+	out := make([]string, len(eventNames))
+	for i, e := range eventNames {
+		out[i] = e.attr
+	}
+	return out
+}
+
+// BoolOptComputed is Optional+Computed with UseStateForUnknown for API-defaulted bools.
+func BoolOptComputed(desc string) schema.BoolAttribute {
+	return schema.BoolAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		Computed:            true,
+		PlanModifiers: []planmodifier.Bool{
+			boolplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+// EventSchemaAttrs returns the 14 shared event bool attributes for a channel.
+// channel is the display name used in Markdown descriptions (e.g. "Discord", "email").
+func EventSchemaAttrs(channel string) map[string]schema.Attribute {
+	attrs := make(map[string]schema.Attribute, len(eventNames))
+	for _, e := range eventNames {
+		desc := fmt.Sprintf("Whether to send %s notifications for %s events.", channel, e.label)
+		attrs[e.attr] = BoolOptComputed(desc)
+	}
+	return attrs
+}
+
+// MergeAttrs returns a new map with base attributes plus overlay (overlay wins on key collision).
+func MergeAttrs(base map[string]schema.Attribute, overlay map[string]schema.Attribute) map[string]schema.Attribute {
+	out := make(map[string]schema.Attribute, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		out[k] = v
+	}
+	return out
+}
+
+// IDAttribute is the computed singleton id attribute (always "current").
+func IDAttribute() schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
+		Computed:            true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+// EnabledAttribute is the channel master enable flag (default false).
+func EnabledAttribute(channel string) schema.BoolAttribute {
+	return schema.BoolAttribute{
+		MarkdownDescription: fmt.Sprintf("Whether %s notifications are enabled for the team.", channel),
+		Optional:            true,
+		Computed:            true,
+		Default:             booldefault.StaticBool(false),
+	}
+}
+
+// ImportIDError returns a non-nil error when id is not empty and not ImportIDCurrent.
+// Empty id is accepted (terraform import sometimes passes blank then framework sets it).
+func ImportIDError(typeName, id string) error {
+	if id == "" || id == ImportIDCurrent {
+		return nil
+	}
+	return fmt.Errorf("%s is a team singleton; import with id %q (got %q)", typeName, ImportIDCurrent, id)
+}
+
+// ImportStateCurrent validates the import id and sets state id to "current".
+// typeName is the full resource type (e.g. coolify_notification_slack) for error text.
+func ImportStateCurrent(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, typeName string) {
+	if err := ImportIDError(typeName, req.ID); err != nil {
+		resp.Diagnostics.AddError("Invalid import ID", err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ImportIDCurrent)...)
+}

--- a/internal/service/notificationcommon/common_test.go
+++ b/internal/service/notificationcommon/common_test.go
@@ -1,0 +1,66 @@
+package notificationcommon_test
+
+import (
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventAttributeNames_CountAndOrder(t *testing.T) {
+	t.Parallel()
+	names := notificationcommon.EventAttributeNames()
+	require.Len(t, names, 14)
+	assert.Equal(t, "deployment_success", names[0])
+	assert.Equal(t, "traefik_outdated", names[len(names)-1])
+	seen := map[string]struct{}{}
+	for _, n := range names {
+		_, dup := seen[n]
+		assert.False(t, dup, "duplicate %s", n)
+		seen[n] = struct{}{}
+	}
+}
+
+func TestEventSchemaAttrs_HasAllEventsAndChannelInDesc(t *testing.T) {
+	t.Parallel()
+	attrs := notificationcommon.EventSchemaAttrs("Discord")
+	require.Len(t, attrs, 14)
+	for _, name := range notificationcommon.EventAttributeNames() {
+		a, ok := attrs[name]
+		require.True(t, ok, "missing attr %s", name)
+		ba, ok := a.(schema.BoolAttribute)
+		require.True(t, ok, "%s should be BoolAttribute", name)
+		assert.True(t, ba.Optional)
+		assert.True(t, ba.Computed)
+		assert.Contains(t, ba.MarkdownDescription, "Discord")
+		assert.NotEmpty(t, ba.PlanModifiers)
+	}
+}
+
+func TestMergeAttrs_OverlayWins(t *testing.T) {
+	t.Parallel()
+	base := map[string]schema.Attribute{
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Slack"),
+	}
+	overlay := notificationcommon.EventSchemaAttrs("Slack")
+	merged := notificationcommon.MergeAttrs(base, overlay)
+	require.Len(t, merged, 2+14)
+	_, ok := merged["deployment_failure"]
+	assert.True(t, ok)
+	_, ok = merged["id"]
+	assert.True(t, ok)
+}
+
+func TestImportIDError(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, notificationcommon.ImportIDError("coolify_notification_slack", ""))
+	assert.NoError(t, notificationcommon.ImportIDError("coolify_notification_slack", "current"))
+	err := notificationcommon.ImportIDError("coolify_notification_slack", "not-current")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team singleton")
+	assert.Contains(t, err.Error(), "coolify_notification_slack")
+	assert.Contains(t, err.Error(), "not-current")
+}

--- a/internal/service/notificationcommon/common_test.go
+++ b/internal/service/notificationcommon/common_test.go
@@ -44,14 +44,44 @@ func TestMergeAttrs_OverlayWins(t *testing.T) {
 	base := map[string]schema.Attribute{
 		"id":      notificationcommon.IDAttribute(),
 		"enabled": notificationcommon.EnabledAttribute("Slack"),
+		// Colliding key: base uses email wording; overlay (EventSchemaAttrs) wins.
+		"deployment_failure": notificationcommon.BoolOptComputed("base description must be replaced"),
 	}
 	overlay := notificationcommon.EventSchemaAttrs("Slack")
 	merged := notificationcommon.MergeAttrs(base, overlay)
 	require.Len(t, merged, 2+14)
-	_, ok := merged["deployment_failure"]
-	assert.True(t, ok)
+	ba, ok := merged["deployment_failure"].(schema.BoolAttribute)
+	require.True(t, ok)
+	assert.Contains(t, ba.MarkdownDescription, "Slack")
+	assert.NotContains(t, ba.MarkdownDescription, "base description")
 	_, ok = merged["id"]
 	assert.True(t, ok)
+}
+
+func TestIDAttribute_ComputedWithPlanModifiers(t *testing.T) {
+	t.Parallel()
+	a := notificationcommon.IDAttribute()
+	assert.True(t, a.Computed)
+	assert.False(t, a.Optional)
+	assert.NotEmpty(t, a.PlanModifiers)
+}
+
+func TestEnabledAttribute_DefaultFalse(t *testing.T) {
+	t.Parallel()
+	a := notificationcommon.EnabledAttribute("Discord")
+	assert.True(t, a.Optional)
+	assert.True(t, a.Computed)
+	assert.NotNil(t, a.Default)
+	assert.Contains(t, a.MarkdownDescription, "Discord")
+}
+
+func TestBoolOptComputed_PlanModifiers(t *testing.T) {
+	t.Parallel()
+	a := notificationcommon.BoolOptComputed("test desc")
+	assert.True(t, a.Optional)
+	assert.True(t, a.Computed)
+	assert.Equal(t, "test desc", a.MarkdownDescription)
+	assert.NotEmpty(t, a.PlanModifiers)
 }
 
 func TestImportIDError(t *testing.T) {

--- a/internal/service/notificationdiscord/resource.go
+++ b/internal/service/notificationdiscord/resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// Import ID for the team-scoped singleton (settings belong to the API token's team).
 var (
 	_ resource.Resource                = (*discordResource)(nil)
 	_ resource.ResourceWithConfigure   = (*discordResource)(nil)

--- a/internal/service/notificationdiscord/resource.go
+++ b/internal/service/notificationdiscord/resource.go
@@ -2,15 +2,12 @@ package notificationdiscord
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -18,8 +15,6 @@ import (
 )
 
 // Import ID for the team-scoped singleton (settings belong to the API token's team).
-const importIDCurrent = "current"
-
 var (
 	_ resource.Resource                = (*discordResource)(nil)
 	_ resource.ResourceWithConfigure   = (*discordResource)(nil)
@@ -63,74 +58,29 @@ func (r *discordResource) Metadata(_ context.Context, req resource.MetadataReque
 }
 
 func (r *discordResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send Discord notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
+	attrs := map[string]schema.Attribute{
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Discord"),
+		"webhook_url": schema.StringAttribute{
+			MarkdownDescription: "Discord webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
+				"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
+				"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
-		}
+		},
+		"ping_enabled": notificationcommon.BoolOptComputed("Whether Discord @here / role pings are enabled."),
 	}
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Discord notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
 			"Requires Coolify >= v4.3.0.\n\n" +
 			"On destroy, Discord notifications are disabled (`enabled = false`); the webhook URL is left unchanged. " +
 			"Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Discord notifications are enabled for the team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"webhook_url": schema.StringAttribute{
-				MarkdownDescription: "Discord webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
-					"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
-					"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"ping_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Discord @here / role pings are enabled.",
-				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"deployment_success":     boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":     boolOptComputed(eventDesc("deployment failure")),
-			"status_change":          boolOptComputed(eventDesc("status change")),
-			"backup_success":         boolOptComputed(eventDesc("backup success")),
-			"backup_failure":         boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success": boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure": boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success": boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure": boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":      boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":       boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":     boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":           boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":       boolOptComputed(eventDesc("Traefik outdated")),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Discord")),
 	}
 }
 
@@ -221,15 +171,7 @@ func (r *discordResource) Delete(ctx context.Context, _ resource.DeleteRequest, 
 }
 
 func (r *discordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_discord is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_discord")
 }
 
 func createInputFromPlan(plan model) client.UpdateDiscordNotificationInput {
@@ -284,7 +226,7 @@ func updateInputFromPlan(plan, state model) client.UpdateDiscordNotificationInpu
 }
 
 func flatten(api *client.DiscordNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	m.PingEnabled = types.BoolValue(api.PingEnabled)
 	// Preserve webhook from state when API hides encrypted field.

--- a/internal/service/notificationemail/resource.go
+++ b/internal/service/notificationemail/resource.go
@@ -2,17 +2,15 @@ package notificationemail
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -20,8 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-const importIDCurrent = "current"
 
 var (
 	_ resource.Resource                = (*emailResource)(nil)
@@ -75,19 +71,6 @@ func (r *emailResource) Metadata(_ context.Context, req resource.MetadataRequest
 }
 
 func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send email notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
-			},
-		}
-	}
 	sensStr := func(desc string) schema.StringAttribute {
 		return schema.StringAttribute{
 			MarkdownDescription: desc + " Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.",
@@ -100,6 +83,68 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		}
 	}
 
+	attrs := map[string]schema.Attribute{
+		"id": notificationcommon.IDAttribute(),
+
+		"smtp_enabled": schema.BoolAttribute{
+			MarkdownDescription: "Whether SMTP delivery is enabled.",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+		},
+		"smtp_from_address": sensStr("SMTP From address."),
+		"smtp_from_name":    sensStr("SMTP From display name."),
+		"smtp_recipients":   sensStr("Comma-separated recipient addresses."),
+		"smtp_host":         sensStr("SMTP host."),
+		"smtp_port": schema.Int64Attribute{
+			MarkdownDescription: "SMTP port (1-65535).",
+			Optional:            true,
+			Computed:            true,
+			Validators: []validator.Int64{
+				int64validator.Between(1, 65535),
+			},
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"smtp_encryption": schema.StringAttribute{
+			MarkdownDescription: "SMTP encryption. One of `starttls`, `tls`, or `none`.",
+			Optional:            true,
+			Computed:            true,
+			Validators: []validator.String{
+				stringvalidator.OneOf("starttls", "tls", "none"),
+			},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"smtp_username": sensStr("SMTP username."),
+		"smtp_password": sensStr("SMTP password."),
+		"smtp_timeout": schema.Int64Attribute{
+			MarkdownDescription: "SMTP timeout in seconds (>= 0).",
+			Optional:            true,
+			Computed:            true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(0),
+			},
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"resend_enabled": schema.BoolAttribute{
+			MarkdownDescription: "Whether Resend delivery is enabled.",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+		},
+		"resend_api_key": sensStr("Resend API key."),
+		"use_instance_email_settings": schema.BoolAttribute{
+			MarkdownDescription: "Whether to use the Coolify instance's shared email settings for this team.",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+		},
+	}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's email notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
@@ -107,87 +152,7 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"Email can use SMTP, Resend, and/or instance-level settings. Coolify treats the channel as enabled when any of " +
 			"`smtp_enabled`, `resend_enabled`, or `use_instance_email_settings` is true.\n\n" +
 			"On destroy, all three enable flags are set to `false`; credentials are left unchanged. Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"smtp_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether SMTP delivery is enabled.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"smtp_from_address": sensStr("SMTP From address."),
-			"smtp_from_name":    sensStr("SMTP From display name."),
-			"smtp_recipients":   sensStr("Comma-separated recipient addresses."),
-			"smtp_host":         sensStr("SMTP host."),
-			"smtp_port": schema.Int64Attribute{
-				MarkdownDescription: "SMTP port (1-65535).",
-				Optional:            true,
-				Computed:            true,
-				Validators: []validator.Int64{
-					int64validator.Between(1, 65535),
-				},
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
-			},
-			"smtp_encryption": schema.StringAttribute{
-				MarkdownDescription: "SMTP encryption. One of `starttls`, `tls`, or `none`.",
-				Optional:            true,
-				Computed:            true,
-				Validators: []validator.String{
-					stringvalidator.OneOf("starttls", "tls", "none"),
-				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"smtp_username": sensStr("SMTP username."),
-			"smtp_password": sensStr("SMTP password."),
-			"smtp_timeout": schema.Int64Attribute{
-				MarkdownDescription: "SMTP timeout in seconds (>= 0).",
-				Optional:            true,
-				Computed:            true,
-				Validators: []validator.Int64{
-					int64validator.AtLeast(0),
-				},
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
-			},
-			"resend_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Resend delivery is enabled.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"resend_api_key": sensStr("Resend API key."),
-			"use_instance_email_settings": schema.BoolAttribute{
-				MarkdownDescription: "Whether to use the Coolify instance's shared email settings for this team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"deployment_success":     boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":     boolOptComputed(eventDesc("deployment failure")),
-			"status_change":          boolOptComputed(eventDesc("status change")),
-			"backup_success":         boolOptComputed(eventDesc("backup success")),
-			"backup_failure":         boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success": boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure": boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success": boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure": boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":      boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":       boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":     boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":           boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":       boolOptComputed(eventDesc("Traefik outdated")),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("email")),
 	}
 }
 
@@ -269,15 +234,7 @@ func (r *emailResource) Delete(ctx context.Context, _ resource.DeleteRequest, re
 }
 
 func (r *emailResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_email is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_email")
 }
 
 func createInputFromPlan(plan model) client.UpdateEmailNotificationInput {
@@ -375,7 +332,7 @@ func updateInputFromPlan(plan, state model) client.UpdateEmailNotificationInput 
 }
 
 func flatten(api *client.EmailNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.SMTPEnabled = types.BoolValue(api.SMTPEnabled)
 	m.ResendEnabled = types.BoolValue(api.ResendEnabled)
 	m.UseInstanceEmail = types.BoolValue(api.UseInstanceEmail)

--- a/internal/service/notificationpushover/resource.go
+++ b/internal/service/notificationpushover/resource.go
@@ -2,22 +2,17 @@ package notificationpushover
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-const importIDCurrent = "current"
 
 var (
 	_ resource.Resource                = (*pushoverResource)(nil)
@@ -61,75 +56,37 @@ func (r *pushoverResource) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *pushoverResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send Pushover notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
+	attrs := map[string]schema.Attribute{
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Pushover"),
+		"user_key": schema.StringAttribute{
+			MarkdownDescription: "Pushover user key. Sensitive; Coolify may omit it on read unless the API token " +
+				"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import.",
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
-		}
+		},
+		"api_token": schema.StringAttribute{
+			MarkdownDescription: "Pushover API token. Sensitive; Coolify may omit it on read unless the API token " +
+				"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import.",
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 	}
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Pushover notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
 			"Requires Coolify >= v4.3.0.\n\n" +
-			"On destroy, Pushover notifications are disabled (`enabled = false`); user key and API token are left unchanged. " +
+			"On destroy, Pushover notifications are disabled (`enabled = false`); credentials are left unchanged. " +
 			"Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Pushover notifications are enabled for the team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"user_key": schema.StringAttribute{
-				MarkdownDescription: "Pushover user key. Sensitive; Coolify may omit it on read unless the API token " +
-					"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import.",
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"api_token": schema.StringAttribute{
-				MarkdownDescription: "Pushover API token. Sensitive; Coolify may omit it on read unless the API token " +
-					"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import.",
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"deployment_success":     boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":     boolOptComputed(eventDesc("deployment failure")),
-			"status_change":          boolOptComputed(eventDesc("status change")),
-			"backup_success":         boolOptComputed(eventDesc("backup success")),
-			"backup_failure":         boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success": boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure": boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success": boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure": boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":      boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":       boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":     boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":           boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":       boolOptComputed(eventDesc("Traefik outdated")),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Pushover")),
 	}
 }
 
@@ -218,15 +175,7 @@ func (r *pushoverResource) Delete(ctx context.Context, _ resource.DeleteRequest,
 }
 
 func (r *pushoverResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_pushover is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_pushover")
 }
 
 func createInputFromPlan(plan model) client.UpdatePushoverNotificationInput {
@@ -286,7 +235,7 @@ func updateInputFromPlan(plan, state model) client.UpdatePushoverNotificationInp
 }
 
 func flatten(api *client.PushoverNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.UserKey, api.UserKey)
 	flex.SetStringPreserveEmpty(&m.APIToken, api.APIToken)

--- a/internal/service/notificationslack/resource.go
+++ b/internal/service/notificationslack/resource.go
@@ -2,22 +2,17 @@ package notificationslack
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-const importIDCurrent = "current"
 
 var (
 	_ resource.Resource                = (*slackResource)(nil)
@@ -60,66 +55,28 @@ func (r *slackResource) Metadata(_ context.Context, req resource.MetadataRequest
 }
 
 func (r *slackResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send Slack notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
+	attrs := map[string]schema.Attribute{
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Slack"),
+		"webhook_url": schema.StringAttribute{
+			MarkdownDescription: "Slack incoming webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
+				"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
+				"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
-		}
+		},
 	}
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Slack notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
 			"Requires Coolify >= v4.3.0.\n\n" +
 			"On destroy, Slack notifications are disabled (`enabled = false`); the webhook URL is left unchanged. " +
 			"Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Slack notifications are enabled for the team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"webhook_url": schema.StringAttribute{
-				MarkdownDescription: "Slack incoming webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
-					"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
-					"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"deployment_success":     boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":     boolOptComputed(eventDesc("deployment failure")),
-			"status_change":          boolOptComputed(eventDesc("status change")),
-			"backup_success":         boolOptComputed(eventDesc("backup success")),
-			"backup_failure":         boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success": boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure": boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success": boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure": boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":      boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":       boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":     boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":           boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":       boolOptComputed(eventDesc("Traefik outdated")),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Slack")),
 	}
 }
 
@@ -208,15 +165,7 @@ func (r *slackResource) Delete(ctx context.Context, _ resource.DeleteRequest, re
 }
 
 func (r *slackResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_slack is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_slack")
 }
 
 func createInputFromPlan(plan model) client.UpdateSlackNotificationInput {
@@ -269,7 +218,7 @@ func updateInputFromPlan(plan, state model) client.UpdateSlackNotificationInput 
 }
 
 func flatten(api *client.SlackNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.WebhookURL, api.Webhook)
 	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)

--- a/internal/service/notificationtelegram/resource.go
+++ b/internal/service/notificationtelegram/resource.go
@@ -2,22 +2,17 @@ package notificationtelegram
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-const importIDCurrent = "current"
 
 var (
 	_ resource.Resource                = (*telegramResource)(nil)
@@ -75,19 +70,6 @@ func (r *telegramResource) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send Telegram notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
-			},
-		}
-	}
 	sensStr := func(desc string) schema.StringAttribute {
 		return schema.StringAttribute{
 			MarkdownDescription: desc + " Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.",
@@ -99,58 +81,33 @@ func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 		}
 	}
-
+	attrs := map[string]schema.Attribute{
+		"id":                            notificationcommon.IDAttribute(),
+		"enabled":                       notificationcommon.EnabledAttribute("Telegram"),
+		"token":                         sensStr("Telegram bot token."),
+		"chat_id":                       sensStr("Telegram chat ID."),
+		"thread_deployment_success":     sensStr("Telegram forum thread ID for deployment_success events."),
+		"thread_deployment_failure":     sensStr("Telegram forum thread ID for deployment_failure events."),
+		"thread_status_change":          sensStr("Telegram forum thread ID for status_change events."),
+		"thread_backup_success":         sensStr("Telegram forum thread ID for backup_success events."),
+		"thread_backup_failure":         sensStr("Telegram forum thread ID for backup_failure events."),
+		"thread_scheduled_task_success": sensStr("Telegram forum thread ID for scheduled_task_success events."),
+		"thread_scheduled_task_failure": sensStr("Telegram forum thread ID for scheduled_task_failure events."),
+		"thread_docker_cleanup_success": sensStr("Telegram forum thread ID for docker_cleanup_success events."),
+		"thread_docker_cleanup_failure": sensStr("Telegram forum thread ID for docker_cleanup_failure events."),
+		"thread_server_disk_usage":      sensStr("Telegram forum thread ID for server_disk_usage events."),
+		"thread_server_reachable":       sensStr("Telegram forum thread ID for server_reachable events."),
+		"thread_server_unreachable":     sensStr("Telegram forum thread ID for server_unreachable events."),
+		"thread_server_patch":           sensStr("Telegram forum thread ID for server_patch events."),
+		"thread_traefik_outdated":       sensStr("Telegram forum thread ID for traefik_outdated events."),
+	}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Telegram notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
 			"**Requires Coolify >= v4.3.0** (notification routes are absent on v4.2.x and older; acceptance tests skip when the API is missing).\n\n" +
 			"On destroy, Telegram notifications are disabled (`enabled = false`); token, chat ID, and thread IDs are left unchanged. " +
 			"Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Telegram notifications are enabled for the team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"token":                         sensStr("Telegram bot token."),
-			"chat_id":                       sensStr("Telegram chat ID."),
-			"deployment_success":            boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":            boolOptComputed(eventDesc("deployment failure")),
-			"status_change":                 boolOptComputed(eventDesc("status change")),
-			"backup_success":                boolOptComputed(eventDesc("backup success")),
-			"backup_failure":                boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success":        boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure":        boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success":        boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure":        boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":             boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":              boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":            boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":                  boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":              boolOptComputed(eventDesc("Traefik outdated")),
-			"thread_deployment_success":     sensStr("Telegram forum thread ID for deployment_success events."),
-			"thread_deployment_failure":     sensStr("Telegram forum thread ID for deployment_failure events."),
-			"thread_status_change":          sensStr("Telegram forum thread ID for status_change events."),
-			"thread_backup_success":         sensStr("Telegram forum thread ID for backup_success events."),
-			"thread_backup_failure":         sensStr("Telegram forum thread ID for backup_failure events."),
-			"thread_scheduled_task_success": sensStr("Telegram forum thread ID for scheduled_task_success events."),
-			"thread_scheduled_task_failure": sensStr("Telegram forum thread ID for scheduled_task_failure events."),
-			"thread_docker_cleanup_success": sensStr("Telegram forum thread ID for docker_cleanup_success events."),
-			"thread_docker_cleanup_failure": sensStr("Telegram forum thread ID for docker_cleanup_failure events."),
-			"thread_server_disk_usage":      sensStr("Telegram forum thread ID for server_disk_usage events."),
-			"thread_server_reachable":       sensStr("Telegram forum thread ID for server_reachable events."),
-			"thread_server_unreachable":     sensStr("Telegram forum thread ID for server_unreachable events."),
-			"thread_server_patch":           sensStr("Telegram forum thread ID for server_patch events."),
-			"thread_traefik_outdated":       sensStr("Telegram forum thread ID for traefik_outdated events."),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Telegram")),
 	}
 }
 
@@ -230,15 +187,7 @@ func (r *telegramResource) Delete(ctx context.Context, _ resource.DeleteRequest,
 }
 
 func (r *telegramResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_telegram is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_telegram")
 }
 
 func createInputFromPlan(plan model) client.UpdateTelegramNotificationInput {
@@ -396,7 +345,7 @@ func updateInputFromPlan(plan, state model) client.UpdateTelegramNotificationInp
 }
 
 func flatten(api *client.TelegramNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.Token, api.Token)
 	flex.SetStringPreserveEmpty(&m.ChatID, api.ChatID)

--- a/internal/service/notificationwebhook/resource.go
+++ b/internal/service/notificationwebhook/resource.go
@@ -2,22 +2,17 @@ package notificationwebhook
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-const importIDCurrent = "current"
 
 var (
 	_ resource.Resource                = (*webhookResource)(nil)
@@ -60,66 +55,28 @@ func (r *webhookResource) Metadata(_ context.Context, req resource.MetadataReque
 }
 
 func (r *webhookResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	eventDesc := func(event string) string {
-		return fmt.Sprintf("Whether to send Webhook notifications for %s events.", event)
-	}
-	boolOptComputed := func(desc string) schema.BoolAttribute {
-		return schema.BoolAttribute{
-			MarkdownDescription: desc,
-			Optional:            true,
-			Computed:            true,
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
+	attrs := map[string]schema.Attribute{
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Webhook"),
+		"webhook_url": schema.StringAttribute{
+			MarkdownDescription: "Generic webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
+				"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
+				"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
-		}
+		},
 	}
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Webhook notification settings in Coolify. " +
 			"This is a team-scoped singleton (one configuration per team, selected by the API token). " +
 			"Requires Coolify >= v4.3.0.\n\n" +
 			"On destroy, Webhook notifications are disabled (`enabled = false`); the webhook URL is left unchanged. " +
 			"Import with id `current`.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Resource identifier. Always `current` (team is implied by the API token).",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether Webhook notifications are enabled for the team.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-			},
-			"webhook_url": schema.StringAttribute{
-				MarkdownDescription: "Webhook incoming webhook URL. Sensitive; Coolify may omit it on read unless the API token " +
-					"can read sensitive fields (`read:sensitive` or root). Preserve the value in configuration after import. " +
-					"Must pass Coolify's SafeWebhookUrl rule (public http/https; private/loopback hosts rejected).",
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"deployment_success":     boolOptComputed(eventDesc("deployment success")),
-			"deployment_failure":     boolOptComputed(eventDesc("deployment failure")),
-			"status_change":          boolOptComputed(eventDesc("status change")),
-			"backup_success":         boolOptComputed(eventDesc("backup success")),
-			"backup_failure":         boolOptComputed(eventDesc("backup failure")),
-			"scheduled_task_success": boolOptComputed(eventDesc("scheduled task success")),
-			"scheduled_task_failure": boolOptComputed(eventDesc("scheduled task failure")),
-			"docker_cleanup_success": boolOptComputed(eventDesc("Docker cleanup success")),
-			"docker_cleanup_failure": boolOptComputed(eventDesc("Docker cleanup failure")),
-			"server_disk_usage":      boolOptComputed(eventDesc("server disk usage")),
-			"server_reachable":       boolOptComputed(eventDesc("server reachable")),
-			"server_unreachable":     boolOptComputed(eventDesc("server unreachable")),
-			"server_patch":           boolOptComputed(eventDesc("server patch")),
-			"traefik_outdated":       boolOptComputed(eventDesc("Traefik outdated")),
-		},
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Webhook")),
 	}
 }
 
@@ -208,15 +165,7 @@ func (r *webhookResource) Delete(ctx context.Context, _ resource.DeleteRequest, 
 }
 
 func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if id != "" && id != importIDCurrent {
-		resp.Diagnostics.AddError(
-			"Invalid import ID",
-			fmt.Sprintf("coolify_notification_webhook is a team singleton; import with id %q (got %q)", importIDCurrent, id),
-		)
-		return
-	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), importIDCurrent)...)
+	notificationcommon.ImportStateCurrent(ctx, req, resp, "coolify_notification_webhook")
 }
 
 func createInputFromPlan(plan model) client.UpdateWebhookNotificationInput {
@@ -269,7 +218,7 @@ func updateInputFromPlan(plan, state model) client.UpdateWebhookNotificationInpu
 }
 
 func flatten(api *client.WebhookNotificationSettings, m *model) {
-	m.ID = types.StringValue(importIDCurrent)
+	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.WebhookURL, api.Webhook)
 	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 17 ACME Corp scenarios                │
+│  - 18 ACME Corp scenarios                │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐

--- a/templates/guides/scenario-testing.md.tmpl
+++ b/templates/guides/scenario-testing.md.tmpl
@@ -372,4 +372,5 @@ server validation (see Step 4), then rerun `terraform apply`.
 | `acme-multi-env` | Advanced | Terraform module composition for dev + staging environments |
 | `acme-platform` | Intermediate | Private keys, environments, storage, data sources |
 | `acme-backups` | Beginner | Full backup lifecycle: schedule, trigger, monitor execution status |
+| `acme-notifications` | Intermediate | Team Discord/email/webhook channels (Coolify >= 4.3; destroy disables) |
 | `acme-private-repo` | Intermediate | Private SSH key + private Git repo app + env vars + deployment with wait |


### PR DESCRIPTION
## Summary

- **#712:** Extract `internal/service/notificationcommon` for shared event schema attrs (14 bools), singleton import (`current`), and id/enabled helpers. Wire Discord, Slack, Webhook, Pushover, Telegram, and email through `MergeAttrs`.
- **#713:** Add `examples/scenarios/acme-notifications` (Discord + email + webhook) with `.tftest.hcl`, channels default **disabled**, destroy-disables docs, scenario count **18**.

## Test plan

- [x] `go test ./internal/service/notification...`
- [x] Unit tests for `EventSchemaAttrs`, `MergeAttrs`, `ImportIDError`
- [ ] CI green (unit + scenarios)
- [ ] Reviewer pass before undraft/auto-merge

Closes #712
Closes #713