### PR TITLE
refactor: share notification event create/update/flatten helpers

### DIFF
--- a/internal/client/notifications_events.go
+++ b/internal/client/notifications_events.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// NotificationEvents is the 14 shared Coolify notification event flags
+// (channel-agnostic). Field names must match the exported event fields on
+// every *NotificationSettings and Update*NotificationInput struct.
+type NotificationEvents struct {
+	DeploymentSuccess    bool
+	DeploymentFailure    bool
+	StatusChange         bool
+	BackupSuccess        bool
+	BackupFailure        bool
+	ScheduledTaskSuccess bool
+	ScheduledTaskFailure bool
+	DockerCleanupSuccess bool
+	DockerCleanupFailure bool
+	ServerDiskUsage      bool
+	ServerReachable      bool
+	ServerUnreachable    bool
+	ServerPatch          bool
+	TraefikOutdated      bool
+}
+
+// NotificationEventUpdate is the PATCH form of NotificationEvents (nil = omit).
+type NotificationEventUpdate struct {
+	DeploymentSuccess    *bool
+	DeploymentFailure    *bool
+	StatusChange         *bool
+	BackupSuccess        *bool
+	BackupFailure        *bool
+	ScheduledTaskSuccess *bool
+	ScheduledTaskFailure *bool
+	DockerCleanupSuccess *bool
+	DockerCleanupFailure *bool
+	ServerDiskUsage      *bool
+	ServerReachable      *bool
+	ServerUnreachable    *bool
+	ServerPatch          *bool
+	TraefikOutdated      *bool
+}
+
+// ApplyEventUpdate copies shared event pointers onto a channel Update* input.
+// dst must be a pointer to UpdateDiscordNotificationInput or the other five
+// channel update types. Extra destination fields are left unchanged.
+func ApplyEventUpdate(dst any, ev NotificationEventUpdate) error {
+	return copyFieldsByName(dst, ev, false)
+}
+
+// EventsFrom copies shared event bools from a channel *NotificationSettings.
+func EventsFrom(src any) (NotificationEvents, error) {
+	var out NotificationEvents
+	if err := copyFieldsByName(&out, src, true); err != nil {
+		return NotificationEvents{}, err
+	}
+	return out, nil
+}
+
+// copyFieldsByName copies exported fields from src onto dst by name.
+// When requireSrc is true, every exported dst field must exist on src.
+func copyFieldsByName(dst, src any, requireSrc bool) error {
+	d, err := structElem(dst)
+	if err != nil {
+		return fmt.Errorf("dst: %w", err)
+	}
+	s, err := structElem(src)
+	if err != nil {
+		return fmt.Errorf("src: %w", err)
+	}
+	if requireSrc {
+		return copyDestFields(d, s)
+	}
+	return copySrcFields(d, s)
+}
+
+func copyDestFields(d, s reflect.Value) error {
+	dt := d.Type()
+	for i := 0; i < dt.NumField(); i++ {
+		df := dt.Field(i)
+		if !df.IsExported() {
+			continue
+		}
+		sf := s.FieldByName(df.Name)
+		if err := assignField(d.Field(i), sf, df.Name, s.Type()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copySrcFields(d, s reflect.Value) error {
+	st := s.Type()
+	for i := 0; i < st.NumField(); i++ {
+		sf := st.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		df := d.FieldByName(sf.Name)
+		if err := assignField(df, s.Field(i), sf.Name, d.Type()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func assignField(dst, src reflect.Value, name string, missingOn reflect.Type) error {
+	if !src.IsValid() || !dst.IsValid() || !dst.CanSet() {
+		return fmt.Errorf("%s missing field %s", missingOn, name)
+	}
+	if !src.Type().AssignableTo(dst.Type()) {
+		return fmt.Errorf("field %s: cannot assign %s to %s", name, src.Type(), dst.Type())
+	}
+	dst.Set(src)
+	return nil
+}
+
+func structElem(v any) (reflect.Value, error) {
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return reflect.Value{}, fmt.Errorf("nil value")
+	}
+	if k := rv.Kind(); k == reflect.Pointer {
+		if rv.IsNil() {
+			return reflect.Value{}, fmt.Errorf("nil pointer")
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return reflect.Value{}, fmt.Errorf("want struct, got %s", rv.Kind())
+	}
+	return rv, nil
+}

--- a/internal/client/notifications_events_test.go
+++ b/internal/client/notifications_events_test.go
@@ -1,0 +1,124 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyEventUpdate_AllChannels(t *testing.T) {
+	t.Parallel()
+	yes := true
+	ev := client.NotificationEventUpdate{
+		DeploymentFailure: &yes,
+		ServerDiskUsage:   &yes,
+	}
+
+	t.Run("discord", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdateDiscordNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.DeploymentFailure)
+		assert.True(t, *in.DeploymentFailure)
+		require.NotNil(t, in.ServerDiskUsage)
+		assert.True(t, *in.ServerDiskUsage)
+		assert.Nil(t, in.DeploymentSuccess)
+		assert.Nil(t, in.Enabled) // channel-specific left alone
+	})
+	t.Run("slack", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdateSlackNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.DeploymentFailure)
+		assert.True(t, *in.DeploymentFailure)
+	})
+	t.Run("webhook", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdateWebhookNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.ServerDiskUsage)
+		assert.True(t, *in.ServerDiskUsage)
+	})
+	t.Run("pushover", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdatePushoverNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.DeploymentFailure)
+		assert.True(t, *in.DeploymentFailure)
+	})
+	t.Run("email", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdateEmailNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.DeploymentFailure)
+		assert.True(t, *in.DeploymentFailure)
+	})
+	t.Run("telegram", func(t *testing.T) {
+		t.Parallel()
+		var in client.UpdateTelegramNotificationInput
+		require.NoError(t, client.ApplyEventUpdate(&in, ev))
+		require.NotNil(t, in.DeploymentFailure)
+		assert.True(t, *in.DeploymentFailure)
+	})
+}
+
+func TestEventsFrom_AllChannels(t *testing.T) {
+	t.Parallel()
+	t.Run("discord", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.DiscordNotificationSettings{
+			Enabled:           true,
+			DeploymentFailure: true,
+			ServerDiskUsage:   true,
+		})
+		require.NoError(t, err)
+		assert.True(t, got.DeploymentFailure)
+		assert.True(t, got.ServerDiskUsage)
+		assert.False(t, got.DeploymentSuccess)
+	})
+	t.Run("slack", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.SlackNotificationSettings{BackupFailure: true})
+		require.NoError(t, err)
+		assert.True(t, got.BackupFailure)
+	})
+	t.Run("webhook", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.WebhookNotificationSettings{StatusChange: true})
+		require.NoError(t, err)
+		assert.True(t, got.StatusChange)
+	})
+	t.Run("pushover", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.PushoverNotificationSettings{TraefikOutdated: true})
+		require.NoError(t, err)
+		assert.True(t, got.TraefikOutdated)
+	})
+	t.Run("email", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.EmailNotificationSettings{ServerPatch: true})
+		require.NoError(t, err)
+		assert.True(t, got.ServerPatch)
+	})
+	t.Run("telegram", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.EventsFrom(&client.TelegramNotificationSettings{DockerCleanupFailure: true})
+		require.NoError(t, err)
+		assert.True(t, got.DockerCleanupFailure)
+	})
+}
+
+func TestApplyEventUpdate_RejectsUnknownDest(t *testing.T) {
+	t.Parallel()
+	var notAChannel struct{ Name string }
+	err := client.ApplyEventUpdate(&notAChannel, client.NotificationEventUpdate{})
+	require.Error(t, err)
+}
+
+func TestEventsFrom_Nil(t *testing.T) {
+	t.Parallel()
+	_, err := client.EventsFrom((*client.DiscordNotificationSettings)(nil))
+	require.Error(t, err)
+}

