### PR TITLE
test: notification Update/Destroy API errors and validator coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1270+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 56 data sources, 1280+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1270+ tests (unit + acceptance)
+- 1280+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 56 data sources, 1250+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 56 data sources, 1270+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1250+ tests (unit + acceptance)
+- 1270+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 45 |
 | Data sources | 56 |
-| Tests | 1270+ unit and acceptance tests |
+| Tests | 1280+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -316,7 +316,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1270+ tests, race detector enabled)
+make test                                       # Run unit tests (1280+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 45 |
 | Data sources | 56 |
-| Tests | 1250+ unit and acceptance tests |
+| Tests | 1270+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -316,7 +316,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1250+ tests, race detector enabled)
+make test                                       # Run unit tests (1270+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -279,3 +279,44 @@ func TestDiscordNotificationResource_ReadAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestDiscordNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating Discord notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationdiscord/resource_test.go
+++ b/internal/service/notificationdiscord/resource_test.go
@@ -320,3 +320,41 @@ func TestDiscordNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestDiscordNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/discord", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"discord_enabled":true,"discord_webhook_url":"https://discord.com/api/webhooks/1/x"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_discord", "test", `
+  enabled     = true
+  webhook_url = "https://discord.com/api/webhooks/1/x"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling Discord notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -1,7 +1,6 @@
 package notificationemail_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -203,28 +202,21 @@ func TestEmailNotificationResource_PreserveHiddenSecrets(t *testing.T) {
 	store := &mockEmail{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		notificationcommon.WriteJSON(w, map[string]interface{}{
 			"id": 1, "team_id": 0,
 			"smtp_enabled": true,
 		})
 	})
 	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		body, ok := notificationcommon.DecodeJSONBody(w, r)
+		if !ok {
 			return
 		}
 		store.mu.Lock()
-		if v, ok := body["smtp_enabled"].(bool); ok {
-			store.SMTPEnabled = v
-		}
-		if v, ok := body["smtp_host"].(string); ok {
-			store.SMTPHost = v
-		}
+		notificationcommon.BoolFromBody(body, "smtp_enabled", &store.SMTPEnabled)
+		notificationcommon.StringFromBody(body, "smtp_host", &store.SMTPHost)
 		store.mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		notificationcommon.WriteJSON(w, map[string]interface{}{
 			"id": 1, "team_id": 0, "smtp_enabled": true,
 		})
 	})
