### PR TITLE
refactor: share Telegram notification thread-id helpers

### DIFF
--- a/internal/client/notifications_threads.go
+++ b/internal/client/notifications_threads.go
@@ -1,0 +1,55 @@
+package client
+
+// NotificationThreads is the 14 Telegram forum thread IDs (channel-specific).
+// Field names must match the Thread* fields on TelegramNotificationSettings
+// and UpdateTelegramNotificationInput.
+type NotificationThreads struct {
+	ThreadDeploymentSuccess    string
+	ThreadDeploymentFailure    string
+	ThreadStatusChange         string
+	ThreadBackupSuccess        string
+	ThreadBackupFailure        string
+	ThreadScheduledTaskSuccess string
+	ThreadScheduledTaskFailure string
+	ThreadDockerCleanupSuccess string
+	ThreadDockerCleanupFailure string
+	ThreadServerDiskUsage      string
+	ThreadServerReachable      string
+	ThreadServerUnreachable    string
+	ThreadServerPatch          string
+	ThreadTraefikOutdated      string
+}
+
+// NotificationThreadUpdate is the PATCH form of NotificationThreads (nil = omit).
+type NotificationThreadUpdate struct {
+	ThreadDeploymentSuccess    *string
+	ThreadDeploymentFailure    *string
+	ThreadStatusChange         *string
+	ThreadBackupSuccess        *string
+	ThreadBackupFailure        *string
+	ThreadScheduledTaskSuccess *string
+	ThreadScheduledTaskFailure *string
+	ThreadDockerCleanupSuccess *string
+	ThreadDockerCleanupFailure *string
+	ThreadServerDiskUsage      *string
+	ThreadServerReachable      *string
+	ThreadServerUnreachable    *string
+	ThreadServerPatch          *string
+	ThreadTraefikOutdated      *string
+}
+
+// ApplyThreadUpdate copies Telegram thread-id pointers onto an update input.
+// dst must be a pointer to UpdateTelegramNotificationInput. Extra destination
+// fields are left unchanged.
+func ApplyThreadUpdate(dst any, th NotificationThreadUpdate) error {
+	return copyFieldsByName(dst, th, false)
+}
+
+// ThreadsFrom copies Telegram thread IDs from TelegramNotificationSettings.
+func ThreadsFrom(src any) (NotificationThreads, error) {
+	var out NotificationThreads
+	if err := copyFieldsByName(&out, src, true); err != nil {
+		return NotificationThreads{}, err
+	}
+	return out, nil
+}

