### PR TITLE
test: share notification EventStore mock helpers across channels

### DIFF
--- a/internal/service/notificationcommon/mock_events.go
+++ b/internal/service/notificationcommon/mock_events.go
@@ -33,7 +33,8 @@ func EventJSONKey(channel, eventAttr string) string {
 	return eventAttr + "_" + channel + "_notifications"
 }
 
-// eventFieldMaps maps EventAttributeNames entries to EventStore fields.
+// fieldPtrs maps EventAttributeNames entries to EventStore fields.
+// Keep attrs in the same order/names as eventNames in common.go.
 func (e *EventStore) fieldPtrs() []struct {
 	attr string
 	ptr  *bool

--- a/internal/service/notificationcommon/mock_events.go
+++ b/internal/service/notificationcommon/mock_events.go
@@ -1,0 +1,140 @@
+package notificationcommon
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// EventStore holds the 14 shared Coolify notification event flags used by
+// httptest mock servers in unit tests. Embed it in channel-specific mocks.
+//
+// JSON keys follow Coolify's pattern: <event>_<channel>_notifications
+// (e.g. deployment_failure_discord_notifications).
+type EventStore struct {
+	DeploymentSuccess    bool
+	DeploymentFailure    bool
+	StatusChange         bool
+	BackupSuccess        bool
+	BackupFailure        bool
+	ScheduledTaskSuccess bool
+	ScheduledTaskFailure bool
+	DockerCleanupSuccess bool
+	DockerCleanupFailure bool
+	ServerDiskUsage      bool
+	ServerReachable      bool
+	ServerUnreachable    bool
+	ServerPatch          bool
+	TraefikOutdated      bool
+}
+
+// EventJSONKey returns the Coolify PATCH/GET JSON key for a schema event attr.
+// channel is the API channel slug (discord, slack, email, telegram, pushover, webhook).
+func EventJSONKey(channel, eventAttr string) string {
+	return eventAttr + "_" + channel + "_notifications"
+}
+
+// eventFieldMaps maps EventAttributeNames entries to EventStore fields.
+func (e *EventStore) fieldPtrs() []struct {
+	attr string
+	ptr  *bool
+} {
+	return []struct {
+		attr string
+		ptr  *bool
+	}{
+		{"deployment_success", &e.DeploymentSuccess},
+		{"deployment_failure", &e.DeploymentFailure},
+		{"status_change", &e.StatusChange},
+		{"backup_success", &e.BackupSuccess},
+		{"backup_failure", &e.BackupFailure},
+		{"scheduled_task_success", &e.ScheduledTaskSuccess},
+		{"scheduled_task_failure", &e.ScheduledTaskFailure},
+		{"docker_cleanup_success", &e.DockerCleanupSuccess},
+		{"docker_cleanup_failure", &e.DockerCleanupFailure},
+		{"server_disk_usage", &e.ServerDiskUsage},
+		{"server_reachable", &e.ServerReachable},
+		{"server_unreachable", &e.ServerUnreachable},
+		{"server_patch", &e.ServerPatch},
+		{"traefik_outdated", &e.TraefikOutdated},
+	}
+}
+
+// PutSnapshot writes all 14 event flags into out under Coolify JSON keys for channel.
+func (e *EventStore) PutSnapshot(out map[string]interface{}, channel string) {
+	for _, f := range e.fieldPtrs() {
+		out[EventJSONKey(channel, f.attr)] = *f.ptr
+	}
+}
+
+// ApplyBody sets event flags from a decoded PATCH body when keys are present.
+func (e *EventStore) ApplyBody(channel string, body map[string]interface{}) {
+	for _, f := range e.fieldPtrs() {
+		if v, ok := body[EventJSONKey(channel, f.attr)].(bool); ok {
+			*f.ptr = v
+		}
+	}
+}
+
+// EventAllowedFields returns a map with all 14 event JSON keys set to true for
+// Coolify-style unknown-field rejection in mock PATCH handlers.
+func EventAllowedFields(channel string) map[string]bool {
+	out := make(map[string]bool, len(eventNames))
+	for _, e := range eventNames {
+		out[EventJSONKey(channel, e.attr)] = true
+	}
+	return out
+}
+
+// MergeAllowed returns a copy of base with each extra key set to true.
+func MergeAllowed(base map[string]bool, extra ...string) map[string]bool {
+	out := make(map[string]bool, len(base)+len(extra))
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, k := range extra {
+		out[k] = true
+	}
+	return out
+}
+
+// RejectUnknownFields writes a Coolify-like 422 when body contains keys not in
+// allowed. Returns true if the request was rejected (caller should return).
+func RejectUnknownFields(w http.ResponseWriter, body map[string]interface{}, allowed map[string]bool) bool {
+	for k := range body {
+		if !allowed[k] {
+			http.Error(w, `{"message":"Validation failed.","errors":{"`+k+`":["This field is not allowed."]}}`, http.StatusUnprocessableEntity)
+			return true
+		}
+	}
+	return false
+}
+
+// BoolFromBody sets *dst when key is present as a JSON bool.
+func BoolFromBody(body map[string]interface{}, key string, dst *bool) {
+	if v, ok := body[key].(bool); ok {
+		*dst = v
+	}
+}
+
+// StringFromBody sets *dst when key is present as a JSON string.
+func StringFromBody(body map[string]interface{}, key string, dst *string) {
+	if v, ok := body[key].(string); ok {
+		*dst = v
+	}
+}
+
+// DecodeJSONBody decodes r.Body into a map, or writes 400 and returns nil, false.
+func DecodeJSONBody(w http.ResponseWriter, r *http.Request) (map[string]interface{}, bool) {
+	var body map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		return nil, false
+	}
+	return body, true
+}
+
+// WriteJSON encodes v as application/json.
+func WriteJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/service/notificationcommon/mock_events_test.go
+++ b/internal/service/notificationcommon/mock_events_test.go
@@ -1,0 +1,121 @@
+package notificationcommon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventJSONKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "deployment_failure_discord_notifications",
+		notificationcommon.EventJSONKey("discord", "deployment_failure"))
+	assert.Equal(t, "traefik_outdated_slack_notifications",
+		notificationcommon.EventJSONKey("slack", "traefik_outdated"))
+}
+
+func TestEventStore_PutSnapshotAndApplyBody(t *testing.T) {
+	t.Parallel()
+	var e notificationcommon.EventStore
+	e.DeploymentFailure = true
+	e.ServerDiskUsage = true
+
+	out := map[string]interface{}{"id": 1}
+	e.PutSnapshot(out, "webhook")
+	require.Len(t, out, 1+14)
+	assert.Equal(t, true, out["deployment_failure_webhook_notifications"])
+	assert.Equal(t, false, out["deployment_success_webhook_notifications"])
+	assert.Equal(t, true, out["server_disk_usage_webhook_notifications"])
+
+	body := map[string]interface{}{
+		"deployment_failure_webhook_notifications": false,
+		"status_change_webhook_notifications":      true,
+		"ignored":                                  "x",
+	}
+	e.ApplyBody("webhook", body)
+	assert.False(t, e.DeploymentFailure)
+	assert.True(t, e.StatusChange)
+	assert.True(t, e.ServerDiskUsage) // unchanged
+}
+
+func TestEventAllowedFields_AllFourteen(t *testing.T) {
+	t.Parallel()
+	allowed := notificationcommon.EventAllowedFields("email")
+	require.Len(t, allowed, 14)
+	for _, name := range notificationcommon.EventAttributeNames() {
+		key := notificationcommon.EventJSONKey("email", name)
+		assert.True(t, allowed[key], "missing %s", key)
+	}
+}
+
+func TestMergeAllowed(t *testing.T) {
+	t.Parallel()
+	base := notificationcommon.EventAllowedFields("slack")
+	merged := notificationcommon.MergeAllowed(base, "slack_enabled", "slack_webhook_url")
+	assert.True(t, merged["slack_enabled"])
+	assert.True(t, merged["slack_webhook_url"])
+	assert.True(t, merged[notificationcommon.EventJSONKey("slack", "backup_failure")])
+	// base not mutated
+	assert.False(t, base["slack_enabled"])
+}
+
+func TestRejectUnknownFields(t *testing.T) {
+	t.Parallel()
+	allowed := notificationcommon.MergeAllowed(
+		notificationcommon.EventAllowedFields("discord"),
+		"discord_enabled",
+	)
+	rec := httptest.NewRecorder()
+	okBody := map[string]interface{}{"discord_enabled": true}
+	assert.False(t, notificationcommon.RejectUnknownFields(rec, okBody, allowed))
+	assert.Equal(t, 200, rec.Code) // unchanged (no write on accept)
+
+	rec = httptest.NewRecorder()
+	badBody := map[string]interface{}{"not_a_field": true}
+	assert.True(t, notificationcommon.RejectUnknownFields(rec, badBody, allowed))
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestDecodeJSONBodyAndWriteJSON(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewBufferString(`{"a":true}`))
+	rec := httptest.NewRecorder()
+	body, ok := notificationcommon.DecodeJSONBody(rec, req)
+	require.True(t, ok)
+	assert.Equal(t, true, body["a"])
+
+	req = httptest.NewRequest(http.MethodPatch, "/", bytes.NewBufferString(`{`))
+	rec = httptest.NewRecorder()
+	_, ok = notificationcommon.DecodeJSONBody(rec, req)
+	assert.False(t, ok)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = httptest.NewRecorder()
+	notificationcommon.WriteJSON(rec, map[string]interface{}{"ok": true})
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var got map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, true, got["ok"])
+}
+
+func TestBoolAndStringFromBody(t *testing.T) {
+	t.Parallel()
+	body := map[string]interface{}{"b": true, "s": "hi", "n": 1.0}
+	var b bool
+	var s string
+	notificationcommon.BoolFromBody(body, "b", &b)
+	notificationcommon.StringFromBody(body, "s", &s)
+	assert.True(t, b)
+	assert.Equal(t, "hi", s)
+	// wrong types no-op
+	notificationcommon.BoolFromBody(body, "s", &b)
+	assert.True(t, b)
+	notificationcommon.StringFromBody(body, "n", &s)
+	assert.Equal(t, "hi", s)
+}

