### PR TITLE
fix: align notification mapping errors and thread tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-45 resources, 62 data sources, 1310+ tests (unit + acceptance), 10 CI jobs.
+45 resources, 62 data sources, 1330+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1310+ tests (unit + acceptance)
+- 1330+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 45 |
 | Data sources | 62 |
-| Tests | 1310+ unit and acceptance tests |
+| Tests | 1330+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -317,7 +317,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1310+ tests, race detector enabled)
+make test                                       # Run unit tests (1330+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/internal/client/notifications_test.go
+++ b/internal/client/notifications_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -272,16 +273,8 @@ func TestNotificationThreadJSONTags_CoverTelegramThreads(t *testing.T) {
 	t.Parallel()
 	tags := client.NotificationUpdateJSONTags("telegram")
 	require.NotEmpty(t, tags)
-	events := []string{
-		"deployment_success", "deployment_failure", "status_change",
-		"backup_success", "backup_failure",
-		"scheduled_task_success", "scheduled_task_failure",
-		"docker_cleanup_success", "docker_cleanup_failure",
-		"server_disk_usage", "server_reachable", "server_unreachable",
-		"server_patch", "traefik_outdated",
-	}
-	for _, ev := range events {
-		key := "telegram_notifications_" + ev + "_thread_id"
+	for _, ev := range notificationcommon.EventAttributeNames() {
+		key := notificationcommon.ThreadJSONKey("telegram", ev)
 		_, ok := tags[key]
 		assert.True(t, ok, "telegram update input missing thread JSON key %q", key)
 	}
@@ -291,14 +284,7 @@ func TestNotificationEventJSONTags_CoverSharedEvents(t *testing.T) {
 	t.Parallel()
 	// Short schema names from notificationcommon must appear in each channel's
 	// Update* JSON tags (as <event>_<channel>_notifications or similar).
-	events := []string{
-		"deployment_success", "deployment_failure", "status_change",
-		"backup_success", "backup_failure",
-		"scheduled_task_success", "scheduled_task_failure",
-		"docker_cleanup_success", "docker_cleanup_failure",
-		"server_disk_usage", "server_reachable", "server_unreachable",
-		"server_patch", "traefik_outdated",
-	}
+	events := notificationcommon.EventAttributeNames()
 	for _, ch := range []string{"discord", "slack", "telegram", "pushover", "webhook", "email"} {
 		ch := ch
 		t.Run(ch, func(t *testing.T) {

--- a/internal/client/notifications_test.go
+++ b/internal/client/notifications_test.go
@@ -268,6 +268,25 @@ func TestNotificationUpdateJSONTags(t *testing.T) {
 	assert.Nil(t, client.NotificationUpdateJSONTags(""))
 }
 
+func TestNotificationThreadJSONTags_CoverTelegramThreads(t *testing.T) {
+	t.Parallel()
+	tags := client.NotificationUpdateJSONTags("telegram")
+	require.NotEmpty(t, tags)
+	events := []string{
+		"deployment_success", "deployment_failure", "status_change",
+		"backup_success", "backup_failure",
+		"scheduled_task_success", "scheduled_task_failure",
+		"docker_cleanup_success", "docker_cleanup_failure",
+		"server_disk_usage", "server_reachable", "server_unreachable",
+		"server_patch", "traefik_outdated",
+	}
+	for _, ev := range events {
+		key := "telegram_notifications_" + ev + "_thread_id"
+		_, ok := tags[key]
+		assert.True(t, ok, "telegram update input missing thread JSON key %q", key)
+	}
+}
+
 func TestNotificationEventJSONTags_CoverSharedEvents(t *testing.T) {
 	t.Parallel()
 	// Short schema names from notificationcommon must appear in each channel's

--- a/internal/client/notifications_threads_test.go
+++ b/internal/client/notifications_threads_test.go
@@ -22,6 +22,50 @@ func TestApplyThreadUpdate_Telegram(t *testing.T) {
 	assert.Nil(t, in.Token) // channel-specific left alone
 }
 
+func TestApplyThreadUpdate_AllFourteenFields(t *testing.T) {
+	t.Parallel()
+	vals := make([]string, 14)
+	ptrs := make([]*string, 14)
+	for i := range vals {
+		vals[i] = string(rune('a' + i))
+		ptrs[i] = &vals[i]
+	}
+	th := client.NotificationThreadUpdate{
+		ThreadDeploymentSuccess:    ptrs[0],
+		ThreadDeploymentFailure:    ptrs[1],
+		ThreadStatusChange:         ptrs[2],
+		ThreadBackupSuccess:        ptrs[3],
+		ThreadBackupFailure:        ptrs[4],
+		ThreadScheduledTaskSuccess: ptrs[5],
+		ThreadScheduledTaskFailure: ptrs[6],
+		ThreadDockerCleanupSuccess: ptrs[7],
+		ThreadDockerCleanupFailure: ptrs[8],
+		ThreadServerDiskUsage:      ptrs[9],
+		ThreadServerReachable:      ptrs[10],
+		ThreadServerUnreachable:    ptrs[11],
+		ThreadServerPatch:          ptrs[12],
+		ThreadTraefikOutdated:      ptrs[13],
+	}
+	var in client.UpdateTelegramNotificationInput
+	require.NoError(t, client.ApplyThreadUpdate(&in, th))
+	got := []*string{
+		in.ThreadDeploymentSuccess, in.ThreadDeploymentFailure, in.ThreadStatusChange,
+		in.ThreadBackupSuccess, in.ThreadBackupFailure,
+		in.ThreadScheduledTaskSuccess, in.ThreadScheduledTaskFailure,
+		in.ThreadDockerCleanupSuccess, in.ThreadDockerCleanupFailure,
+		in.ThreadServerDiskUsage, in.ThreadServerReachable, in.ThreadServerUnreachable,
+		in.ThreadServerPatch, in.ThreadTraefikOutdated,
+	}
+	require.Len(t, got, 14)
+	for i, p := range got {
+		require.NotNil(t, p, "field %d", i)
+		assert.Equal(t, vals[i], *p, "field %d", i)
+	}
+	assert.Nil(t, in.Enabled)
+	assert.Nil(t, in.Token)
+	assert.Nil(t, in.ChatID)
+}
+
 func TestApplyThreadUpdate_RejectsUnknownDest(t *testing.T) {
 	t.Parallel()
 	var notTelegram struct{ Name string }

--- a/internal/service/notificationcommon/common.go
+++ b/internal/service/notificationcommon/common.go
@@ -75,6 +75,15 @@ func StringOptComputedSensitive(desc string) schema.StringAttribute {
 	}
 }
 
+// SensitiveOmitSuffix is appended to resource schema descriptions for values
+// Coolify may hide without read:sensitive.
+const SensitiveOmitSuffix = " Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import."
+
+// StringSensitiveOmit is StringOptComputedSensitive with SensitiveOmitSuffix.
+func StringSensitiveOmit(prefix string) schema.StringAttribute {
+	return StringOptComputedSensitive(prefix + SensitiveOmitSuffix)
+}
+
 // BoolOptComputed is Optional+Computed with UseStateForUnknown for API-defaulted bools.
 func BoolOptComputed(desc string) schema.BoolAttribute {
 	return schema.BoolAttribute{
@@ -109,14 +118,17 @@ func ThreadSchemaAttrs(channel string) map[string]schema.Attribute {
 	return attrs
 }
 
-// MergeAttrs returns a new map with base attributes plus overlay (overlay wins on key collision).
-func MergeAttrs(base map[string]schema.Attribute, overlay map[string]schema.Attribute) map[string]schema.Attribute {
-	out := make(map[string]schema.Attribute, len(base)+len(overlay))
-	for k, v := range base {
-		out[k] = v
+// MergeAttrs returns a new map with later maps winning on key collision.
+func MergeAttrs(maps ...map[string]schema.Attribute) map[string]schema.Attribute {
+	n := 0
+	for _, m := range maps {
+		n += len(m)
 	}
-	for k, v := range overlay {
-		out[k] = v
+	out := make(map[string]schema.Attribute, n)
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
 	}
 	return out
 }

--- a/internal/service/notificationcommon/common_test.go
+++ b/internal/service/notificationcommon/common_test.go
@@ -2,6 +2,7 @@ package notificationcommon_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
@@ -124,6 +125,17 @@ func TestEnabledAttribute_DefaultFalse(t *testing.T) {
 	assert.True(t, a.Computed)
 	assert.NotNil(t, a.Default)
 	assert.Contains(t, a.MarkdownDescription, "Discord")
+}
+
+func TestStringSensitiveOmit(t *testing.T) {
+	t.Parallel()
+	a := notificationcommon.StringSensitiveOmit("Telegram bot token.")
+	assert.True(t, a.Optional)
+	assert.True(t, a.Computed)
+	assert.True(t, a.Sensitive)
+	assert.True(t, strings.HasPrefix(a.MarkdownDescription, "Telegram bot token."))
+	assert.Contains(t, a.MarkdownDescription, "read:sensitive")
+	assert.NotEmpty(t, a.PlanModifiers)
 }
 
 func TestBoolOptComputed_PlanModifiers(t *testing.T) {

--- a/internal/service/notificationcommon/data_source_schema.go
+++ b/internal/service/notificationcommon/data_source_schema.go
@@ -54,14 +54,17 @@ func ThreadDataSourceAttrs() map[string]schema.Attribute {
 	return attrs
 }
 
-// MergeDSAttrs returns a new map with base attributes plus overlay (overlay wins).
-func MergeDSAttrs(base map[string]schema.Attribute, overlay map[string]schema.Attribute) map[string]schema.Attribute {
-	out := make(map[string]schema.Attribute, len(base)+len(overlay))
-	for k, v := range base {
-		out[k] = v
+// MergeDSAttrs returns a new map with later maps winning on key collision.
+func MergeDSAttrs(maps ...map[string]schema.Attribute) map[string]schema.Attribute {
+	n := 0
+	for _, m := range maps {
+		n += len(m)
 	}
-	for k, v := range overlay {
-		out[k] = v
+	out := make(map[string]schema.Attribute, n)
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
 	}
 	return out
 }

--- a/internal/service/notificationdiscord/data_source.go
+++ b/internal/service/notificationdiscord/data_source.go
@@ -60,7 +60,7 @@ func (d *discordDataSource) Read(ctx context.Context, _ datasource.ReadRequest, 
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationdiscord/resource.go
+++ b/internal/service/notificationdiscord/resource.go
@@ -85,7 +85,7 @@ func (r *discordResource) Create(ctx context.Context, req resource.CreateRequest
 
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateDiscordNotifications(ctx, input)
@@ -95,7 +95,7 @@ func (r *discordResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -121,7 +121,7 @@ func (r *discordResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -143,7 +143,7 @@ func (r *discordResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateDiscordNotifications(ctx, input)
@@ -153,7 +153,7 @@ func (r *discordResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/notificationemail/data_source.go
+++ b/internal/service/notificationemail/data_source.go
@@ -73,7 +73,7 @@ func (d *emailDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationemail/resource.go
+++ b/internal/service/notificationemail/resource.go
@@ -144,7 +144,7 @@ func (r *emailResource) Create(ctx context.Context, req resource.CreateRequest, 
 	tflog.Debug(ctx, "creating resource", map[string]interface{}{"resource_type": "coolify_notification_email"})
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateEmailNotifications(ctx, input)
@@ -153,7 +153,7 @@ func (r *emailResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -176,7 +176,7 @@ func (r *emailResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -196,7 +196,7 @@ func (r *emailResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	tflog.Debug(ctx, "updating resource", map[string]interface{}{"resource_type": "coolify_notification_email"})
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateEmailNotifications(ctx, input)
@@ -205,7 +205,7 @@ func (r *emailResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/notificationemail/resource.go
+++ b/internal/service/notificationemail/resource.go
@@ -58,18 +58,6 @@ func (r *emailResource) Metadata(_ context.Context, req resource.MetadataRequest
 }
 
 func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	sensStr := func(desc string) schema.StringAttribute {
-		return schema.StringAttribute{
-			MarkdownDescription: desc + " Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.",
-			Optional:            true,
-			Computed:            true,
-			Sensitive:           true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		}
-	}
-
 	attrs := map[string]schema.Attribute{
 		"id": notificationcommon.IDAttribute(),
 
@@ -79,10 +67,10 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
 		},
-		"smtp_from_address": sensStr("SMTP From address."),
-		"smtp_from_name":    sensStr("SMTP From display name."),
-		"smtp_recipients":   sensStr("Comma-separated recipient addresses."),
-		"smtp_host":         sensStr("SMTP host."),
+		"smtp_from_address": notificationcommon.StringSensitiveOmit("SMTP From address."),
+		"smtp_from_name":    notificationcommon.StringSensitiveOmit("SMTP From display name."),
+		"smtp_recipients":   notificationcommon.StringSensitiveOmit("Comma-separated recipient addresses."),
+		"smtp_host":         notificationcommon.StringSensitiveOmit("SMTP host."),
 		"smtp_port": schema.Int64Attribute{
 			MarkdownDescription: "SMTP port (1-65535).",
 			Optional:            true,
@@ -105,8 +93,8 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"smtp_username": sensStr("SMTP username."),
-		"smtp_password": sensStr("SMTP password."),
+		"smtp_username": notificationcommon.StringSensitiveOmit("SMTP username."),
+		"smtp_password": notificationcommon.StringSensitiveOmit("SMTP password."),
 		"smtp_timeout": schema.Int64Attribute{
 			MarkdownDescription: "SMTP timeout in seconds (>= 0).",
 			Optional:            true,
@@ -124,7 +112,7 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
 		},
-		"resend_api_key": sensStr("Resend API key."),
+		"resend_api_key": notificationcommon.StringSensitiveOmit("Resend API key."),
 		"use_instance_email_settings": schema.BoolAttribute{
 			MarkdownDescription: "Whether to use the Coolify instance's shared email settings for this team.",
 			Optional:            true,

--- a/internal/service/notificationpushover/data_source.go
+++ b/internal/service/notificationpushover/data_source.go
@@ -63,7 +63,7 @@ func (d *pushoverDataSource) Read(ctx context.Context, _ datasource.ReadRequest,
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationpushover/resource.go
+++ b/internal/service/notificationpushover/resource.go
@@ -92,7 +92,7 @@ func (r *pushoverResource) Create(ctx context.Context, req resource.CreateReques
 
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdatePushoverNotifications(ctx, input)
@@ -102,7 +102,7 @@ func (r *pushoverResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -128,7 +128,7 @@ func (r *pushoverResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -150,7 +150,7 @@ func (r *pushoverResource) Update(ctx context.Context, req resource.UpdateReques
 
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdatePushoverNotifications(ctx, input)
@@ -160,7 +160,7 @@ func (r *pushoverResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/notificationslack/data_source.go
+++ b/internal/service/notificationslack/data_source.go
@@ -59,7 +59,7 @@ func (d *slackDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationslack/resource.go
+++ b/internal/service/notificationslack/resource.go
@@ -82,7 +82,7 @@ func (r *slackResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateSlackNotifications(ctx, input)
@@ -92,7 +92,7 @@ func (r *slackResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -118,7 +118,7 @@ func (r *slackResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -140,7 +140,7 @@ func (r *slackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateSlackNotifications(ctx, input)
@@ -150,7 +150,7 @@ func (r *slackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/service/notificationtelegram/data_source.go
+++ b/internal/service/notificationtelegram/data_source.go
@@ -46,10 +46,7 @@ func (d *telegramDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Reads the current team's Telegram notification settings. " +
 			"This is a team-scoped singleton (selected by the API token). Requires Coolify >= v4.3.0.",
-		Attributes: notificationcommon.MergeDSAttrs(
-			notificationcommon.MergeDSAttrs(attrs, notificationcommon.EventDataSourceAttrs("Telegram")),
-			notificationcommon.ThreadDataSourceAttrs(),
-		),
+		Attributes: notificationcommon.MergeDSAttrs(attrs, notificationcommon.EventDataSourceAttrs("Telegram"), notificationcommon.ThreadDataSourceAttrs()),
 	}
 }
 

--- a/internal/service/notificationtelegram/data_source_test.go
+++ b/internal/service/notificationtelegram/data_source_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestNotificationDataSource_Read(t *testing.T) {
 	t.Parallel()
-	store := &mockTelegram{EventStore: notificationcommon.EventStore{DeploymentFailure: true}}
+	store := &mockTelegram{
+		ThreadDeployFail: "42",
+		EventStore:       notificationcommon.EventStore{DeploymentFailure: true},
+	}
 	srv := newMockServer(store)
 	defer srv.Close()
 
@@ -27,6 +30,7 @@ data "coolify_notification_telegram" "test" {}
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.coolify_notification_telegram.test", "id", "current"),
 					resource.TestCheckResourceAttr("data.coolify_notification_telegram.test", "deployment_failure", "true"),
+					resource.TestCheckResourceAttr("data.coolify_notification_telegram.test", "thread_deployment_failure", "42"),
 				),
 			},
 		},

--- a/internal/service/notificationtelegram/resource.go
+++ b/internal/service/notificationtelegram/resource.go
@@ -8,8 +8,6 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/notificationcommon"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -43,22 +41,11 @@ func (r *telegramResource) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	sensStr := func(desc string) schema.StringAttribute {
-		return schema.StringAttribute{
-			MarkdownDescription: desc + " Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.",
-			Optional:            true,
-			Computed:            true,
-			Sensitive:           true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		}
-	}
 	attrs := map[string]schema.Attribute{
 		"id":      notificationcommon.IDAttribute(),
 		"enabled": notificationcommon.EnabledAttribute("Telegram"),
-		"token":   sensStr("Telegram bot token."),
-		"chat_id": sensStr("Telegram chat ID."),
+		"token":   notificationcommon.StringSensitiveOmit("Telegram bot token."),
+		"chat_id": notificationcommon.StringSensitiveOmit("Telegram chat ID."),
 	}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the current team's Telegram notification settings in Coolify. " +
@@ -66,10 +53,7 @@ func (r *telegramResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"**Requires Coolify >= v4.3.0** (notification routes are absent on v4.2.x and older; acceptance tests skip when the API is missing).\n\n" +
 			"On destroy, Telegram notifications are disabled (`enabled = false`); token, chat ID, and thread IDs are left unchanged. " +
 			"Import with id `current`.",
-		Attributes: notificationcommon.MergeAttrs(
-			notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Telegram")),
-			notificationcommon.ThreadSchemaAttrs("Telegram"),
-		),
+		Attributes: notificationcommon.MergeAttrs(attrs, notificationcommon.EventSchemaAttrs("Telegram"), notificationcommon.ThreadSchemaAttrs("Telegram")),
 	}
 }
 

--- a/internal/service/notificationwebhook/data_source.go
+++ b/internal/service/notificationwebhook/data_source.go
@@ -59,7 +59,7 @@ func (d *webhookDataSource) Read(ctx context.Context, _ datasource.ReadRequest, 
 	}
 	var state model
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/notificationwebhook/resource.go
+++ b/internal/service/notificationwebhook/resource.go
@@ -82,7 +82,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 
 	input, err := createInputFromPlan(plan)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateWebhookNotifications(ctx, input)
@@ -92,7 +92,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -118,7 +118,7 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	if err := flatten(got, &state); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -140,7 +140,7 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	input, err := updateInputFromPlan(plan, state)
 	if err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	updated, err := r.client.UpdateWebhookNotifications(ctx, input)
@@ -150,7 +150,7 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if err := flatten(updated, &plan); err != nil {
-		resp.Diagnostics.AddError("Error mapping notification events", err.Error())
+		resp.Diagnostics.AddError("Error mapping notification settings", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)


### PR DESCRIPTION
## Description

MPI follow-up after #727: tighten Telegram thread mapping tests, share the omit-on-read string schema helper, bump the documented test floor, and use one mapping-error summary across notification channels.

## The problem

Thread helpers landed without a JSON-tag guard for all 14 `telegram_*_thread_id` keys. Email and Telegram still copied the same sensitive-string schema factory. Documented test floor lagged the counts-check actual (1335, floor 1330). Discord/Slack/webhook/Pushover/email still said "Error mapping notification events" after Telegram moved to "settings".

## The change

- Client tests: all 14 thread JSON keys, all-field `ApplyThreadUpdate`, Telegram data source asserts `thread_deployment_failure`
- `StringSensitiveOmit` plus variadic `MergeAttrs`/`MergeDSAttrs`
- AGENTS.md and README.md test floor 1330+
- Shared diagnostic: `Error mapping notification settings`

## Validation

- `go test` on `client`, `notificationcommon`, and all six notification packages

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Targeted `go test` passes locally
- [x] `gofmt` ran
- [x] Documentation updated (test floor)
- [x] `make docs` regenerated (if templates changed) (not needed)
- [x] Examples updated (if adding new resources) (not needed)
- [x] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

Ref #728