--- a/internal/client/notifications_threads_test.go
+++ b/internal/client/notifications_threads_test.go
@@ -1,0 +1,50 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyThreadUpdate_Telegram(t *testing.T) {
+	t.Parallel()
+	fail := "42"
+	th := client.NotificationThreadUpdate{
+		ThreadDeploymentFailure: &fail,
+	}
+	var in client.UpdateTelegramNotificationInput
+	require.NoError(t, client.ApplyThreadUpdate(&in, th))
+	require.NotNil(t, in.ThreadDeploymentFailure)
+	assert.Equal(t, "42", *in.ThreadDeploymentFailure)
+	assert.Nil(t, in.ThreadDeploymentSuccess)
+	assert.Nil(t, in.Token) // channel-specific left alone
+}
+
+func TestApplyThreadUpdate_RejectsUnknownDest(t *testing.T) {
+	t.Parallel()
+	var notTelegram struct{ Name string }
+	err := client.ApplyThreadUpdate(&notTelegram, client.NotificationThreadUpdate{})
+	require.Error(t, err)
+}
+
+func TestThreadsFrom_Telegram(t *testing.T) {
+	t.Parallel()
+	got, err := client.ThreadsFrom(&client.TelegramNotificationSettings{
+		Enabled:                 true,
+		Token:                   "secret",
+		ThreadDeploymentFailure: "99",
+		ThreadBackupFailure:     "7",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "99", got.ThreadDeploymentFailure)
+	assert.Equal(t, "7", got.ThreadBackupFailure)
+	assert.Empty(t, got.ThreadDeploymentSuccess)
+}
+
+func TestThreadsFrom_Nil(t *testing.T) {
+	t.Parallel()
+	_, err := client.ThreadsFrom((*client.TelegramNotificationSettings)(nil))
+	require.Error(t, err)
+}

--- a/internal/service/notificationcommon/common.go
+++ b/internal/service/notificationcommon/common.go
@@ -51,6 +51,30 @@ func EventAttributeNames() []string {
 	return out
 }
 
+// ThreadAttributeNames returns the 14 Telegram thread-id attribute names
+// (thread_ + EventAttributeNames) in the same order.
+func ThreadAttributeNames() []string {
+	out := make([]string, len(eventNames))
+	for i, e := range eventNames {
+		out[i] = "thread_" + e.attr
+	}
+	return out
+}
+
+// StringOptComputedSensitive is Optional+Computed+Sensitive with UseStateForUnknown
+// for Coolify fields that may be omitted on read without read:sensitive.
+func StringOptComputedSensitive(desc string) schema.StringAttribute {
+	return schema.StringAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		Computed:            true,
+		Sensitive:           true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
 // BoolOptComputed is Optional+Computed with UseStateForUnknown for API-defaulted bools.
 func BoolOptComputed(desc string) schema.BoolAttribute {
 	return schema.BoolAttribute{
@@ -70,6 +94,17 @@ func EventSchemaAttrs(channel string) map[string]schema.Attribute {
 	for _, e := range eventNames {
 		desc := fmt.Sprintf("Whether to send %s notifications for %s events.", channel, e.label)
 		attrs[e.attr] = BoolOptComputed(desc)
+	}
+	return attrs
+}
+
+// ThreadSchemaAttrs returns the 14 Telegram forum thread-id attributes.
+// channel is the display name used in Markdown descriptions (e.g. "Telegram").
+func ThreadSchemaAttrs(channel string) map[string]schema.Attribute {
+	attrs := make(map[string]schema.Attribute, len(eventNames))
+	for _, e := range eventNames {
+		desc := fmt.Sprintf("%s forum thread ID for %s events. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.", channel, e.attr)
+		attrs["thread_"+e.attr] = StringOptComputedSensitive(desc)
 	}
 	return attrs
 }

--- a/internal/service/notificationcommon/common_test.go
+++ b/internal/service/notificationcommon/common_test.go
@@ -47,6 +47,33 @@ func TestEventAttributeNames_CountAndOrder(t *testing.T) {
 	}
 }
 
+func TestThreadAttributeNames_PrefixAndOrder(t *testing.T) {
+	t.Parallel()
+	events := notificationcommon.EventAttributeNames()
+	threads := notificationcommon.ThreadAttributeNames()
+	require.Len(t, threads, len(events))
+	for i, ev := range events {
+		assert.Equal(t, "thread_"+ev, threads[i])
+	}
+}
+
+func TestThreadSchemaAttrs_HasAllThreadsAndChannelInDesc(t *testing.T) {
+	t.Parallel()
+	attrs := notificationcommon.ThreadSchemaAttrs("Telegram")
+	require.Len(t, attrs, 14)
+	for _, name := range notificationcommon.ThreadAttributeNames() {
+		a, ok := attrs[name]
+		require.True(t, ok, "missing attr %s", name)
+		sa, ok := a.(schema.StringAttribute)
+		require.True(t, ok, "%s should be StringAttribute", name)
+		assert.True(t, sa.Optional)
+		assert.True(t, sa.Computed)
+		assert.True(t, sa.Sensitive)
+		assert.Contains(t, sa.MarkdownDescription, "Telegram")
+		assert.NotEmpty(t, sa.PlanModifiers)
+	}
+}
+
 func TestEventSchemaAttrs_HasAllEventsAndChannelInDesc(t *testing.T) {
 	t.Parallel()
 	attrs := notificationcommon.EventSchemaAttrs("Discord")

--- a/internal/service/notificationcommon/data_source_schema.go
+++ b/internal/service/notificationcommon/data_source_schema.go
@@ -40,6 +40,20 @@ func EventDataSourceAttrs(channel string) map[string]schema.Attribute {
 	return attrs
 }
 
+// ThreadDataSourceAttrs returns the 14 Telegram forum thread IDs as computed attributes.
+func ThreadDataSourceAttrs() map[string]schema.Attribute {
+	attrs := make(map[string]schema.Attribute, len(eventNames))
+	for _, e := range eventNames {
+		desc := fmt.Sprintf("Forum thread ID for %s events. Coolify may omit this unless the API token can read sensitive fields (`read:sensitive` or root).", e.attr)
+		attrs["thread_"+e.attr] = schema.StringAttribute{
+			MarkdownDescription: desc,
+			Computed:            true,
+			Sensitive:           true,
+		}
+	}
+	return attrs
+}
+
 // MergeDSAttrs returns a new map with base attributes plus overlay (overlay wins).
 func MergeDSAttrs(base map[string]schema.Attribute, overlay map[string]schema.Attribute) map[string]schema.Attribute {
 	out := make(map[string]schema.Attribute, len(base)+len(overlay))

--- a/internal/service/notificationcommon/data_source_schema_test.go
+++ b/internal/service/notificationcommon/data_source_schema_test.go
@@ -19,6 +19,20 @@ func TestEventDataSourceAttrs_AllFourteen(t *testing.T) {
 	}
 }
 
+func TestThreadDataSourceAttrs_AllFourteen(t *testing.T) {
+	t.Parallel()
+	attrs := notificationcommon.ThreadDataSourceAttrs()
+	require.Len(t, attrs, 14)
+	for _, name := range notificationcommon.ThreadAttributeNames() {
+		a, ok := attrs[name]
+		require.True(t, ok, "missing %s", name)
+		sa, ok := a.(schema.StringAttribute)
+		require.True(t, ok, "%s should be StringAttribute", name)
+		assert.True(t, sa.Computed)
+		assert.True(t, sa.Sensitive)
+	}
+}
+
 func TestMergeDSAttrs(t *testing.T) {
 	t.Parallel()
 	base := notificationcommon.EventDataSourceAttrs("Slack")

--- a/internal/service/notificationcommon/mock_events.go
+++ b/internal/service/notificationcommon/mock_events.go
@@ -33,6 +33,12 @@ func EventJSONKey(channel, eventAttr string) string {
 	return eventAttr + "_" + channel + "_notifications"
 }
 
+// ThreadJSONKey returns the Coolify PATCH/GET JSON key for a Telegram thread id.
+// eventAttr is the schema event name (e.g. deployment_failure).
+func ThreadJSONKey(channel, eventAttr string) string {
+	return channel + "_notifications_" + eventAttr + "_thread_id"
+}
+
 // fieldPtrs maps EventAttributeNames entries to EventStore fields.
 // Keep attrs in the same order/names as eventNames in common.go.
 func (e *EventStore) fieldPtrs() []struct {
@@ -82,6 +88,30 @@ func EventAllowedFields(channel string) map[string]bool {
 	out := make(map[string]bool, len(eventNames))
 	for _, e := range eventNames {
 		out[EventJSONKey(channel, e.attr)] = true
+	}
+	return out
+}
+
+// ThreadAllowedFields returns a map with all 14 Telegram thread-id JSON keys.
+func ThreadAllowedFields(channel string) map[string]bool {
+	out := make(map[string]bool, len(eventNames))
+	for _, e := range eventNames {
+		out[ThreadJSONKey(channel, e.attr)] = true
+	}
+	return out
+}
+
+// MergeAllowedMaps returns a new map with every key from the inputs.
+func MergeAllowedMaps(maps ...map[string]bool) map[string]bool {
+	n := 0
+	for _, m := range maps {
+		n += len(m)
+	}
+	out := make(map[string]bool, n)
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
 	}
 	return out
 }

--- a/internal/service/notificationcommon/mock_events_test.go
+++ b/internal/service/notificationcommon/mock_events_test.go
@@ -102,6 +102,35 @@ func TestEventStore_AlignsWithEventAttributeNames(t *testing.T) {
 	}
 }
 
+func TestThreadJSONKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "telegram_notifications_deployment_failure_thread_id",
+		notificationcommon.ThreadJSONKey("telegram", "deployment_failure"))
+	assert.Equal(t, "telegram_notifications_traefik_outdated_thread_id",
+		notificationcommon.ThreadJSONKey("telegram", "traefik_outdated"))
+}
+
+func TestThreadAllowedFields_AllFourteen(t *testing.T) {
+	t.Parallel()
+	allowed := notificationcommon.ThreadAllowedFields("telegram")
+	require.Len(t, allowed, 14)
+	for _, name := range notificationcommon.EventAttributeNames() {
+		key := notificationcommon.ThreadJSONKey("telegram", name)
+		assert.True(t, allowed[key], "missing %s", key)
+	}
+}
+
+func TestMergeAllowedMaps(t *testing.T) {
+	t.Parallel()
+	merged := notificationcommon.MergeAllowedMaps(
+		notificationcommon.EventAllowedFields("telegram"),
+		notificationcommon.ThreadAllowedFields("telegram"),
+	)
+	require.Len(t, merged, 28)
+	assert.True(t, merged[notificationcommon.EventJSONKey("telegram", "backup_failure")])
+	assert.True(t, merged[notificationcommon.ThreadJSONKey("telegram", "backup_failure")])
+}
+
 func TestMergeAllowed(t *testing.T) {
 	t.Parallel()
 	base := notificationcommon.EventAllowedFields("slack")

--- a/internal/service/notificationcommon/thread_model.go
+++ b/internal/service/notificationcommon/thread_model.go
@@ -1,0 +1,87 @@
+package notificationcommon
+
+import (
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ThreadModel is the 14 Telegram forum thread-id strings. Embed it in the
+// Telegram resource model so tfsdk names stay promoted (thread_deployment_success, …).
+// Method names are Thread-prefixed so they do not collide with EventModel
+// when both are embedded.
+type ThreadModel struct {
+	ThreadDeploymentSuccess    types.String `tfsdk:"thread_deployment_success"`
+	ThreadDeploymentFailure    types.String `tfsdk:"thread_deployment_failure"`
+	ThreadStatusChange         types.String `tfsdk:"thread_status_change"`
+	ThreadBackupSuccess        types.String `tfsdk:"thread_backup_success"`
+	ThreadBackupFailure        types.String `tfsdk:"thread_backup_failure"`
+	ThreadScheduledTaskSuccess types.String `tfsdk:"thread_scheduled_task_success"`
+	ThreadScheduledTaskFailure types.String `tfsdk:"thread_scheduled_task_failure"`
+	ThreadDockerCleanupSuccess types.String `tfsdk:"thread_docker_cleanup_success"`
+	ThreadDockerCleanupFailure types.String `tfsdk:"thread_docker_cleanup_failure"`
+	ThreadServerDiskUsage      types.String `tfsdk:"thread_server_disk_usage"`
+	ThreadServerReachable      types.String `tfsdk:"thread_server_reachable"`
+	ThreadServerUnreachable    types.String `tfsdk:"thread_server_unreachable"`
+	ThreadServerPatch          types.String `tfsdk:"thread_server_patch"`
+	ThreadTraefikOutdated      types.String `tfsdk:"thread_traefik_outdated"`
+}
+
+// CreateThreadUpdate returns PATCH thread-id pointers for every known plan value.
+func (t ThreadModel) CreateThreadUpdate() client.NotificationThreadUpdate {
+	return client.NotificationThreadUpdate{
+		ThreadDeploymentSuccess:    flex.StringValueOrNull(t.ThreadDeploymentSuccess),
+		ThreadDeploymentFailure:    flex.StringValueOrNull(t.ThreadDeploymentFailure),
+		ThreadStatusChange:         flex.StringValueOrNull(t.ThreadStatusChange),
+		ThreadBackupSuccess:        flex.StringValueOrNull(t.ThreadBackupSuccess),
+		ThreadBackupFailure:        flex.StringValueOrNull(t.ThreadBackupFailure),
+		ThreadScheduledTaskSuccess: flex.StringValueOrNull(t.ThreadScheduledTaskSuccess),
+		ThreadScheduledTaskFailure: flex.StringValueOrNull(t.ThreadScheduledTaskFailure),
+		ThreadDockerCleanupSuccess: flex.StringValueOrNull(t.ThreadDockerCleanupSuccess),
+		ThreadDockerCleanupFailure: flex.StringValueOrNull(t.ThreadDockerCleanupFailure),
+		ThreadServerDiskUsage:      flex.StringValueOrNull(t.ThreadServerDiskUsage),
+		ThreadServerReachable:      flex.StringValueOrNull(t.ThreadServerReachable),
+		ThreadServerUnreachable:    flex.StringValueOrNull(t.ThreadServerUnreachable),
+		ThreadServerPatch:          flex.StringValueOrNull(t.ThreadServerPatch),
+		ThreadTraefikOutdated:      flex.StringValueOrNull(t.ThreadTraefikOutdated),
+	}
+}
+
+// DiffThreadUpdate returns PATCH thread-id pointers only for values that changed.
+func (t ThreadModel) DiffThreadUpdate(state ThreadModel) client.NotificationThreadUpdate {
+	return client.NotificationThreadUpdate{
+		ThreadDeploymentSuccess:    flex.StringIfChanged(t.ThreadDeploymentSuccess, state.ThreadDeploymentSuccess),
+		ThreadDeploymentFailure:    flex.StringIfChanged(t.ThreadDeploymentFailure, state.ThreadDeploymentFailure),
+		ThreadStatusChange:         flex.StringIfChanged(t.ThreadStatusChange, state.ThreadStatusChange),
+		ThreadBackupSuccess:        flex.StringIfChanged(t.ThreadBackupSuccess, state.ThreadBackupSuccess),
+		ThreadBackupFailure:        flex.StringIfChanged(t.ThreadBackupFailure, state.ThreadBackupFailure),
+		ThreadScheduledTaskSuccess: flex.StringIfChanged(t.ThreadScheduledTaskSuccess, state.ThreadScheduledTaskSuccess),
+		ThreadScheduledTaskFailure: flex.StringIfChanged(t.ThreadScheduledTaskFailure, state.ThreadScheduledTaskFailure),
+		ThreadDockerCleanupSuccess: flex.StringIfChanged(t.ThreadDockerCleanupSuccess, state.ThreadDockerCleanupSuccess),
+		ThreadDockerCleanupFailure: flex.StringIfChanged(t.ThreadDockerCleanupFailure, state.ThreadDockerCleanupFailure),
+		ThreadServerDiskUsage:      flex.StringIfChanged(t.ThreadServerDiskUsage, state.ThreadServerDiskUsage),
+		ThreadServerReachable:      flex.StringIfChanged(t.ThreadServerReachable, state.ThreadServerReachable),
+		ThreadServerUnreachable:    flex.StringIfChanged(t.ThreadServerUnreachable, state.ThreadServerUnreachable),
+		ThreadServerPatch:          flex.StringIfChanged(t.ThreadServerPatch, state.ThreadServerPatch),
+		ThreadTraefikOutdated:      flex.StringIfChanged(t.ThreadTraefikOutdated, state.ThreadTraefikOutdated),
+	}
+}
+
+// FlattenThreads writes API thread IDs into the model, preserving state when
+// Coolify hides empty sensitive values.
+func (t *ThreadModel) FlattenThreads(src client.NotificationThreads) {
+	flex.SetStringPreserveEmpty(&t.ThreadDeploymentSuccess, src.ThreadDeploymentSuccess)
+	flex.SetStringPreserveEmpty(&t.ThreadDeploymentFailure, src.ThreadDeploymentFailure)
+	flex.SetStringPreserveEmpty(&t.ThreadStatusChange, src.ThreadStatusChange)
+	flex.SetStringPreserveEmpty(&t.ThreadBackupSuccess, src.ThreadBackupSuccess)
+	flex.SetStringPreserveEmpty(&t.ThreadBackupFailure, src.ThreadBackupFailure)
+	flex.SetStringPreserveEmpty(&t.ThreadScheduledTaskSuccess, src.ThreadScheduledTaskSuccess)
+	flex.SetStringPreserveEmpty(&t.ThreadScheduledTaskFailure, src.ThreadScheduledTaskFailure)
+	flex.SetStringPreserveEmpty(&t.ThreadDockerCleanupSuccess, src.ThreadDockerCleanupSuccess)
+	flex.SetStringPreserveEmpty(&t.ThreadDockerCleanupFailure, src.ThreadDockerCleanupFailure)
+	flex.SetStringPreserveEmpty(&t.ThreadServerDiskUsage, src.ThreadServerDiskUsage)
+	flex.SetStringPreserveEmpty(&t.ThreadServerReachable, src.ThreadServerReachable)
+	flex.SetStringPreserveEmpty(&t.ThreadServerUnreachable, src.ThreadServerUnreachable)
+	flex.SetStringPreserveEmpty(&t.ThreadServerPatch, src.ThreadServerPatch)
+	flex.SetStringPreserveEmpty(&t.ThreadTraefikOutdated, src.ThreadTraefikOutdated)
+}

--- a/internal/service/notificationcommon/thread_model_test.go
+++ b/internal/service/notificationcommon/thread_model_test.go
@@ -1,0 +1,74 @@
+package notificationcommon_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThreadModel_AlignsWithThreadAttributeNames(t *testing.T) {
+	t.Parallel()
+	names := notificationcommon.ThreadAttributeNames()
+	require.Len(t, names, 14)
+
+	typ := reflect.TypeOf(notificationcommon.ThreadModel{})
+	require.Equal(t, len(names), typ.NumField())
+	for i, name := range names {
+		tag := typ.Field(i).Tag.Get("tfsdk")
+		assert.Equal(t, name, tag, "ThreadModel field %d tfsdk", i)
+	}
+}
+
+func TestThreadModel_CreateThreadUpdateAndFlatten(t *testing.T) {
+	t.Parallel()
+	plan := notificationcommon.ThreadModel{
+		ThreadDeploymentFailure: types.StringValue("42"),
+		ThreadServerDiskUsage:   types.StringValue(""),
+	}
+	th := plan.CreateThreadUpdate()
+	require.NotNil(t, th.ThreadDeploymentFailure)
+	assert.Equal(t, "42", *th.ThreadDeploymentFailure)
+	require.NotNil(t, th.ThreadServerDiskUsage)
+	assert.Empty(t, *th.ThreadServerDiskUsage)
+	assert.Nil(t, th.ThreadDeploymentSuccess)
+
+	var in client.UpdateTelegramNotificationInput
+	require.NoError(t, client.ApplyThreadUpdate(&in, th))
+	require.NotNil(t, in.ThreadDeploymentFailure)
+	assert.Equal(t, "42", *in.ThreadDeploymentFailure)
+
+	src, err := client.ThreadsFrom(&client.TelegramNotificationSettings{
+		ThreadDeploymentFailure: "99",
+		ThreadBackupFailure:     "7",
+	})
+	require.NoError(t, err)
+	got := notificationcommon.ThreadModel{
+		ThreadDeploymentSuccess: types.StringValue("keep-me"),
+	}
+	got.FlattenThreads(src)
+	assert.Equal(t, "99", got.ThreadDeploymentFailure.ValueString())
+	assert.Equal(t, "7", got.ThreadBackupFailure.ValueString())
+	// API hid this sensitive field (empty); preserve prior state.
+	assert.Equal(t, "keep-me", got.ThreadDeploymentSuccess.ValueString())
+}
+
+func TestThreadModel_DiffThreadUpdate(t *testing.T) {
+	t.Parallel()
+	plan := notificationcommon.ThreadModel{
+		ThreadDeploymentFailure: types.StringValue("42"),
+		ThreadBackupFailure:     types.StringValue("8"),
+	}
+	state := notificationcommon.ThreadModel{
+		ThreadDeploymentFailure: types.StringValue("42"),
+		ThreadBackupFailure:     types.StringValue("7"),
+	}
+	th := plan.DiffThreadUpdate(state)
+	assert.Nil(t, th.ThreadDeploymentFailure)
+	require.NotNil(t, th.ThreadBackupFailure)
+	assert.Equal(t, "8", *th.ThreadBackupFailure)
+}

--- a/internal/service/notificationtelegram/data_source.go
+++ b/internal/service/notificationtelegram/data_source.go
@@ -38,29 +38,18 @@ func (d *telegramDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 		}
 	}
 	attrs := map[string]schema.Attribute{
-		"id":                            notificationcommon.IDAttributeDS(),
-		"enabled":                       notificationcommon.EnabledAttributeDS("Telegram"),
-		"token":                         sens("Telegram bot token."),
-		"chat_id":                       sens("Telegram chat ID."),
-		"thread_deployment_success":     sens("Forum thread ID for deployment_success events."),
-		"thread_deployment_failure":     sens("Forum thread ID for deployment_failure events."),
-		"thread_status_change":          sens("Forum thread ID for status_change events."),
-		"thread_backup_success":         sens("Forum thread ID for backup_success events."),
-		"thread_backup_failure":         sens("Forum thread ID for backup_failure events."),
-		"thread_scheduled_task_success": sens("Forum thread ID for scheduled_task_success events."),
-		"thread_scheduled_task_failure": sens("Forum thread ID for scheduled_task_failure events."),
-		"thread_docker_cleanup_success": sens("Forum thread ID for docker_cleanup_success events."),
-		"thread_docker_cleanup_failure": sens("Forum thread ID for docker_cleanup_failure events."),
-		"thread_server_disk_usage":      sens("Forum thread ID for server_disk_usage events."),
-		"thread_server_reachable":       sens("Forum thread ID for server_reachable events."),
-		"thread_server_unreachable":     sens("Forum thread ID for server_unreachable events."),
-		"thread_server_patch":           sens("Forum thread ID for server_patch events."),
-		"thread_traefik_outdated":       sens("Forum thread ID for traefik_outdated events."),
+		"id":      notificationcommon.IDAttributeDS(),
+		"enabled": notificationcommon.EnabledAttributeDS("Telegram"),
+		"token":   sens("Telegram bot token."),
+		"chat_id": sens("Telegram chat ID."),
 	}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Reads the current team's Telegram notification settings. " +
 			"This is a team-scoped singleton (selected by the API token). Requires Coolify >= v4.3.0.",
-		Attributes: notificationcommon.MergeDSAttrs(attrs, notificationcommon.EventDataSourceAttrs("Telegram")),
+		Attributes: notificationcommon.MergeDSAttrs(
+			notificationcommon.MergeDSAttrs(attrs, notificationcommon.EventDataSourceAttrs("Telegram")),
+			notificationcommon.ThreadDataSourceAttrs(),
+		),
 	}
 }
 
@@ -77,7 +66,7 @@ func (d *telegramDataSource) Read(ctx context.Context, _ datasource.ReadRequest,
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationtelegram/resource.go
+++ b/internal/service/notificationtelegram/resource.go
@@ -31,21 +31,7 @@ type model struct {
 	ChatID  types.String `tfsdk:"chat_id"`
 
 	notificationcommon.EventModel
-
-	ThreadDeploymentSuccess    types.String `tfsdk:"thread_deployment_success"`
-	ThreadDeploymentFailure    types.String `tfsdk:"thread_deployment_failure"`
-	ThreadStatusChange         types.String `tfsdk:"thread_status_change"`
-	ThreadBackupSuccess        types.String `tfsdk:"thread_backup_success"`
-	ThreadBackupFailure        types.String `tfsdk:"thread_backup_failure"`
-	ThreadScheduledTaskSuccess types.String `tfsdk:"thread_scheduled_task_success"`
-	ThreadScheduledTaskFailure types.String `tfsdk:"thread_scheduled_task_failure"`
-	ThreadDockerCleanupSuccess types.String `tfsdk:"thread_docker_cleanup_success"`
-	ThreadDockerCleanupFailure types.String `tfsdk:"thread_docker_cleanup_failure"`
-	ThreadServerDiskUsage      types.String `tfsdk:"thread_server_disk_usage"`
-	ThreadServerReachable      types.String `tfsdk:"thread_server_reachable"`
-	ThreadServerUnreachable    types.String `tfsdk:"thread_server_unreachable"`
-	ThreadServerPatch          types.String `tfsdk:"thread_server_patch"`
-	ThreadTraefikOutdated      types.String `tfsdk:"thread_traefik_outdated"`
+	notificationcommon.ThreadModel
 }
 
 func NewResource() resource.Resource {
@@ -69,24 +55,10 @@ func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 		}
 	}
 	attrs := map[string]schema.Attribute{
-		"id":                            notificationcommon.IDAttribute(),
-		"enabled":                       notificationcommon.EnabledAttribute("Telegram"),
-		"token":                         sensStr("Telegram bot token."),
-		"chat_id":                       sensStr("Telegram chat ID."),
-		"thread_deployment_success":     sensStr("Telegram forum thread ID for deployment_success events."),
-		"thread_deployment_failure":     sensStr("Telegram forum thread ID for deployment_failure events."),
-		"thread_status_change":          sensStr("Telegram forum thread ID for status_change events."),
-		"thread_backup_success":         sensStr("Telegram forum thread ID for backup_success events."),
-		"thread_backup_failure":         sensStr("Telegram forum thread ID for backup_failure events."),
-		"thread_scheduled_task_success": sensStr("Telegram forum thread ID for scheduled_task_success events."),
-		"thread_scheduled_task_failure": sensStr("Telegram forum thread ID for scheduled_task_failure events."),
-		"thread_docker_cleanup_success": sensStr("Telegram forum thread ID for docker_cleanup_success events."),
-		"thread_docker_cleanup_failure": sensStr("Telegram forum thread ID for docker_cleanup_failure events."),
-		"thread_server_disk_usage":      sensStr("Telegram forum thread ID for server_disk_usage events."),
-		"thread_server_reachable":       sensStr("Telegram forum thread ID for server_reachable events."),
-		"thread_server_unreachable":     sensStr("Telegram forum thread ID for server_unreachable events."),
-		"thread_server_patch":           sensStr("Telegram forum thread ID for server_patch events."),
-		"thread_traefik_outdated":       sensStr("Telegram forum thread ID for traefik_outdated events."),
+		"id":      notificationcommon.IDAttribute(),
+		"enabled": notificationcommon.EnabledAttribute("Telegram"),
+		"token":   sensStr("Telegram bot token."),
+		"chat_id": sensStr("Telegram chat ID."),
 	}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Telegram notification settings in Coolify. " +
@@ -94,7 +66,10 @@ func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"**Requires Coolify >= v4.3.0** (notification routes are absent on v4.2.x and older; acceptance tests skip when the API is missing).\n\n" +
 			"On destroy, Telegram notifications are disabled (`enabled = false`); token, chat ID, and thread IDs are left unchanged. " +
 			"Import with id `current`.",
-		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Telegram")),
+		Attributes: notificationcommon.MergeAttrs(
+			notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Telegram")),
+			notificationcommon.ThreadSchemaAttrs("Telegram"),
+		),
 	}
 }
 