@@ -339,6 +331,51 @@ func TestEmailNotificationResource_ReadAPIError(t *testing.T) {
   smtp_host    = "smtp.example.com"
 `),
 				ExpectError: regexp.MustCompile(`Error reading email notifications`),
+			},
+		},
+	})
+}
+
+func TestEmailNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating email notifications`),
 			},
 		},
 	})

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -380,3 +380,43 @@ func TestEmailNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestEmailNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling email notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -285,3 +285,42 @@ func TestPushoverNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestPushoverNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u1","pushover_api_token":"t1"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u1","pushover_api_token":"t1"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled   = true
+  user_key  = "u1"
+  api_token = "t1"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling Pushover notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationpushover/resource_test.go
+++ b/internal/service/notificationpushover/resource_test.go
@@ -242,3 +242,46 @@ func TestPushoverNotificationResource_ReadAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestPushoverNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u1","pushover_api_token":"t1"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/pushover", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"pushover_enabled":true,"pushover_user_key":"u1","pushover_api_token":"t1"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled  = true
+  user_key = "u1"
+  api_token = "t1"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_pushover", "test", `
+  enabled  = true
+  user_key = "u1"
+  api_token = "t1"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating Pushover notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -237,3 +237,44 @@ func TestSlackNotificationResource_ReadAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestSlackNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://hooks.slack.com/services/T/B/x"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://hooks.slack.com/services/T/B/x"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://hooks.slack.com/services/T/B/x"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://hooks.slack.com/services/T/B/x"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating Slack notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationslack/resource_test.go
+++ b/internal/service/notificationslack/resource_test.go
@@ -278,3 +278,41 @@ func TestSlackNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestSlackNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://hooks.slack.com/services/T/B/x"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/slack", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"slack_enabled":true,"slack_webhook_url":"https://hooks.slack.com/services/T/B/x"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_slack", "test", `
+  enabled     = true
+  webhook_url = "https://hooks.slack.com/services/T/B/x"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling Slack notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -298,3 +298,46 @@ func TestTelegramNotificationResource_ReadAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestTelegramNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"bot:token","telegram_chat_id":"123"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"bot:token","telegram_chat_id":"123"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled    = true
+  token      = "bot:token"
+  chat_id    = "123"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled    = true
+  token      = "bot:token"
+  chat_id    = "123"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating Telegram notifications`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -341,3 +341,42 @@ func TestTelegramNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestTelegramNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"bot:token","telegram_chat_id":"123"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/telegram", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"telegram_enabled":true,"telegram_token":"bot:token","telegram_chat_id":"123"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_telegram", "test", `
+  enabled = true
+  token   = "bot:token"
+  chat_id = "123"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling Telegram notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -278,3 +278,41 @@ func TestWebhookNotificationResource_UpdateAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestWebhookNotificationResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		// Create succeeds (patch 1); destroy disable fails (patch 2+).
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling Webhook notifications on destroy`),
+			},
+		},
+	})
+}

--- a/internal/service/notificationwebhook/resource_test.go
+++ b/internal/service/notificationwebhook/resource_test.go
@@ -237,3 +237,44 @@ func TestWebhookNotificationResource_ReadAPIError(t *testing.T) {
 		},
 	})
 }
+
+func TestWebhookNotificationResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/webhook", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"team_id":0,"webhook_enabled":true,"webhook_url":"https://example.com/hook"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_webhook", "test", `
+  enabled     = true
+  webhook_url = "https://example.com/hook"
+  deployment_failure = true
+`),
+				ExpectError: regexp.MustCompile(`Error updating Webhook notifications`),
+			},
+		},
+	})
+}

--- a/internal/validate/descriptions_test.go
+++ b/internal/validate/descriptions_test.go
@@ -1,0 +1,26 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatorDescriptions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	domains := validate.Domains()
+	assert.NotEmpty(t, domains.Description(ctx))
+	assert.Equal(t, domains.Description(ctx), domains.MarkdownDescription(ctx))
+
+	ports := validate.PortMappings()
+	assert.NotEmpty(t, ports.Description(ctx))
+	assert.Equal(t, ports.Description(ctx), ports.MarkdownDescription(ctx))
+
+	shell := validate.NoShellMetachars()
+	assert.NotEmpty(t, shell.Description(ctx))
+	assert.Equal(t, shell.Description(ctx), shell.MarkdownDescription(ctx))
+}

--- a/internal/validate/domains_test.go
+++ b/internal/validate/domains_test.go
@@ -19,6 +19,8 @@ func TestDomains_Valid(t *testing.T) {
 		"https://coolify.io/api",
 		"http://192.168.1.1:3000",
 		"https://a.example.com,https://b.example.com",
+		"https://a.example.com,,https://b.example.com", // empty segment skipped
+		"https://a.example.com,",                       // trailing comma
 	}
 	v := validate.Domains()
 	for _, s := range valid {


### PR DESCRIPTION
## Summary

MPI cycle after #718: strengthen notification channel unit tests and
documentation accuracy.

## Changes

- **UpdateAPIError** and **DestroyAPIError** for all six notification
  channels (422 on the second PATCH only so post-test destroy succeeds)
- Validator `Description` / `MarkdownDescription` coverage; Domains
  empty-segment cases (100% validate package)
- Email preserve-secrets mock uses `notificationcommon` JSON helpers
- Documented test floor **1280+**

## Related

- Tech-debt for production event create/update/flatten DRY: #720
- Coolify 4.3.3 channel (#719): tip API 0-drift; pin wait for tag/stable

## Test plan

- [x] `go test ./internal/service/notification... ./internal/validate/`
- [x] `make counts-check`
- [ ] CI green