--- a/internal/service/notificationcommon/event_model.go
+++ b/internal/service/notificationcommon/event_model.go
@@ -1,0 +1,84 @@
+package notificationcommon
+
+import (
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// EventModel is the 14 shared event bools. Embed it in channel resource models
+// so tfsdk names stay promoted (deployment_success, …).
+type EventModel struct {
+	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
+	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
+	StatusChange         types.Bool `tfsdk:"status_change"`
+	BackupSuccess        types.Bool `tfsdk:"backup_success"`
+	BackupFailure        types.Bool `tfsdk:"backup_failure"`
+	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
+	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
+	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
+	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
+	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
+	ServerReachable      types.Bool `tfsdk:"server_reachable"`
+	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
+	ServerPatch          types.Bool `tfsdk:"server_patch"`
+	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+}
+
+// CreateUpdate returns PATCH event pointers for every known plan value.
+func (e EventModel) CreateUpdate() client.NotificationEventUpdate {
+	return client.NotificationEventUpdate{
+		DeploymentSuccess:    flex.BoolValueOrNull(e.DeploymentSuccess),
+		DeploymentFailure:    flex.BoolValueOrNull(e.DeploymentFailure),
+		StatusChange:         flex.BoolValueOrNull(e.StatusChange),
+		BackupSuccess:        flex.BoolValueOrNull(e.BackupSuccess),
+		BackupFailure:        flex.BoolValueOrNull(e.BackupFailure),
+		ScheduledTaskSuccess: flex.BoolValueOrNull(e.ScheduledTaskSuccess),
+		ScheduledTaskFailure: flex.BoolValueOrNull(e.ScheduledTaskFailure),
+		DockerCleanupSuccess: flex.BoolValueOrNull(e.DockerCleanupSuccess),
+		DockerCleanupFailure: flex.BoolValueOrNull(e.DockerCleanupFailure),
+		ServerDiskUsage:      flex.BoolValueOrNull(e.ServerDiskUsage),
+		ServerReachable:      flex.BoolValueOrNull(e.ServerReachable),
+		ServerUnreachable:    flex.BoolValueOrNull(e.ServerUnreachable),
+		ServerPatch:          flex.BoolValueOrNull(e.ServerPatch),
+		TraefikOutdated:      flex.BoolValueOrNull(e.TraefikOutdated),
+	}
+}
+
+// DiffUpdate returns PATCH event pointers only for values that changed.
+func (e EventModel) DiffUpdate(state EventModel) client.NotificationEventUpdate {
+	return client.NotificationEventUpdate{
+		DeploymentSuccess:    flex.BoolIfChanged(e.DeploymentSuccess, state.DeploymentSuccess),
+		DeploymentFailure:    flex.BoolIfChanged(e.DeploymentFailure, state.DeploymentFailure),
+		StatusChange:         flex.BoolIfChanged(e.StatusChange, state.StatusChange),
+		BackupSuccess:        flex.BoolIfChanged(e.BackupSuccess, state.BackupSuccess),
+		BackupFailure:        flex.BoolIfChanged(e.BackupFailure, state.BackupFailure),
+		ScheduledTaskSuccess: flex.BoolIfChanged(e.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
+		ScheduledTaskFailure: flex.BoolIfChanged(e.ScheduledTaskFailure, state.ScheduledTaskFailure),
+		DockerCleanupSuccess: flex.BoolIfChanged(e.DockerCleanupSuccess, state.DockerCleanupSuccess),
+		DockerCleanupFailure: flex.BoolIfChanged(e.DockerCleanupFailure, state.DockerCleanupFailure),
+		ServerDiskUsage:      flex.BoolIfChanged(e.ServerDiskUsage, state.ServerDiskUsage),
+		ServerReachable:      flex.BoolIfChanged(e.ServerReachable, state.ServerReachable),
+		ServerUnreachable:    flex.BoolIfChanged(e.ServerUnreachable, state.ServerUnreachable),
+		ServerPatch:          flex.BoolIfChanged(e.ServerPatch, state.ServerPatch),
+		TraefikOutdated:      flex.BoolIfChanged(e.TraefikOutdated, state.TraefikOutdated),
+	}
+}
+
+// FlattenEvents writes API event bools into the model.
+func (e *EventModel) FlattenEvents(src client.NotificationEvents) {
+	e.DeploymentSuccess = types.BoolValue(src.DeploymentSuccess)
+	e.DeploymentFailure = types.BoolValue(src.DeploymentFailure)
+	e.StatusChange = types.BoolValue(src.StatusChange)
+	e.BackupSuccess = types.BoolValue(src.BackupSuccess)
+	e.BackupFailure = types.BoolValue(src.BackupFailure)
+	e.ScheduledTaskSuccess = types.BoolValue(src.ScheduledTaskSuccess)
+	e.ScheduledTaskFailure = types.BoolValue(src.ScheduledTaskFailure)
+	e.DockerCleanupSuccess = types.BoolValue(src.DockerCleanupSuccess)
+	e.DockerCleanupFailure = types.BoolValue(src.DockerCleanupFailure)
+	e.ServerDiskUsage = types.BoolValue(src.ServerDiskUsage)
+	e.ServerReachable = types.BoolValue(src.ServerReachable)
+	e.ServerUnreachable = types.BoolValue(src.ServerUnreachable)
+	e.ServerPatch = types.BoolValue(src.ServerPatch)
+	e.TraefikOutdated = types.BoolValue(src.TraefikOutdated)
+}

--- a/internal/service/notificationcommon/event_model_test.go
+++ b/internal/service/notificationcommon/event_model_test.go
@@ -1,0 +1,71 @@
+package notificationcommon_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventModel_AlignsWithEventAttributeNames(t *testing.T) {
+	t.Parallel()
+	names := notificationcommon.EventAttributeNames()
+	require.Len(t, names, 14)
+
+	typ := reflect.TypeOf(notificationcommon.EventModel{})
+	require.Equal(t, len(names), typ.NumField())
+	for i, name := range names {
+		tag := typ.Field(i).Tag.Get("tfsdk")
+		assert.Equal(t, name, tag, "EventModel field %d tfsdk", i)
+	}
+}
+
+func TestEventModel_CreateUpdateAndFlatten(t *testing.T) {
+	t.Parallel()
+	plan := notificationcommon.EventModel{
+		DeploymentFailure: types.BoolValue(true),
+		ServerDiskUsage:   types.BoolValue(false),
+	}
+	ev := plan.CreateUpdate()
+	require.NotNil(t, ev.DeploymentFailure)
+	assert.True(t, *ev.DeploymentFailure)
+	require.NotNil(t, ev.ServerDiskUsage)
+	assert.False(t, *ev.ServerDiskUsage)
+	assert.Nil(t, ev.DeploymentSuccess)
+
+	var in client.UpdateDiscordNotificationInput
+	require.NoError(t, client.ApplyEventUpdate(&in, ev))
+	require.NotNil(t, in.DeploymentFailure)
+	assert.True(t, *in.DeploymentFailure)
+
+	src, err := client.EventsFrom(&client.DiscordNotificationSettings{
+		DeploymentFailure: true,
+		BackupFailure:     true,
+	})
+	require.NoError(t, err)
+	var got notificationcommon.EventModel
+	got.FlattenEvents(src)
+	assert.True(t, got.DeploymentFailure.ValueBool())
+	assert.True(t, got.BackupFailure.ValueBool())
+	assert.False(t, got.DeploymentSuccess.ValueBool())
+}
+
+func TestEventModel_DiffUpdate(t *testing.T) {
+	t.Parallel()
+	plan := notificationcommon.EventModel{
+		DeploymentFailure: types.BoolValue(true),
+		BackupFailure:     types.BoolValue(false),
+	}
+	state := notificationcommon.EventModel{
+		DeploymentFailure: types.BoolValue(true),
+		BackupFailure:     types.BoolValue(true),
+	}
+	ev := plan.DiffUpdate(state)
+	assert.Nil(t, ev.DeploymentFailure)
+	require.NotNil(t, ev.BackupFailure)
+	assert.False(t, *ev.BackupFailure)
+}

--- a/internal/service/notificationdiscord/resource.go
+++ b/internal/service/notificationdiscord/resource.go
@@ -31,20 +31,7 @@ type model struct {
 	WebhookURL  types.String `tfsdk:"webhook_url"`
 	PingEnabled types.Bool   `tfsdk:"ping_enabled"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 }
 
 // NewResource returns a new Discord notification resource.
@@ -175,23 +162,10 @@ func (r *discordResource) ImportState(ctx context.Context, req resource.ImportSt
 
 func createInputFromPlan(plan model) client.UpdateDiscordNotificationInput {
 	in := client.UpdateDiscordNotificationInput{
-		Enabled:              flex.BoolValueOrNull(plan.Enabled),
-		PingEnabled:          flex.BoolValueOrNull(plan.PingEnabled),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		Enabled:     flex.BoolValueOrNull(plan.Enabled),
+		PingEnabled: flex.BoolValueOrNull(plan.PingEnabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	if flex.StringValueConfigured(plan.WebhookURL) {
 		v := plan.WebhookURL.ValueString()
 		in.Webhook = &v
@@ -201,23 +175,10 @@ func createInputFromPlan(plan model) client.UpdateDiscordNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdateDiscordNotificationInput {
 	in := client.UpdateDiscordNotificationInput{
-		Enabled:              flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		PingEnabled:          flex.BoolIfChanged(plan.PingEnabled, state.PingEnabled),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		Enabled:     flex.BoolIfChanged(plan.Enabled, state.Enabled),
+		PingEnabled: flex.BoolIfChanged(plan.PingEnabled, state.PingEnabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.WebhookURL, state.WebhookURL); w != nil {
 		in.Webhook = w
 	}
@@ -225,23 +186,12 @@ func updateInputFromPlan(plan, state model) client.UpdateDiscordNotificationInpu
 }
 
 func flatten(api *client.DiscordNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	m.PingEnabled = types.BoolValue(api.PingEnabled)
 	// Preserve webhook from state when API hides encrypted field.
 	flex.SetStringPreserveEmpty(&m.WebhookURL, api.Webhook)
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 }

--- a/internal/service/notificationemail/resource.go
+++ b/internal/service/notificationemail/resource.go
@@ -46,20 +46,7 @@ type model struct {
 	ResendAPIKey     types.String `tfsdk:"resend_api_key"`
 	UseInstanceEmail types.Bool   `tfsdk:"use_instance_email_settings"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 }
 
 func NewResource() resource.Resource {
@@ -239,24 +226,11 @@ func (r *emailResource) ImportState(ctx context.Context, req resource.ImportStat
 
 func createInputFromPlan(plan model) client.UpdateEmailNotificationInput {
 	in := client.UpdateEmailNotificationInput{
-		SMTPEnabled:          flex.BoolValueOrNull(plan.SMTPEnabled),
-		ResendEnabled:        flex.BoolValueOrNull(plan.ResendEnabled),
-		UseInstanceEmail:     flex.BoolValueOrNull(plan.UseInstanceEmail),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		SMTPEnabled:      flex.BoolValueOrNull(plan.SMTPEnabled),
+		ResendEnabled:    flex.BoolValueOrNull(plan.ResendEnabled),
+		UseInstanceEmail: flex.BoolValueOrNull(plan.UseInstanceEmail),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	setStr := func(v types.String, dst **string) {
 		if flex.StringValueConfigured(v) {
 			s := v.ValueString()
@@ -284,24 +258,11 @@ func createInputFromPlan(plan model) client.UpdateEmailNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdateEmailNotificationInput {
 	in := client.UpdateEmailNotificationInput{
-		SMTPEnabled:          flex.BoolIfChanged(plan.SMTPEnabled, state.SMTPEnabled),
-		ResendEnabled:        flex.BoolIfChanged(plan.ResendEnabled, state.ResendEnabled),
-		UseInstanceEmail:     flex.BoolIfChanged(plan.UseInstanceEmail, state.UseInstanceEmail),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		SMTPEnabled:      flex.BoolIfChanged(plan.SMTPEnabled, state.SMTPEnabled),
+		ResendEnabled:    flex.BoolIfChanged(plan.ResendEnabled, state.ResendEnabled),
+		UseInstanceEmail: flex.BoolIfChanged(plan.UseInstanceEmail, state.UseInstanceEmail),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.SMTPFromAddress, state.SMTPFromAddress); w != nil {
 		in.SMTPFromAddress = w
 	}
@@ -332,6 +293,9 @@ func updateInputFromPlan(plan, state model) client.UpdateEmailNotificationInput 
 }
 
 func flatten(api *client.EmailNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.SMTPEnabled = types.BoolValue(api.SMTPEnabled)
 	m.ResendEnabled = types.BoolValue(api.ResendEnabled)
@@ -357,18 +321,4 @@ func flatten(api *client.EmailNotificationSettings, m *model) {
 	} else if m.SMTPTimeout.IsNull() || m.SMTPTimeout.IsUnknown() {
 		m.SMTPTimeout = types.Int64Null()
 	}
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 }

--- a/internal/service/notificationpushover/resource.go
+++ b/internal/service/notificationpushover/resource.go
@@ -30,20 +30,7 @@ type model struct {
 	UserKey  types.String `tfsdk:"user_key"`
 	APIToken types.String `tfsdk:"api_token"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 }
 
 // NewResource returns a new Pushover notification resource.
@@ -180,22 +167,9 @@ func (r *pushoverResource) ImportState(ctx context.Context, req resource.ImportS
 
 func createInputFromPlan(plan model) client.UpdatePushoverNotificationInput {
 	in := client.UpdatePushoverNotificationInput{
-		Enabled:              flex.BoolValueOrNull(plan.Enabled),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		Enabled: flex.BoolValueOrNull(plan.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	if flex.StringValueConfigured(plan.UserKey) {
 		v := plan.UserKey.ValueString()
 		in.UserKey = &v
@@ -209,22 +183,9 @@ func createInputFromPlan(plan model) client.UpdatePushoverNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdatePushoverNotificationInput {
 	in := client.UpdatePushoverNotificationInput{
-		Enabled:              flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		Enabled: flex.BoolIfChanged(plan.Enabled, state.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.UserKey, state.UserKey); w != nil {
 		in.UserKey = w
 	}
@@ -235,22 +196,11 @@ func updateInputFromPlan(plan, state model) client.UpdatePushoverNotificationInp
 }
 
 func flatten(api *client.PushoverNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.UserKey, api.UserKey)
 	flex.SetStringPreserveEmpty(&m.APIToken, api.APIToken)
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 }

--- a/internal/service/notificationslack/resource.go
+++ b/internal/service/notificationslack/resource.go
@@ -29,20 +29,7 @@ type model struct {
 	Enabled    types.Bool   `tfsdk:"enabled"`
 	WebhookURL types.String `tfsdk:"webhook_url"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 }
 
 // NewResource returns a new Slack notification resource.
@@ -170,22 +157,9 @@ func (r *slackResource) ImportState(ctx context.Context, req resource.ImportStat
 
 func createInputFromPlan(plan model) client.UpdateSlackNotificationInput {
 	in := client.UpdateSlackNotificationInput{
-		Enabled:              flex.BoolValueOrNull(plan.Enabled),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		Enabled: flex.BoolValueOrNull(plan.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	if flex.StringValueConfigured(plan.WebhookURL) {
 		v := plan.WebhookURL.ValueString()
 		in.Webhook = &v
@@ -195,22 +169,9 @@ func createInputFromPlan(plan model) client.UpdateSlackNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdateSlackNotificationInput {
 	in := client.UpdateSlackNotificationInput{
-		Enabled:              flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		Enabled: flex.BoolIfChanged(plan.Enabled, state.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.WebhookURL, state.WebhookURL); w != nil {
 		in.Webhook = w
 	}
@@ -218,21 +179,10 @@ func updateInputFromPlan(plan, state model) client.UpdateSlackNotificationInput 
 }
 
 func flatten(api *client.SlackNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.WebhookURL, api.Webhook)
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 }

--- a/internal/service/notificationtelegram/resource.go
+++ b/internal/service/notificationtelegram/resource.go
@@ -30,20 +30,7 @@ type model struct {
 	Token   types.String `tfsdk:"token"`
 	ChatID  types.String `tfsdk:"chat_id"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 
 	ThreadDeploymentSuccess    types.String `tfsdk:"thread_deployment_success"`
 	ThreadDeploymentFailure    types.String `tfsdk:"thread_deployment_failure"`
@@ -192,22 +179,9 @@ func (r *telegramResource) ImportState(ctx context.Context, req resource.ImportS
 
 func createInputFromPlan(plan model) client.UpdateTelegramNotificationInput {
 	in := client.UpdateTelegramNotificationInput{
-		Enabled:              flex.BoolValueOrNull(plan.Enabled),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		Enabled: flex.BoolValueOrNull(plan.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	if flex.StringValueConfigured(plan.Token) {
 		s := plan.Token.ValueString()
 		in.Token = &s
@@ -277,22 +251,9 @@ func createInputFromPlan(plan model) client.UpdateTelegramNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdateTelegramNotificationInput {
 	in := client.UpdateTelegramNotificationInput{
-		Enabled:              flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		Enabled: flex.BoolIfChanged(plan.Enabled, state.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.Token, state.Token); w != nil {
 		in.Token = w
 	}
@@ -345,24 +306,13 @@ func updateInputFromPlan(plan, state model) client.UpdateTelegramNotificationInp
 }
 
 func flatten(api *client.TelegramNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.Token, api.Token)
 	flex.SetStringPreserveEmpty(&m.ChatID, api.ChatID)
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 	flex.SetStringPreserveEmpty(&m.ThreadDeploymentSuccess, api.ThreadDeploymentSuccess)
 	flex.SetStringPreserveEmpty(&m.ThreadDeploymentFailure, api.ThreadDeploymentFailure)
 	flex.SetStringPreserveEmpty(&m.ThreadStatusChange, api.ThreadStatusChange)

--- a/internal/service/notificationwebhook/resource.go
+++ b/internal/service/notificationwebhook/resource.go
@@ -29,20 +29,7 @@ type model struct {
 	Enabled    types.Bool   `tfsdk:"enabled"`
 	WebhookURL types.String `tfsdk:"webhook_url"`
 
-	DeploymentSuccess    types.Bool `tfsdk:"deployment_success"`
-	DeploymentFailure    types.Bool `tfsdk:"deployment_failure"`
-	StatusChange         types.Bool `tfsdk:"status_change"`
-	BackupSuccess        types.Bool `tfsdk:"backup_success"`
-	BackupFailure        types.Bool `tfsdk:"backup_failure"`
-	ScheduledTaskSuccess types.Bool `tfsdk:"scheduled_task_success"`
-	ScheduledTaskFailure types.Bool `tfsdk:"scheduled_task_failure"`
-	DockerCleanupSuccess types.Bool `tfsdk:"docker_cleanup_success"`
-	DockerCleanupFailure types.Bool `tfsdk:"docker_cleanup_failure"`
-	ServerDiskUsage      types.Bool `tfsdk:"server_disk_usage"`
-	ServerReachable      types.Bool `tfsdk:"server_reachable"`
-	ServerUnreachable    types.Bool `tfsdk:"server_unreachable"`
-	ServerPatch          types.Bool `tfsdk:"server_patch"`
-	TraefikOutdated      types.Bool `tfsdk:"traefik_outdated"`
+	notificationcommon.EventModel
 }
 
 // NewResource returns a new Webhook notification resource.
@@ -170,22 +157,9 @@ func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportSt
 
 func createInputFromPlan(plan model) client.UpdateWebhookNotificationInput {
 	in := client.UpdateWebhookNotificationInput{
-		Enabled:              flex.BoolValueOrNull(plan.Enabled),
-		DeploymentSuccess:    flex.BoolValueOrNull(plan.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolValueOrNull(plan.DeploymentFailure),
-		StatusChange:         flex.BoolValueOrNull(plan.StatusChange),
-		BackupSuccess:        flex.BoolValueOrNull(plan.BackupSuccess),
-		BackupFailure:        flex.BoolValueOrNull(plan.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolValueOrNull(plan.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolValueOrNull(plan.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolValueOrNull(plan.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolValueOrNull(plan.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolValueOrNull(plan.ServerDiskUsage),
-		ServerReachable:      flex.BoolValueOrNull(plan.ServerReachable),
-		ServerUnreachable:    flex.BoolValueOrNull(plan.ServerUnreachable),
-		ServerPatch:          flex.BoolValueOrNull(plan.ServerPatch),
-		TraefikOutdated:      flex.BoolValueOrNull(plan.TraefikOutdated),
+		Enabled: flex.BoolValueOrNull(plan.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.CreateUpdate())
 	if flex.StringValueConfigured(plan.WebhookURL) {
 		v := plan.WebhookURL.ValueString()
 		in.Webhook = &v
@@ -195,22 +169,9 @@ func createInputFromPlan(plan model) client.UpdateWebhookNotificationInput {
 
 func updateInputFromPlan(plan, state model) client.UpdateWebhookNotificationInput {
 	in := client.UpdateWebhookNotificationInput{
-		Enabled:              flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		DeploymentSuccess:    flex.BoolIfChanged(plan.DeploymentSuccess, state.DeploymentSuccess),
-		DeploymentFailure:    flex.BoolIfChanged(plan.DeploymentFailure, state.DeploymentFailure),
-		StatusChange:         flex.BoolIfChanged(plan.StatusChange, state.StatusChange),
-		BackupSuccess:        flex.BoolIfChanged(plan.BackupSuccess, state.BackupSuccess),
-		BackupFailure:        flex.BoolIfChanged(plan.BackupFailure, state.BackupFailure),
-		ScheduledTaskSuccess: flex.BoolIfChanged(plan.ScheduledTaskSuccess, state.ScheduledTaskSuccess),
-		ScheduledTaskFailure: flex.BoolIfChanged(plan.ScheduledTaskFailure, state.ScheduledTaskFailure),
-		DockerCleanupSuccess: flex.BoolIfChanged(plan.DockerCleanupSuccess, state.DockerCleanupSuccess),
-		DockerCleanupFailure: flex.BoolIfChanged(plan.DockerCleanupFailure, state.DockerCleanupFailure),
-		ServerDiskUsage:      flex.BoolIfChanged(plan.ServerDiskUsage, state.ServerDiskUsage),
-		ServerReachable:      flex.BoolIfChanged(plan.ServerReachable, state.ServerReachable),
-		ServerUnreachable:    flex.BoolIfChanged(plan.ServerUnreachable, state.ServerUnreachable),
-		ServerPatch:          flex.BoolIfChanged(plan.ServerPatch, state.ServerPatch),
-		TraefikOutdated:      flex.BoolIfChanged(plan.TraefikOutdated, state.TraefikOutdated),
+		Enabled: flex.BoolIfChanged(plan.Enabled, state.Enabled),
 	}
+	_ = client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel))
 	if w := flex.StringIfChanged(plan.WebhookURL, state.WebhookURL); w != nil {
 		in.Webhook = w
 	}
@@ -218,21 +179,10 @@ func updateInputFromPlan(plan, state model) client.UpdateWebhookNotificationInpu
 }
 
 func flatten(api *client.WebhookNotificationSettings, m *model) {
+	if ev, err := client.EventsFrom(api); err == nil {
+		m.FlattenEvents(ev)
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.WebhookURL, api.Webhook)
-	m.DeploymentSuccess = types.BoolValue(api.DeploymentSuccess)
-	m.DeploymentFailure = types.BoolValue(api.DeploymentFailure)
-	m.StatusChange = types.BoolValue(api.StatusChange)
-	m.BackupSuccess = types.BoolValue(api.BackupSuccess)
-	m.BackupFailure = types.BoolValue(api.BackupFailure)
-	m.ScheduledTaskSuccess = types.BoolValue(api.ScheduledTaskSuccess)
-	m.ScheduledTaskFailure = types.BoolValue(api.ScheduledTaskFailure)
-	m.DockerCleanupSuccess = types.BoolValue(api.DockerCleanupSuccess)
-	m.DockerCleanupFailure = types.BoolValue(api.DockerCleanupFailure)
-	m.ServerDiskUsage = types.BoolValue(api.ServerDiskUsage)
-	m.ServerReachable = types.BoolValue(api.ServerReachable)
-	m.ServerUnreachable = types.BoolValue(api.ServerUnreachable)
-	m.ServerPatch = types.BoolValue(api.ServerPatch)
-	m.TraefikOutdated = types.BoolValue(api.TraefikOutdated)
 }


### PR DESCRIPTION
## Summary

Share production create/update/flatten mapping for the 14 Coolify
notification event flags so a new event does not require six parallel
`resource.go` edits.

## Changes

- `notificationcommon.EventModel` embedded in all six channel models
  (`CreateUpdate`, `DiffUpdate`, `FlattenEvents`)
- `client.NotificationEventUpdate` / `NotificationEvents` with
  `ApplyEventUpdate` and `EventsFrom` (name-matched field copy)
- Channel resources keep webhook/SMTP/thread fields local

## Test plan

- [x] `go test ./internal/client/ ./internal/service/notification...`
- [x] `golangci-lint run` on those packages
- [ ] CI green

Closes #720