### PR TITLE
test: notificationcommon ImportState coverage and Read error paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1240+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 56 data sources, 1250+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1240+ tests (unit + acceptance)
+- 1250+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 45 |
 | Data sources | 56 |
-| Tests | 1240+ unit and acceptance tests |
+| Tests | 1250+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -316,7 +316,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1240+ tests, race detector enabled)
+make test                                       # Run unit tests (1250+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/resources/notification_email.md
+++ b/docs/resources/notification_email.md
@@ -84,5 +84,6 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 
 ```shell
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_email.main current
 ```

--- a/docs/resources/notification_pushover.md
+++ b/docs/resources/notification_pushover.md
@@ -64,5 +64,6 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 
 ```shell
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_pushover.main current
 ```

--- a/docs/resources/notification_telegram.md
+++ b/docs/resources/notification_telegram.md
@@ -82,5 +82,6 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 
 ```shell
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_telegram.main current
 ```

--- a/docs/resources/notification_webhook.md
+++ b/docs/resources/notification_webhook.md
@@ -63,5 +63,6 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 
 ```shell
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_webhook.main current
 ```

--- a/examples/resources/coolify_notification_email/import.sh
+++ b/examples/resources/coolify_notification_email/import.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_email.main current

--- a/examples/resources/coolify_notification_pushover/import.sh
+++ b/examples/resources/coolify_notification_pushover/import.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_pushover.main current

--- a/examples/resources/coolify_notification_telegram/import.sh
+++ b/examples/resources/coolify_notification_telegram/import.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_telegram.main current

--- a/examples/resources/coolify_notification_webhook/import.sh
+++ b/examples/resources/coolify_notification_webhook/import.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# Team-scoped singleton: always import as "current".
 terraform import coolify_notification_webhook.main current

--- a/internal/client/notifications_test.go
+++ b/internal/client/notifications_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
@@ -265,4 +266,35 @@ func TestNotificationUpdateJSONTags(t *testing.T) {
 	}
 	assert.Nil(t, client.NotificationUpdateJSONTags("unknown-channel"))
 	assert.Nil(t, client.NotificationUpdateJSONTags(""))
+}
+
+func TestNotificationEventJSONTags_CoverSharedEvents(t *testing.T) {
+	t.Parallel()
+	// Short schema names from notificationcommon must appear in each channel's
+	// Update* JSON tags (as <event>_<channel>_notifications or similar).
+	events := []string{
+		"deployment_success", "deployment_failure", "status_change",
+		"backup_success", "backup_failure",
+		"scheduled_task_success", "scheduled_task_failure",
+		"docker_cleanup_success", "docker_cleanup_failure",
+		"server_disk_usage", "server_reachable", "server_unreachable",
+		"server_patch", "traefik_outdated",
+	}
+	for _, ch := range []string{"discord", "slack", "telegram", "pushover", "webhook", "email"} {
+		ch := ch
+		t.Run(ch, func(t *testing.T) {
+			t.Parallel()
+			tags := client.NotificationUpdateJSONTags(ch)
+			require.NotEmpty(t, tags)
+			joined := ""
+			for k := range tags {
+				joined += k + " "
+			}
+			for _, ev := range events {
+				if !strings.Contains(joined, ev) {
+					t.Errorf("channel %s missing event %q in update JSON tags: %v", ch, ev, tags)
+				}
+			}
+		})
+	}
 }

--- a/internal/service/notificationcommon/common_test.go
+++ b/internal/service/notificationcommon/common_test.go
@@ -1,13 +1,37 @@
 package notificationcommon_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func newImportStateResponse(s schema.Schema) *resource.ImportStateResponse {
+	ctx := context.Background()
+	return &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: s,
+			Raw:    tftypes.NewValue(s.Type().TerraformType(ctx), nil),
+		},
+	}
+}
+
+func singletonSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": notificationcommon.IDAttribute(),
+		},
+	}
+}
 
 func TestEventAttributeNames_CountAndOrder(t *testing.T) {
 	t.Parallel()
@@ -93,4 +117,33 @@ func TestImportIDError(t *testing.T) {
 	assert.Contains(t, err.Error(), "team singleton")
 	assert.Contains(t, err.Error(), "coolify_notification_slack")
 	assert.Contains(t, err.Error(), "not-current")
+}
+
+func TestImportStateCurrent_SetsID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for _, id := range []string{"", "current"} {
+		id := id
+		t.Run("id="+id, func(t *testing.T) {
+			t.Parallel()
+			resp := newImportStateResponse(singletonSchema())
+			notificationcommon.ImportStateCurrent(ctx, resource.ImportStateRequest{ID: id}, resp, "coolify_notification_test")
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics.Errors())
+			var got types.String
+			diags := resp.State.GetAttribute(ctx, path.Root("id"), &got)
+			require.False(t, diags.HasError())
+			assert.Equal(t, notificationcommon.ImportIDCurrent, got.ValueString())
+		})
+	}
+}
+
+func TestImportStateCurrent_RejectsOtherID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	resp := newImportStateResponse(singletonSchema())
+	notificationcommon.ImportStateCurrent(ctx, resource.ImportStateRequest{ID: "not-current"}, resp, "coolify_notification_slack")
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Invalid import ID")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "team singleton")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "coolify_notification_slack")
 }

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -303,3 +303,46 @@ func TestDiscordNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestDiscordNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+`),
+				ExpectError: regexp.MustCompile(`Error reading Discord notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -328,3 +328,46 @@ func TestEmailNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestEmailNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled = true
+  smtp_host    = "smtp.example.com"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled = true
+  smtp_host    = "smtp.example.com"
+`),
+				ExpectError: regexp.MustCompile(`Error reading email notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -211,3 +211,48 @@ func TestPushoverNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestPushoverNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u","pushover_api_token":"t"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u","pushover_api_token":"t"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled   = true
+  user_key  = "u"
+  api_token = "t"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled   = true
+  user_key  = "u"
+  api_token = "t"
+`),
+				ExpectError: regexp.MustCompile(`Error reading Pushover notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -244,3 +244,46 @@ func TestSlackNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestSlackNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://example.com/slack"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://example.com/slack"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/slack"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/slack"
+`),
+				ExpectError: regexp.MustCompile(`Error reading Slack notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -272,3 +272,48 @@ func TestTelegramNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestTelegramNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"tok","telegram_chat_id":"1"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"tok","telegram_chat_id":"1"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled = true
+  token   = "tok"
+  chat_id = "1"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled = true
+  token   = "tok"
+  chat_id = "1"
+`),
+				ExpectError: regexp.MustCompile(`Error reading Telegram notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -244,3 +244,46 @@ func TestWebhookNotificationResource_CreateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestWebhookNotificationResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		// Post-create refresh is get #1 after patch; fail subsequent Reads (step 2).
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+`),
+				ExpectError: regexp.MustCompile(`Error reading Webhook notifications`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

MPI cycle after #715:

- Unit tests for `notificationcommon.ImportStateCurrent` (package isolation coverage 100%)
- Read diagnostics unit tests (API 422) for all six notification channels
- Client event JSON tag parity vs shared event names
- import.sh singleton comments + docs regen; test floor **1250+**

Filed follow-up: #716 share notification unit-test mock servers.

## Test plan

- [x] Targeted `go test` on notification packages + client (local)
- [ ] Full GitHub CI (this PR; concurrent matrix preferred over local serial `make ci`)

Ref #716