--- a/internal/service/notificationcommon/mock_events_test.go
+++ b/internal/service/notificationcommon/mock_events_test.go
@@ -54,6 +54,54 @@ func TestEventAllowedFields_AllFourteen(t *testing.T) {
 	}
 }
 
+// TestEventStore_AlignsWithEventAttributeNames guards fieldPtrs attrs against
+// eventNames drift (EventAllowedFields uses eventNames; PutSnapshot uses fieldPtrs).
+func TestEventStore_AlignsWithEventAttributeNames(t *testing.T) {
+	t.Parallel()
+	names := notificationcommon.EventAttributeNames()
+	require.Len(t, names, 14)
+
+	var e notificationcommon.EventStore
+	// Flip every field so the snapshot is not all-false noise.
+	e.DeploymentSuccess = true
+	e.DeploymentFailure = true
+	e.StatusChange = true
+	e.BackupSuccess = true
+	e.BackupFailure = true
+	e.ScheduledTaskSuccess = true
+	e.ScheduledTaskFailure = true
+	e.DockerCleanupSuccess = true
+	e.DockerCleanupFailure = true
+	e.ServerDiskUsage = true
+	e.ServerReachable = true
+	e.ServerUnreachable = true
+	e.ServerPatch = true
+	e.TraefikOutdated = true
+
+	out := map[string]interface{}{}
+	e.PutSnapshot(out, "discord")
+	require.Len(t, out, len(names))
+	for _, name := range names {
+		key := notificationcommon.EventJSONKey("discord", name)
+		v, ok := out[key]
+		require.True(t, ok, "PutSnapshot missing key for attr %q", name)
+		assert.Equal(t, true, v, "PutSnapshot value for %q", name)
+	}
+
+	// ApplyBody must accept every EventJSONKey from EventAttributeNames.
+	body := make(map[string]interface{}, len(names))
+	for _, name := range names {
+		body[notificationcommon.EventJSONKey("discord", name)] = false
+	}
+	e.ApplyBody("discord", body)
+	out2 := map[string]interface{}{}
+	e.PutSnapshot(out2, "discord")
+	for _, name := range names {
+		key := notificationcommon.EventJSONKey("discord", name)
+		assert.Equal(t, false, out2[key], "ApplyBody did not clear %q", name)
+	}
+}
+
 func TestMergeAllowed(t *testing.T) {
 	t.Parallel()
 	base := notificationcommon.EventAllowedFields("slack")

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -32,7 +32,7 @@ func (m *mockDiscord) snapshot() map[string]interface{} {
 		"discord_enabled":      m.Enabled,
 		"discord_ping_enabled": m.PingEnabled,
 	}
-	m.EventStore.PutSnapshot(out, "discord")
+	m.PutSnapshot(out, "discord")
 	if !m.HideWebhook {
 		out["discord_webhook_url"] = m.Webhook
 	}
@@ -60,7 +60,7 @@ func newMockServer(store *mockDiscord) *httptest.Server {
 		notificationcommon.BoolFromBody(body, "discord_enabled", &store.Enabled)
 		notificationcommon.StringFromBody(body, "discord_webhook_url", &store.Webhook)
 		notificationcommon.BoolFromBody(body, "discord_ping_enabled", &store.PingEnabled)
-		store.EventStore.ApplyBody("discord", body)
+		store.ApplyBody("discord", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -1,7 +1,6 @@
 package notificationdiscord_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,30 +9,18 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockDiscord struct {
-	mu                   sync.Mutex
-	Enabled              bool   `json:"discord_enabled"`
-	Webhook              string `json:"discord_webhook_url"`
-	PingEnabled          bool   `json:"discord_ping_enabled"`
-	DeploymentSuccess    bool   `json:"deployment_success_discord_notifications"`
-	DeploymentFailure    bool   `json:"deployment_failure_discord_notifications"`
-	StatusChange         bool   `json:"status_change_discord_notifications"`
-	BackupSuccess        bool   `json:"backup_success_discord_notifications"`
-	BackupFailure        bool   `json:"backup_failure_discord_notifications"`
-	ScheduledTaskSuccess bool   `json:"scheduled_task_success_discord_notifications"`
-	ScheduledTaskFailure bool   `json:"scheduled_task_failure_discord_notifications"`
-	DockerCleanupSuccess bool   `json:"docker_cleanup_success_discord_notifications"`
-	DockerCleanupFailure bool   `json:"docker_cleanup_failure_discord_notifications"`
-	ServerDiskUsage      bool   `json:"server_disk_usage_discord_notifications"`
-	ServerReachable      bool   `json:"server_reachable_discord_notifications"`
-	ServerUnreachable    bool   `json:"server_unreachable_discord_notifications"`
-	ServerPatch          bool   `json:"server_patch_discord_notifications"`
-	TraefikOutdated      bool   `json:"traefik_outdated_discord_notifications"`
-	HideWebhook          bool   `json:"-"`
+	mu          sync.Mutex
+	Enabled     bool
+	Webhook     string
+	PingEnabled bool
+	HideWebhook bool
+	notificationcommon.EventStore
 }
 
 func (m *mockDiscord) snapshot() map[string]interface{} {
@@ -44,21 +31,8 @@ func (m *mockDiscord) snapshot() map[string]interface{} {
 		"team_id":              0,
 		"discord_enabled":      m.Enabled,
 		"discord_ping_enabled": m.PingEnabled,
-		"deployment_success_discord_notifications":     m.DeploymentSuccess,
-		"deployment_failure_discord_notifications":     m.DeploymentFailure,
-		"status_change_discord_notifications":          m.StatusChange,
-		"backup_success_discord_notifications":         m.BackupSuccess,
-		"backup_failure_discord_notifications":         m.BackupFailure,
-		"scheduled_task_success_discord_notifications": m.ScheduledTaskSuccess,
-		"scheduled_task_failure_discord_notifications": m.ScheduledTaskFailure,
-		"docker_cleanup_success_discord_notifications": m.DockerCleanupSuccess,
-		"docker_cleanup_failure_discord_notifications": m.DockerCleanupFailure,
-		"server_disk_usage_discord_notifications":      m.ServerDiskUsage,
-		"server_reachable_discord_notifications":       m.ServerReachable,
-		"server_unreachable_discord_notifications":     m.ServerUnreachable,
-		"server_patch_discord_notifications":           m.ServerPatch,
-		"traefik_outdated_discord_notifications":       m.TraefikOutdated,
 	}
+	m.EventStore.PutSnapshot(out, "discord")
 	if !m.HideWebhook {
 		out["discord_webhook_url"] = m.Webhook
 	}
@@ -68,75 +42,34 @@ func (m *mockDiscord) snapshot() map[string]interface{} {
 func newMockServer(store *mockDiscord) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
-		// Reject unknown fields like Coolify does.
-		allowed := map[string]bool{
-			"discord_enabled": true, "discord_webhook_url": true, "discord_ping_enabled": true,
-			"deployment_success_discord_notifications": true, "deployment_failure_discord_notifications": true,
-			"status_change_discord_notifications": true, "backup_success_discord_notifications": true,
-			"backup_failure_discord_notifications": true, "scheduled_task_success_discord_notifications": true,
-			"scheduled_task_failure_discord_notifications": true, "docker_cleanup_success_discord_notifications": true,
-			"docker_cleanup_failure_discord_notifications": true, "server_disk_usage_discord_notifications": true,
-			"server_reachable_discord_notifications": true, "server_unreachable_discord_notifications": true,
-			"server_patch_discord_notifications": true, "traefik_outdated_discord_notifications": true,
-		}
-		for k := range body {
-			if !allowed[k] {
-				http.Error(w, `{"message":"Validation failed.","errors":{"`+k+`":["This field is not allowed."]}}`, http.StatusUnprocessableEntity)
-				return
-			}
+		allowed := notificationcommon.MergeAllowed(
+			notificationcommon.EventAllowedFields("discord"),
+			"discord_enabled", "discord_webhook_url", "discord_ping_enabled",
+		)
+		if notificationcommon.RejectUnknownFields(w, body, allowed) {
+			return
 		}
 		store.mu.Lock()
-		if v, ok := body["discord_enabled"].(bool); ok {
-			store.Enabled = v
-		}
-		if v, ok := body["discord_webhook_url"].(string); ok {
-			store.Webhook = v
-		}
-		if v, ok := body["discord_ping_enabled"].(bool); ok {
-			store.PingEnabled = v
-		}
-		setB := func(key string, dst *bool) {
-			if v, ok := body[key].(bool); ok {
-				*dst = v
-			}
-		}
-		setB("deployment_success_discord_notifications", &store.DeploymentSuccess)
-		setB("deployment_failure_discord_notifications", &store.DeploymentFailure)
-		setB("status_change_discord_notifications", &store.StatusChange)
-		setB("backup_success_discord_notifications", &store.BackupSuccess)
-		setB("backup_failure_discord_notifications", &store.BackupFailure)
-		setB("scheduled_task_success_discord_notifications", &store.ScheduledTaskSuccess)
-		setB("scheduled_task_failure_discord_notifications", &store.ScheduledTaskFailure)
-		setB("docker_cleanup_success_discord_notifications", &store.DockerCleanupSuccess)
-		setB("docker_cleanup_failure_discord_notifications", &store.DockerCleanupFailure)
-		setB("server_disk_usage_discord_notifications", &store.ServerDiskUsage)
-		setB("server_reachable_discord_notifications", &store.ServerReachable)
-		setB("server_unreachable_discord_notifications", &store.ServerUnreachable)
-		setB("server_patch_discord_notifications", &store.ServerPatch)
-		setB("traefik_outdated_discord_notifications", &store.TraefikOutdated)
+		notificationcommon.BoolFromBody(body, "discord_enabled", &store.Enabled)
+		notificationcommon.StringFromBody(body, "discord_webhook_url", &store.Webhook)
+		notificationcommon.BoolFromBody(body, "discord_ping_enabled", &store.PingEnabled)
+		store.EventStore.ApplyBody("discord", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestDiscordNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockDiscord{
-		DeploymentFailure: true,
-		BackupFailure:     true,
-		ServerDiskUsage:   true,
-	}
+	store := &mockDiscord{EventStore: notificationcommon.EventStore{DeploymentFailure: true, BackupFailure: true, ServerDiskUsage: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -10,109 +10,81 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockEmail struct {
-	mu                sync.Mutex
-	SMTPEnabled       bool
-	SMTPHost          string
-	SMTPPort          int
-	SMTPEncryption    string
-	ResendEnabled     bool
-	UseInstanceEmail  bool
-	DeploymentFailure bool
-	BackupFailure     bool
+	mu               sync.Mutex
+	SMTPEnabled      bool
+	SMTPHost         string
+	SMTPPort         int
+	SMTPEncryption   string
+	ResendEnabled    bool
+	UseInstanceEmail bool
+	notificationcommon.EventStore
 }
 
 func (m *mockEmail) snapshot() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := map[string]interface{}{
-		"id": 1, "team_id": 0,
-		"smtp_enabled":                           m.SMTPEnabled,
-		"smtp_host":                              m.SMTPHost,
-		"smtp_encryption":                        m.SMTPEncryption,
-		"resend_enabled":                         m.ResendEnabled,
-		"use_instance_email_settings":            m.UseInstanceEmail,
-		"deployment_failure_email_notifications": m.DeploymentFailure,
-		"backup_failure_email_notifications":     m.BackupFailure,
+		"id":                          1,
+		"team_id":                     0,
+		"smtp_enabled":                m.SMTPEnabled,
+		"smtp_host":                   m.SMTPHost,
+		"smtp_encryption":             m.SMTPEncryption,
+		"resend_enabled":              m.ResendEnabled,
+		"use_instance_email_settings": m.UseInstanceEmail,
 	}
 	if m.SMTPPort != 0 {
 		out["smtp_port"] = m.SMTPPort
 	}
+	m.EventStore.PutSnapshot(out, "email")
 	return out
 }
 
 func newMockServer(store *mockEmail) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
-		// Reject unknown fields like Coolify.
-		allowed := map[string]bool{
-			"smtp_enabled": true, "smtp_from_address": true, "smtp_from_name": true,
-			"smtp_recipients": true, "smtp_host": true, "smtp_port": true,
-			"smtp_encryption": true, "smtp_username": true, "smtp_password": true,
-			"smtp_timeout": true, "resend_enabled": true, "resend_api_key": true,
-			"use_instance_email_settings":            true,
-			"deployment_success_email_notifications": true, "deployment_failure_email_notifications": true,
-			"status_change_email_notifications": true, "backup_success_email_notifications": true,
-			"backup_failure_email_notifications": true, "scheduled_task_success_email_notifications": true,
-			"scheduled_task_failure_email_notifications": true, "docker_cleanup_success_email_notifications": true,
-			"docker_cleanup_failure_email_notifications": true, "server_disk_usage_email_notifications": true,
-			"server_reachable_email_notifications": true, "server_unreachable_email_notifications": true,
-			"server_patch_email_notifications": true, "traefik_outdated_email_notifications": true,
-		}
-		for k := range body {
-			if !allowed[k] {
-				http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
-				return
-			}
+		allowed := notificationcommon.MergeAllowed(
+			notificationcommon.EventAllowedFields("email"),
+			"smtp_enabled", "smtp_from_address", "smtp_from_name",
+			"smtp_recipients", "smtp_host", "smtp_port",
+			"smtp_encryption", "smtp_username", "smtp_password",
+			"smtp_timeout", "resend_enabled", "resend_api_key",
+			"use_instance_email_settings",
+		)
+		if notificationcommon.RejectUnknownFields(w, body, allowed) {
+			return
 		}
 		store.mu.Lock()
-		if v, ok := body["smtp_enabled"].(bool); ok {
-			store.SMTPEnabled = v
-		}
-		if v, ok := body["smtp_host"].(string); ok {
-			store.SMTPHost = v
-		}
-		if v, ok := body["smtp_encryption"].(string); ok {
-			store.SMTPEncryption = v
-		}
+		notificationcommon.BoolFromBody(body, "smtp_enabled", &store.SMTPEnabled)
+		notificationcommon.StringFromBody(body, "smtp_host", &store.SMTPHost)
+		notificationcommon.StringFromBody(body, "smtp_encryption", &store.SMTPEncryption)
 		if v, ok := body["smtp_port"].(float64); ok {
 			store.SMTPPort = int(v)
 		}
-		if v, ok := body["resend_enabled"].(bool); ok {
-			store.ResendEnabled = v
-		}
-		if v, ok := body["use_instance_email_settings"].(bool); ok {
-			store.UseInstanceEmail = v
-		}
-		if v, ok := body["deployment_failure_email_notifications"].(bool); ok {
-			store.DeploymentFailure = v
-		}
-		if v, ok := body["backup_failure_email_notifications"].(bool); ok {
-			store.BackupFailure = v
-		}
+		notificationcommon.BoolFromBody(body, "resend_enabled", &store.ResendEnabled)
+		notificationcommon.BoolFromBody(body, "use_instance_email_settings", &store.UseInstanceEmail)
+		store.EventStore.ApplyBody("email", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestEmailNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockEmail{DeploymentFailure: true}
+	store := &mockEmail{EventStore: notificationcommon.EventStore{DeploymentFailure: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -41,7 +41,7 @@ func (m *mockEmail) snapshot() map[string]interface{} {
 	if m.SMTPPort != 0 {
 		out["smtp_port"] = m.SMTPPort
 	}
-	m.EventStore.PutSnapshot(out, "email")
+	m.PutSnapshot(out, "email")
 	return out
 }
 
@@ -75,7 +75,7 @@ func newMockServer(store *mockEmail) *httptest.Server {
 		}
 		notificationcommon.BoolFromBody(body, "resend_enabled", &store.ResendEnabled)
 		notificationcommon.BoolFromBody(body, "use_instance_email_settings", &store.UseInstanceEmail)
-		store.EventStore.ApplyBody("email", body)
+		store.ApplyBody("email", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -32,7 +32,7 @@ func (m *mockPushover) snapshot() map[string]interface{} {
 		"pushover_user_key":  m.UserKey,
 		"pushover_api_token": m.Token,
 	}
-	m.EventStore.PutSnapshot(out, "pushover")
+	m.PutSnapshot(out, "pushover")
 	return out
 }
 
@@ -50,7 +50,7 @@ func newMockServer(store *mockPushover) *httptest.Server {
 		notificationcommon.BoolFromBody(body, "pushover_enabled", &store.Enabled)
 		notificationcommon.StringFromBody(body, "pushover_user_key", &store.UserKey)
 		notificationcommon.StringFromBody(body, "pushover_api_token", &store.Token)
-		store.EventStore.ApplyBody("pushover", body)
+		store.ApplyBody("pushover", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -1,7 +1,6 @@
 package notificationpushover_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,70 +9,57 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockPushover struct {
-	mu                sync.Mutex
-	Enabled           bool
-	UserKey           string
-	Token             string
-	DeploymentFailure bool
-	BackupFailure     bool
+	mu      sync.Mutex
+	Enabled bool
+	UserKey string
+	Token   string
+	notificationcommon.EventStore
 }
 
 func (m *mockPushover) snapshot() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return map[string]interface{}{
-		"id": 1, "team_id": 0,
-		"pushover_enabled":                          m.Enabled,
-		"pushover_user_key":                         m.UserKey,
-		"pushover_api_token":                        m.Token,
-		"deployment_failure_pushover_notifications": m.DeploymentFailure,
-		"backup_failure_pushover_notifications":     m.BackupFailure,
+	out := map[string]interface{}{
+		"id":                 1,
+		"team_id":            0,
+		"pushover_enabled":   m.Enabled,
+		"pushover_user_key":  m.UserKey,
+		"pushover_api_token": m.Token,
 	}
+	m.EventStore.PutSnapshot(out, "pushover")
+	return out
 }
 
 func newMockServer(store *mockPushover) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
 		store.mu.Lock()
-		if v, ok := body["pushover_enabled"].(bool); ok {
-			store.Enabled = v
-		}
-		if v, ok := body["pushover_user_key"].(string); ok {
-			store.UserKey = v
-		}
-		if v, ok := body["pushover_api_token"].(string); ok {
-			store.Token = v
-		}
-		if v, ok := body["deployment_failure_pushover_notifications"].(bool); ok {
-			store.DeploymentFailure = v
-		}
-		if v, ok := body["backup_failure_pushover_notifications"].(bool); ok {
-			store.BackupFailure = v
-		}
+		notificationcommon.BoolFromBody(body, "pushover_enabled", &store.Enabled)
+		notificationcommon.StringFromBody(body, "pushover_user_key", &store.UserKey)
+		notificationcommon.StringFromBody(body, "pushover_api_token", &store.Token)
+		store.EventStore.ApplyBody("pushover", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestPushoverNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockPushover{DeploymentFailure: true}
+	store := &mockPushover{EventStore: notificationcommon.EventStore{DeploymentFailure: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -30,7 +30,7 @@ func (m *mockSlack) snapshot() map[string]interface{} {
 		"slack_enabled":     m.Enabled,
 		"slack_webhook_url": m.Webhook,
 	}
-	m.EventStore.PutSnapshot(out, "slack")
+	m.PutSnapshot(out, "slack")
 	return out
 }
 
@@ -47,7 +47,7 @@ func newMockServer(store *mockSlack) *httptest.Server {
 		store.mu.Lock()
 		notificationcommon.BoolFromBody(body, "slack_enabled", &store.Enabled)
 		notificationcommon.StringFromBody(body, "slack_webhook_url", &store.Webhook)
-		store.EventStore.ApplyBody("slack", body)
+		store.ApplyBody("slack", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -1,7 +1,6 @@
 package notificationslack_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,103 +9,54 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockSlack struct {
-	mu                   sync.Mutex
-	Enabled              bool
-	Webhook              string
-	DeploymentSuccess    bool
-	DeploymentFailure    bool
-	StatusChange         bool
-	BackupSuccess        bool
-	BackupFailure        bool
-	ScheduledTaskSuccess bool
-	ScheduledTaskFailure bool
-	DockerCleanupSuccess bool
-	DockerCleanupFailure bool
-	ServerDiskUsage      bool
-	ServerReachable      bool
-	ServerUnreachable    bool
-	ServerPatch          bool
-	TraefikOutdated      bool
+	mu      sync.Mutex
+	Enabled bool
+	Webhook string
+	notificationcommon.EventStore
 }
 
 func (m *mockSlack) snapshot() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return map[string]interface{}{
-		"id":                                         1,
-		"team_id":                                    0,
-		"slack_enabled":                              m.Enabled,
-		"slack_webhook_url":                          m.Webhook,
-		"deployment_success_slack_notifications":     m.DeploymentSuccess,
-		"deployment_failure_slack_notifications":     m.DeploymentFailure,
-		"status_change_slack_notifications":          m.StatusChange,
-		"backup_success_slack_notifications":         m.BackupSuccess,
-		"backup_failure_slack_notifications":         m.BackupFailure,
-		"scheduled_task_success_slack_notifications": m.ScheduledTaskSuccess,
-		"scheduled_task_failure_slack_notifications": m.ScheduledTaskFailure,
-		"docker_cleanup_success_slack_notifications": m.DockerCleanupSuccess,
-		"docker_cleanup_failure_slack_notifications": m.DockerCleanupFailure,
-		"server_disk_usage_slack_notifications":      m.ServerDiskUsage,
-		"server_reachable_slack_notifications":       m.ServerReachable,
-		"server_unreachable_slack_notifications":     m.ServerUnreachable,
-		"server_patch_slack_notifications":           m.ServerPatch,
-		"traefik_outdated_slack_notifications":       m.TraefikOutdated,
+	out := map[string]interface{}{
+		"id":                1,
+		"team_id":           0,
+		"slack_enabled":     m.Enabled,
+		"slack_webhook_url": m.Webhook,
 	}
+	m.EventStore.PutSnapshot(out, "slack")
+	return out
 }
 
 func newMockServer(store *mockSlack) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
 		store.mu.Lock()
-		if v, ok := body["slack_enabled"].(bool); ok {
-			store.Enabled = v
-		}
-		if v, ok := body["slack_webhook_url"].(string); ok {
-			store.Webhook = v
-		}
-		setB := func(key string, dst *bool) {
-			if v, ok := body[key].(bool); ok {
-				*dst = v
-			}
-		}
-		setB("deployment_success_slack_notifications", &store.DeploymentSuccess)
-		setB("deployment_failure_slack_notifications", &store.DeploymentFailure)
-		setB("status_change_slack_notifications", &store.StatusChange)
-		setB("backup_success_slack_notifications", &store.BackupSuccess)
-		setB("backup_failure_slack_notifications", &store.BackupFailure)
-		setB("scheduled_task_success_slack_notifications", &store.ScheduledTaskSuccess)
-		setB("scheduled_task_failure_slack_notifications", &store.ScheduledTaskFailure)
-		setB("docker_cleanup_success_slack_notifications", &store.DockerCleanupSuccess)
-		setB("docker_cleanup_failure_slack_notifications", &store.DockerCleanupFailure)
-		setB("server_disk_usage_slack_notifications", &store.ServerDiskUsage)
-		setB("server_reachable_slack_notifications", &store.ServerReachable)
-		setB("server_unreachable_slack_notifications", &store.ServerUnreachable)
-		setB("server_patch_slack_notifications", &store.ServerPatch)
-		setB("traefik_outdated_slack_notifications", &store.TraefikOutdated)
+		notificationcommon.BoolFromBody(body, "slack_enabled", &store.Enabled)
+		notificationcommon.StringFromBody(body, "slack_webhook_url", &store.Webhook)
+		store.EventStore.ApplyBody("slack", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestSlackNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockSlack{DeploymentFailure: true, BackupFailure: true, ServerDiskUsage: true}
+	store := &mockSlack{EventStore: notificationcommon.EventStore{DeploymentFailure: true, BackupFailure: true, ServerDiskUsage: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -32,7 +32,7 @@ func (m *mockTelegram) snapshot() map[string]interface{} {
 		"team_id":          0,
 		"telegram_enabled": m.Enabled,
 	}
-	m.EventStore.PutSnapshot(out, "telegram")
+	m.PutSnapshot(out, "telegram")
 	if !m.HideSecrets {
 		out["telegram_token"] = m.Token
 		out["telegram_chat_id"] = m.ChatID
@@ -77,7 +77,7 @@ func newMockServer(store *mockTelegram) *httptest.Server {
 		notificationcommon.StringFromBody(body, "telegram_token", &store.Token)
 		notificationcommon.StringFromBody(body, "telegram_chat_id", &store.ChatID)
 		notificationcommon.StringFromBody(body, "telegram_notifications_deployment_failure_thread_id", &store.ThreadDeployFail)
-		store.EventStore.ApplyBody("telegram", body)
+		store.ApplyBody("telegram", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -1,7 +1,6 @@
 package notificationtelegram_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,30 +9,30 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockTelegram struct {
-	mu                sync.Mutex
-	Enabled           bool
-	Token             string
-	ChatID            string
-	DeploymentFailure bool
-	BackupFailure     bool
-	ThreadDeployFail  string
-	HideSecrets       bool
+	mu               sync.Mutex
+	Enabled          bool
+	Token            string
+	ChatID           string
+	ThreadDeployFail string
+	HideSecrets      bool
+	notificationcommon.EventStore
 }
 
 func (m *mockTelegram) snapshot() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := map[string]interface{}{
-		"id": 1, "team_id": 0,
-		"telegram_enabled":                          m.Enabled,
-		"deployment_failure_telegram_notifications": m.DeploymentFailure,
-		"backup_failure_telegram_notifications":     m.BackupFailure,
+		"id":               1,
+		"team_id":          0,
+		"telegram_enabled": m.Enabled,
 	}
+	m.EventStore.PutSnapshot(out, "telegram")
 	if !m.HideSecrets {
 		out["telegram_token"] = m.Token
 		out["telegram_chat_id"] = m.ChatID
@@ -45,67 +44,49 @@ func (m *mockTelegram) snapshot() map[string]interface{} {
 func newMockServer(store *mockTelegram) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
-		allowed := map[string]bool{
-			"telegram_enabled": true, "telegram_token": true, "telegram_chat_id": true,
-			"deployment_success_telegram_notifications": true, "deployment_failure_telegram_notifications": true,
-			"status_change_telegram_notifications": true, "backup_success_telegram_notifications": true,
-			"backup_failure_telegram_notifications": true, "scheduled_task_success_telegram_notifications": true,
-			"scheduled_task_failure_telegram_notifications": true, "docker_cleanup_success_telegram_notifications": true,
-			"docker_cleanup_failure_telegram_notifications": true, "server_disk_usage_telegram_notifications": true,
-			"server_reachable_telegram_notifications": true, "server_unreachable_telegram_notifications": true,
-			"server_patch_telegram_notifications": true, "traefik_outdated_telegram_notifications": true,
-			"telegram_notifications_deployment_success_thread_id": true, "telegram_notifications_deployment_failure_thread_id": true,
-			"telegram_notifications_status_change_thread_id": true, "telegram_notifications_backup_success_thread_id": true,
-			"telegram_notifications_backup_failure_thread_id": true, "telegram_notifications_scheduled_task_success_thread_id": true,
-			"telegram_notifications_scheduled_task_failure_thread_id": true, "telegram_notifications_docker_cleanup_success_thread_id": true,
-			"telegram_notifications_docker_cleanup_failure_thread_id": true, "telegram_notifications_server_disk_usage_thread_id": true,
-			"telegram_notifications_server_reachable_thread_id": true, "telegram_notifications_server_unreachable_thread_id": true,
-			"telegram_notifications_server_patch_thread_id": true, "telegram_notifications_traefik_outdated_thread_id": true,
-		}
-		for k := range body {
-			if !allowed[k] {
-				http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
-				return
-			}
+		allowed := notificationcommon.MergeAllowed(
+			notificationcommon.EventAllowedFields("telegram"),
+			"telegram_enabled", "telegram_token", "telegram_chat_id",
+			"telegram_notifications_deployment_success_thread_id",
+			"telegram_notifications_deployment_failure_thread_id",
+			"telegram_notifications_status_change_thread_id",
+			"telegram_notifications_backup_success_thread_id",
+			"telegram_notifications_backup_failure_thread_id",
+			"telegram_notifications_scheduled_task_success_thread_id",
+			"telegram_notifications_scheduled_task_failure_thread_id",
+			"telegram_notifications_docker_cleanup_success_thread_id",
+			"telegram_notifications_docker_cleanup_failure_thread_id",
+			"telegram_notifications_server_disk_usage_thread_id",
+			"telegram_notifications_server_reachable_thread_id",
+			"telegram_notifications_server_unreachable_thread_id",
+			"telegram_notifications_server_patch_thread_id",
+			"telegram_notifications_traefik_outdated_thread_id",
+		)
+		if notificationcommon.RejectUnknownFields(w, body, allowed) {
+			return
 		}
 		store.mu.Lock()
-		if v, ok := body["telegram_enabled"].(bool); ok {
-			store.Enabled = v
-		}
-		if v, ok := body["telegram_token"].(string); ok {
-			store.Token = v
-		}
-		if v, ok := body["telegram_chat_id"].(string); ok {
-			store.ChatID = v
-		}
-		if v, ok := body["deployment_failure_telegram_notifications"].(bool); ok {
-			store.DeploymentFailure = v
-		}
-		if v, ok := body["backup_failure_telegram_notifications"].(bool); ok {
-			store.BackupFailure = v
-		}
-		if v, ok := body["telegram_notifications_deployment_failure_thread_id"].(string); ok {
-			store.ThreadDeployFail = v
-		}
+		notificationcommon.BoolFromBody(body, "telegram_enabled", &store.Enabled)
+		notificationcommon.StringFromBody(body, "telegram_token", &store.Token)
+		notificationcommon.StringFromBody(body, "telegram_chat_id", &store.ChatID)
+		notificationcommon.StringFromBody(body, "telegram_notifications_deployment_failure_thread_id", &store.ThreadDeployFail)
+		store.EventStore.ApplyBody("telegram", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestTelegramNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockTelegram{DeploymentFailure: true}
+	store := &mockTelegram{EventStore: notificationcommon.EventStore{DeploymentFailure: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -30,7 +30,7 @@ func (m *mockWebhook) snapshot() map[string]interface{} {
 		"webhook_enabled": m.Enabled,
 		"webhook_url":     m.Webhook,
 	}
-	m.EventStore.PutSnapshot(out, "webhook")
+	m.PutSnapshot(out, "webhook")
 	return out
 }
 
@@ -47,7 +47,7 @@ func newMockServer(store *mockWebhook) *httptest.Server {
 		store.mu.Lock()
 		notificationcommon.BoolFromBody(body, "webhook_enabled", &store.Enabled)
 		notificationcommon.StringFromBody(body, "webhook_url", &store.Webhook)
-		store.EventStore.ApplyBody("webhook", body)
+		store.ApplyBody("webhook", body)
 		store.mu.Unlock()
 		notificationcommon.WriteJSON(w, store.snapshot())
 	})

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -1,7 +1,6 @@
 package notificationwebhook_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,103 +9,54 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 type mockWebhook struct {
-	mu                   sync.Mutex
-	Enabled              bool
-	Webhook              string
-	DeploymentSuccess    bool
-	DeploymentFailure    bool
-	StatusChange         bool
-	BackupSuccess        bool
-	BackupFailure        bool
-	ScheduledTaskSuccess bool
-	ScheduledTaskFailure bool
-	DockerCleanupSuccess bool
-	DockerCleanupFailure bool
-	ServerDiskUsage      bool
-	ServerReachable      bool
-	ServerUnreachable    bool
-	ServerPatch          bool
-	TraefikOutdated      bool
+	mu      sync.Mutex
+	Enabled bool
+	Webhook string
+	notificationcommon.EventStore
 }
 
 func (m *mockWebhook) snapshot() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"id":              1,
 		"team_id":         0,
 		"webhook_enabled": m.Enabled,
 		"webhook_url":     m.Webhook,
-		"deployment_success_webhook_notifications":     m.DeploymentSuccess,
-		"deployment_failure_webhook_notifications":     m.DeploymentFailure,
-		"status_change_webhook_notifications":          m.StatusChange,
-		"backup_success_webhook_notifications":         m.BackupSuccess,
-		"backup_failure_webhook_notifications":         m.BackupFailure,
-		"scheduled_task_success_webhook_notifications": m.ScheduledTaskSuccess,
-		"scheduled_task_failure_webhook_notifications": m.ScheduledTaskFailure,
-		"docker_cleanup_success_webhook_notifications": m.DockerCleanupSuccess,
-		"docker_cleanup_failure_webhook_notifications": m.DockerCleanupFailure,
-		"server_disk_usage_webhook_notifications":      m.ServerDiskUsage,
-		"server_reachable_webhook_notifications":       m.ServerReachable,
-		"server_unreachable_webhook_notifications":     m.ServerUnreachable,
-		"server_patch_webhook_notifications":           m.ServerPatch,
-		"traefik_outdated_webhook_notifications":       m.TraefikOutdated,
 	}
+	m.EventStore.PutSnapshot(out, "webhook")
+	return out
 }
 
 func newMockServer(store *mockWebhook) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"message":"bad json"}`, http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
 		store.mu.Lock()
-		if v, ok := body["webhook_enabled"].(bool); ok {
-			store.Enabled = v
-		}
-		if v, ok := body["webhook_url"].(string); ok {
-			store.Webhook = v
-		}
-		setB := func(key string, dst *bool) {
-			if v, ok := body[key].(bool); ok {
-				*dst = v
-			}
-		}
-		setB("deployment_success_webhook_notifications", &store.DeploymentSuccess)
-		setB("deployment_failure_webhook_notifications", &store.DeploymentFailure)
-		setB("status_change_webhook_notifications", &store.StatusChange)
-		setB("backup_success_webhook_notifications", &store.BackupSuccess)
-		setB("backup_failure_webhook_notifications", &store.BackupFailure)
-		setB("scheduled_task_success_webhook_notifications", &store.ScheduledTaskSuccess)
-		setB("scheduled_task_failure_webhook_notifications", &store.ScheduledTaskFailure)
-		setB("docker_cleanup_success_webhook_notifications", &store.DockerCleanupSuccess)
-		setB("docker_cleanup_failure_webhook_notifications", &store.DockerCleanupFailure)
-		setB("server_disk_usage_webhook_notifications", &store.ServerDiskUsage)
-		setB("server_reachable_webhook_notifications", &store.ServerReachable)
-		setB("server_unreachable_webhook_notifications", &store.ServerUnreachable)
-		setB("server_patch_webhook_notifications", &store.ServerPatch)
-		setB("traefik_outdated_webhook_notifications", &store.TraefikOutdated)
+		notificationcommon.BoolFromBody(body, "webhook_enabled", &store.Enabled)
+		notificationcommon.StringFromBody(body, "webhook_url", &store.Webhook)
+		store.EventStore.ApplyBody("webhook", body)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(store.snapshot())
+		notificationcommon.WriteJSON(w, store.snapshot())
 	})
 	return httptest.NewServer(acctest.WithVersionEndpoint(mux))
 }
 
 func TestWebhookNotificationResource_CreateUpdateImport(t *testing.T) {
 	t.Parallel()
-	store := &mockWebhook{DeploymentFailure: true, BackupFailure: true, ServerDiskUsage: true}
+	store := &mockWebhook{EventStore: notificationcommon.EventStore{DeploymentFailure: true, BackupFailure: true, ServerDiskUsage: true}}
 	srv := newMockServer(store)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary

Extract shared unit-test mock helpers for Coolify notification event flags into `notificationcommon`, then rewrite the six channel package mock servers to use them.

## Changes

- **`EventStore`** holds the 14 shared event bools; embed in channel mocks
- **`EventJSONKey` / `PutSnapshot` / `ApplyBody`** map schema attrs to Coolify JSON keys (`<event>_<channel>_notifications`)
- **`EventAllowedFields` / `MergeAllowed` / `RejectUnknownFields`** for Coolify-style 422 unknown-field rejection
- **`DecodeJSONBody` / `WriteJSON` / `BoolFromBody` / `StringFromBody`** small HTTP/JSON helpers
- Unit coverage for the helpers; all six `notification*` resource tests updated

## Why

After #715 shared production schema/import helpers, each channel still duplicated nearly identical event maps and PATCH allowlists. New Coolify event fields required six parallel mock edits.

## Test plan

- [x] `go test ./internal/service/notification...`
- [ ] CI green on this PR

Closes #716