@@ -111,7 +86,7 @@ func (r *telegramResource) Create(ctx context.Context, req resource.CreateReques
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_notification_telegram"})
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateTelegramNotifications(ctx, input)
@@ -120,7 +95,7 @@ func (r *telegramResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -143,7 +118,7 @@ func (r *telegramResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -163,7 +138,7 @@ func (r *telegramResource) Update(ctx context.Context, req resource.UpdateReques
 	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_notification_telegram"})
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateTelegramNotifications(ctx, input)
@@ -172,7 +147,7 @@ func (r *telegramResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -203,6 +178,9 @@ func createInputFromPlan(plan model) (client.UpdateTelegramNotificationInput, er
 	if err := client.ApplyEventUpdate(&in, plan.CreateUpdate()); err != nil {
 		return in, err
 	}
+	if err := client.ApplyThreadUpdate(&in, plan.CreateThreadUpdate()); err != nil {
+		return in, err
+	}
 	if flex.StringValueConfigured(plan.Token) {
 		s := plan.Token.ValueString()
 		in.Token = &s
@@ -210,62 +188,6 @@ func createInputFromPlan(plan model) (client.UpdateTelegramNotificationInput, er
 	if flex.StringValueConfigured(plan.ChatID) {
 		s := plan.ChatID.ValueString()
 		in.ChatID = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadDeploymentSuccess) {
-		s := plan.ThreadDeploymentSuccess.ValueString()
-		in.ThreadDeploymentSuccess = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadDeploymentFailure) {
-		s := plan.ThreadDeploymentFailure.ValueString()
-		in.ThreadDeploymentFailure = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadStatusChange) {
-		s := plan.ThreadStatusChange.ValueString()
-		in.ThreadStatusChange = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadBackupSuccess) {
-		s := plan.ThreadBackupSuccess.ValueString()
-		in.ThreadBackupSuccess = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadBackupFailure) {
-		s := plan.ThreadBackupFailure.ValueString()
-		in.ThreadBackupFailure = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadScheduledTaskSuccess) {
-		s := plan.ThreadScheduledTaskSuccess.ValueString()
-		in.ThreadScheduledTaskSuccess = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadScheduledTaskFailure) {
-		s := plan.ThreadScheduledTaskFailure.ValueString()
-		in.ThreadScheduledTaskFailure = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadDockerCleanupSuccess) {
-		s := plan.ThreadDockerCleanupSuccess.ValueString()
-		in.ThreadDockerCleanupSuccess = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadDockerCleanupFailure) {
-		s := plan.ThreadDockerCleanupFailure.ValueString()
-		in.ThreadDockerCleanupFailure = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadServerDiskUsage) {
-		s := plan.ThreadServerDiskUsage.ValueString()
-		in.ThreadServerDiskUsage = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadServerReachable) {
-		s := plan.ThreadServerReachable.ValueString()
-		in.ThreadServerReachable = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadServerUnreachable) {
-		s := plan.ThreadServerUnreachable.ValueString()
-		in.ThreadServerUnreachable = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadServerPatch) {
-		s := plan.ThreadServerPatch.ValueString()
-		in.ThreadServerPatch = &s
-	}
-	if flex.StringValueConfigured(plan.ThreadTraefikOutdated) {
-		s := plan.ThreadTraefikOutdated.ValueString()
-		in.ThreadTraefikOutdated = &s
 	}
 	return in, nil
 }
@@ -277,53 +199,14 @@ func updateInputFromPlan(plan, state model) (client.UpdateTelegramNotificationIn
 	if err := client.ApplyEventUpdate(&in, plan.DiffUpdate(state.EventModel)); err != nil {
 		return in, err
 	}
+	if err := client.ApplyThreadUpdate(&in, plan.DiffThreadUpdate(state.ThreadModel)); err != nil {
+		return in, err
+	}
 	if w := flex.StringIfChanged(plan.Token, state.Token); w != nil {
 		in.Token = w
 	}
 	if w := flex.StringIfChanged(plan.ChatID, state.ChatID); w != nil {
 		in.ChatID = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadDeploymentSuccess, state.ThreadDeploymentSuccess); w != nil {
-		in.ThreadDeploymentSuccess = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadDeploymentFailure, state.ThreadDeploymentFailure); w != nil {
-		in.ThreadDeploymentFailure = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadStatusChange, state.ThreadStatusChange); w != nil {
-		in.ThreadStatusChange = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadBackupSuccess, state.ThreadBackupSuccess); w != nil {
-		in.ThreadBackupSuccess = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadBackupFailure, state.ThreadBackupFailure); w != nil {
-		in.ThreadBackupFailure = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadScheduledTaskSuccess, state.ThreadScheduledTaskSuccess); w != nil {
-		in.ThreadScheduledTaskSuccess = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadScheduledTaskFailure, state.ThreadScheduledTaskFailure); w != nil {
-		in.ThreadScheduledTaskFailure = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadDockerCleanupSuccess, state.ThreadDockerCleanupSuccess); w != nil {
-		in.ThreadDockerCleanupSuccess = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadDockerCleanupFailure, state.ThreadDockerCleanupFailure); w != nil {
-		in.ThreadDockerCleanupFailure = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadServerDiskUsage, state.ThreadServerDiskUsage); w != nil {
-		in.ThreadServerDiskUsage = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadServerReachable, state.ThreadServerReachable); w != nil {
-		in.ThreadServerReachable = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadServerUnreachable, state.ThreadServerUnreachable); w != nil {
-		in.ThreadServerUnreachable = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadServerPatch, state.ThreadServerPatch); w != nil {
-		in.ThreadServerPatch = w
-	}
-	if w := flex.StringIfChanged(plan.ThreadTraefikOutdated, state.ThreadTraefikOutdated); w != nil {
-		in.ThreadTraefikOutdated = w
 	}
 	return in, nil
 }
@@ -334,23 +217,14 @@ func flatten(api *client.TelegramNotificationSettings, m *model) error {
 		return err
 	}
 	m.FlattenEvents(ev)
+	th, err := client.ThreadsFrom(api)
+	if err != nil {
+		return err
+	}
+	m.FlattenThreads(th)
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.Enabled = types.BoolValue(api.Enabled)
 	flex.SetStringPreserveEmpty(&m.Token, api.Token)
 	flex.SetStringPreserveEmpty(&m.ChatID, api.ChatID)
-	flex.SetStringPreserveEmpty(&m.ThreadDeploymentSuccess, api.ThreadDeploymentSuccess)
-	flex.SetStringPreserveEmpty(&m.ThreadDeploymentFailure, api.ThreadDeploymentFailure)
-	flex.SetStringPreserveEmpty(&m.ThreadStatusChange, api.ThreadStatusChange)
-	flex.SetStringPreserveEmpty(&m.ThreadBackupSuccess, api.ThreadBackupSuccess)
-	flex.SetStringPreserveEmpty(&m.ThreadBackupFailure, api.ThreadBackupFailure)
-	flex.SetStringPreserveEmpty(&m.ThreadScheduledTaskSuccess, api.ThreadScheduledTaskSuccess)
-	flex.SetStringPreserveEmpty(&m.ThreadScheduledTaskFailure, api.ThreadScheduledTaskFailure)
-	flex.SetStringPreserveEmpty(&m.ThreadDockerCleanupSuccess, api.ThreadDockerCleanupSuccess)
-	flex.SetStringPreserveEmpty(&m.ThreadDockerCleanupFailure, api.ThreadDockerCleanupFailure)
-	flex.SetStringPreserveEmpty(&m.ThreadServerDiskUsage, api.ThreadServerDiskUsage)
-	flex.SetStringPreserveEmpty(&m.ThreadServerReachable, api.ThreadServerReachable)
-	flex.SetStringPreserveEmpty(&m.ThreadServerUnreachable, api.ThreadServerUnreachable)
-	flex.SetStringPreserveEmpty(&m.ThreadServerPatch, api.ThreadServerPatch)
-	flex.SetStringPreserveEmpty(&m.ThreadTraefikOutdated, api.ThreadTraefikOutdated)
 	return nil
 }

--- a/internal/service/notificationtelegram/resource_test.go
+++ b/internal/service/notificationtelegram/resource_test.go
@@ -52,22 +52,11 @@ func newMockServer(store *mockTelegram) *httptest.Server {
 			return
 		}
 		allowed := notificationcommon.MergeAllowed(
-			notificationcommon.EventAllowedFields("telegram"),
+			notificationcommon.MergeAllowedMaps(
+				notificationcommon.EventAllowedFields("telegram"),
+				notificationcommon.ThreadAllowedFields("telegram"),
+			),
 			"telegram_enabled", "telegram_token", "telegram_chat_id",
-			"telegram_notifications_deployment_success_thread_id",
-			"telegram_notifications_deployment_failure_thread_id",
-			"telegram_notifications_status_change_thread_id",
-			"telegram_notifications_backup_success_thread_id",
-			"telegram_notifications_backup_failure_thread_id",
-			"telegram_notifications_scheduled_task_success_thread_id",
-			"telegram_notifications_scheduled_task_failure_thread_id",
-			"telegram_notifications_docker_cleanup_success_thread_id",
-			"telegram_notifications_docker_cleanup_failure_thread_id",
-			"telegram_notifications_server_disk_usage_thread_id",
-			"telegram_notifications_server_reachable_thread_id",
-			"telegram_notifications_server_unreachable_thread_id",
-			"telegram_notifications_server_patch_thread_id",
-			"telegram_notifications_traefik_outdated_thread_id",
 		)
 		if notificationcommon.RejectUnknownFields(w, body, allowed) {
 			return


### PR DESCRIPTION
## Description

Shares Telegram forum thread-id create, update, and flatten through a `ThreadModel` embed and client `ApplyThreadUpdate` / `ThreadsFrom` helpers (same shape as the event bools from #722). Token and chat_id stay on the Telegram resource.

## The problem

`notificationtelegram/resource.go` still copied all 14 thread-id strings in create, update, and flatten. A new Coolify thread field required three parallel edits in one file.

## The change

- Add `client.NotificationThreads` / `NotificationThreadUpdate` with name-matched copy helpers
- Add `notificationcommon.ThreadModel` (`CreateThreadUpdate`, `DiffThreadUpdate`, `FlattenThreads`)
- Generate thread schema, data-source attrs, and mock allowed JSON keys from the shared event name list
- Wire the Telegram resource and data source; keep token and chat_id local

## Validation

- `go test ./internal/client/ ./internal/service/notificationcommon/ ./internal/service/notificationtelegram/`
- Existing Telegram create/update/import unit tests still cover `thread_deployment_failure`

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] Targeted `go test` passes locally
- [x] `gofmt` ran
- [x] Documentation updated (if adding/changing resources or data sources) (schema text unchanged)
- [x] `make docs` regenerated (if templates changed) (not needed)
- [x] Examples updated (if adding new resources) (not needed)
- [x] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

Closes #724
