### PR TITLE
fix: include Coolify deploy logs and retry acme-github-cicd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,40 +649,7 @@ jobs:
           export TF_VAR_coolify_token="$COOLIFY_TOKEN"
           export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 
-          failed=0
-          for dir in examples/scenarios/acme-*/; do
-            scenario=$(basename "$dir")
-            echo "=== Testing $scenario ==="
-
-            # Skip scenarios with missing required secrets
-            case "$scenario" in
-              acme-github-cicd)
-                if [ -z "$TF_VAR_github_app_id" ]; then
-                  echo "SKIP: GitHub App secrets not configured"
-                  echo ""
-                  continue
-                fi
-                ;;
-              acme-hetzner-infra)
-                if [ -z "$TF_VAR_hetzner_api_token" ]; then
-                  echo "SKIP: Hetzner token not configured"
-                  echo ""
-                  continue
-                fi
-                ;;
-            esac
-
-            (
-              cd "$dir"
-              if [ -d "modules" ]; then
-                # terraform init still resolves providers with dev_overrides, so fetch only local modules here.
-                terraform get
-              fi
-              terraform test -verbose
-            ) || failed=1
-            echo ""
-          done
-          exit $failed
+          bash scripts/run-scenario-tests.sh
 
       - name: Capture Coolify logs on failure
         if: failure()
@@ -694,7 +661,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coolify-logs-scenario-tests
-          path: /tmp/coolify-logs.txt
+          path: |
+            /tmp/coolify-logs.txt
+            /tmp/scenario-diag/
+          if-no-files-found: ignore
           retention-days: 7
 
   acceptance-tests:

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -317,38 +317,7 @@ jobs:
           export TF_VAR_coolify_token="$COOLIFY_TOKEN"
           export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 
-          failed=0
-          for dir in examples/scenarios/acme-*/; do
-            scenario=$(basename "$dir")
-            echo "=== Testing $scenario ==="
-
-            case "$scenario" in
-              acme-github-cicd)
-                if [ -z "$TF_VAR_github_app_id" ]; then
-                  echo "SKIP: GitHub App secrets not configured"
-                  echo ""
-                  continue
-                fi
-                ;;
-              acme-hetzner-infra)
-                if [ -z "$TF_VAR_hetzner_api_token" ]; then
-                  echo "SKIP: Hetzner token not configured"
-                  echo ""
-                  continue
-                fi
-                ;;
-            esac
-
-            (
-              cd "$dir"
-              if [ -d "modules" ]; then
-                terraform get
-              fi
-              terraform test -verbose
-            ) || failed=1
-            echo ""
-          done
-          exit $failed
+          bash scripts/run-scenario-tests.sh
 
       - name: Capture Coolify logs on failure
         if: failure()
@@ -360,7 +329,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coolify-logs-nightly-scenarios
-          path: /tmp/coolify-logs.txt
+          path: |
+            /tmp/coolify-logs.txt
+            /tmp/scenario-diag/
+          if-no-files-found: ignore
           retention-days: 7
 
   report:

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,6 +41,16 @@ Every resource test should include these scenarios:
 - **Disappears** (simulate out-of-band deletion)
 - **CheckDestroy** (verify cleanup after `terraform destroy`)
 
+## Scenario Tests
+
+`terraform test` under `examples/scenarios/` boots a real Coolify
+instance in CI. `scripts/run-scenario-tests.sh` retries
+`acme-github-cicd` once when Coolify reports deploy status `failed`
+(see #728). A single failed Coolify build is not a provider regression
+if Acceptance Tests on the same SHA are green; inspect the job artifact
+(`scenario-diag/` plus compose logs) and the `coolify_deployment`
+error, which now includes the last Coolify deployment log lines.
+
 ## Acceptance Tests
 
 Acceptance tests run against a real Coolify instance. They exercise the

--- a/docs/guides/scenario-testing.md
+++ b/docs/guides/scenario-testing.md
@@ -272,18 +272,17 @@ export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 cd examples/scenarios/acme-website
 terraform test -verbose
 
-# Run all scenarios
-for dir in examples/scenarios/acme-*/; do
-  echo "=== Testing $(basename "$dir") ==="
-  cd "$dir"
-  if [ -d "modules" ]; then
-    # terraform init still resolves providers with dev_overrides, so fetch only local modules here.
-    terraform get
-  fi
-  terraform test -verbose
-  cd -
-done
+# Run all scenarios (retries acme-github-cicd once if Coolify deploy status is failed)
+bash scripts/run-scenario-tests.sh
 ```
+
+CI uses the same script. A single Coolify deploy `failed` on
+`acme-github-cicd` is retried once; if it still fails, Coolify
+deployment JSON (including logs when the API token can read them)
+is written to `/tmp/scenario-diag/` and uploaded with the job
+artifact. Acceptance Tests remain the product-code gate; inspect
+those before treating a lone scenario deploy failure as a provider
+regression.
 
 ## Coming Back Later
 

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 type Deployment struct {
@@ -15,7 +17,50 @@ type Deployment struct {
 	ID         int    `json:"id,omitempty"`
 	Status     string `json:"status,omitempty"`
 	ServerUUID string `json:"server_uuid,omitempty"`
+	// Logs is the Coolify ApplicationDeploymentQueue log payload. The API
+	// returns it only when the token can read sensitive fields. The wire
+	// form is either a JSON array of entries or a JSON string containing
+	// that array.
+	Logs json.RawMessage `json:"logs,omitempty"`
 }
+
+type deploymentLogEntry struct {
+	Output string `json:"output"`
+	Hidden bool   `json:"hidden"`
+}
+
+// FormatLogs returns the last maxLines visible log outputs, joined by
+// newlines. Empty when logs are missing, hidden, or unreadable.
+func (d Deployment) FormatLogs(maxLines int) string {
+	raw := bytes.TrimSpace(d.Logs)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		raw = []byte(asString)
+	}
+	var entries []deploymentLogEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		s := string(raw)
+		if len(s) > 2000 {
+			s = s[len(s)-2000:]
+		}
+		return s
+	}
+	var lines []string
+	for _, e := range entries {
+		if e.Hidden || e.Output == "" {
+			continue
+		}
+		lines = append(lines, e.Output)
+	}
+	if maxLines > 0 && len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	return strings.Join(lines, "\n")
+}
+
 type DeployByTagInput struct {
 	ForceRebuild bool `json:"force_rebuild"`
 }

--- a/internal/client/deployments_logs_test.go
+++ b/internal/client/deployments_logs_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployment_FormatLogs_Array(t *testing.T) {
+	t.Parallel()
+	logs, err := json.Marshal([]map[string]interface{}{
+		{"output": "cloning repo", "type": "stdout", "hidden": false},
+		{"output": "secret", "type": "stdout", "hidden": true},
+		{"output": "nixpacks failed", "type": "stderr", "hidden": false},
+	})
+	require.NoError(t, err)
+	d := Deployment{Logs: logs}
+	got := d.FormatLogs(40)
+	assert.Contains(t, got, "cloning repo")
+	assert.Contains(t, got, "nixpacks failed")
+	assert.NotContains(t, got, "secret")
+}
+
+func TestDeployment_FormatLogs_JSONString(t *testing.T) {
+	t.Parallel()
+	inner := `[{"output":"git clone failed","type":"stderr","hidden":false}]`
+	quoted, err := json.Marshal(inner)
+	require.NoError(t, err)
+	d := Deployment{Logs: quoted}
+	assert.Equal(t, "git clone failed", d.FormatLogs(10))
+}
+
+func TestDeployment_FormatLogs_Tail(t *testing.T) {
+	t.Parallel()
+	entries := make([]map[string]interface{}, 0, 5)
+	for _, s := range []string{"a", "b", "c", "d", "e"} {
+		entries = append(entries, map[string]interface{}{"output": s, "hidden": false})
+	}
+	logs, err := json.Marshal(entries)
+	require.NoError(t, err)
+	d := Deployment{Logs: logs}
+	assert.Equal(t, "d\ne", d.FormatLogs(2))
+}
+
+func TestDeployment_FormatLogs_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, Deployment{}.FormatLogs(10))
+	assert.Empty(t, Deployment{Logs: json.RawMessage("null")}.FormatLogs(10))
+}

--- a/internal/service/deployment/resource.go
+++ b/internal/service/deployment/resource.go
@@ -179,9 +179,13 @@ func (r *deploymentResource) pollDeployment(ctx context.Context, uuid string, pl
 		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 		if dep.Status == "finished" || dep.Status == "failed" || dep.Status == "error" {
 			if dep.Status == "failed" || dep.Status == "error" {
-				resp.Diagnostics.AddError("Deployment failed",
-					fmt.Sprintf("Deployment %s finished with status '%s'. "+
-						"Check the deployment logs in the Coolify UI (application > Deployments) for details.", uuid, dep.Status))
+				msg := fmt.Sprintf("Deployment %s finished with status '%s'.", uuid, dep.Status)
+				if tail := dep.FormatLogs(40); tail != "" {
+					msg += " Last log lines:\n" + tail
+				} else {
+					msg += " Check the Coolify UI (application > Deployments) for details."
+				}
+				resp.Diagnostics.AddError("Deployment failed", msg)
 			}
 			return
 		}

--- a/internal/service/deployment/resource_test.go
+++ b/internal/service/deployment/resource_test.go
@@ -479,10 +479,17 @@ func TestDeploymentResource_WaitForCompletionFailed(t *testing.T) {
 					status = failureStatus
 				}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(map[string]interface{}{
+				body := map[string]interface{}{
 					"deployment_uuid": uuid,
 					"status":          status,
-				})
+				}
+				if status == failureStatus {
+					body["logs"] = []map[string]interface{}{
+						{"output": "cloning repository", "hidden": false},
+						{"output": "nixpacks build failed: no start command", "hidden": false},
+					}
+				}
+				json.NewEncoder(w).Encode(body)
 			})
 
 			srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
@@ -506,7 +513,7 @@ resource "coolify_deployment" "test" {
   }
 }
 `, srv.URL, appUUID),
-						ExpectError: regexp.MustCompile(`Deployment failed`),
+						ExpectError: regexp.MustCompile(`nixpacks build failed: no start command`),
 					},
 				},
 			})

--- a/scripts/dump-coolify-deployments.py
+++ b/scripts/dump-coolify-deployments.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Write Coolify deployment payloads (including logs) to a directory.
+
+GET /deployments only lists in-progress jobs. After a failed scenario
+teardown those are usually gone, so this also walks applications and
+GET /deployments/applications/{uuid}.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def fetch_json(endpoint: str, token: str, path: str) -> Any:
+    url = endpoint.rstrip("/") + path
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.load(resp)
+
+
+def deployment_uuids(payload: Any) -> list[str]:
+    items: list[Any]
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        for key in ("deployments", "data"):
+            if isinstance(payload.get(key), list):
+                items = payload[key]
+                break
+        else:
+            items = [payload]
+    else:
+        return []
+    out: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        uid = item.get("deployment_uuid") or item.get("uuid")
+        if uid:
+            out.append(str(uid))
+    return out
+
+
+def application_uuids(payload: Any) -> list[str]:
+    items = payload if isinstance(payload, list) else []
+    if isinstance(payload, dict):
+        items = payload.get("data") or payload.get("applications") or []
+    out: list[str] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("uuid"):
+            out.append(str(item["uuid"]))
+    return out
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def dump(endpoint: str, token: str, out_dir: Path) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    try:
+        running = fetch_json(endpoint, token, "/api/v1/deployments")
+        write_json(out_dir / "deployments-running.json", running)
+        written += 1
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as err:
+        print(f"FAIL: list running deployments: {err}", file=sys.stderr)
+        running = []
+
+    uuids = set(deployment_uuids(running))
+    try:
+        apps = fetch_json(endpoint, token, "/api/v1/applications")
+        write_json(out_dir / "applications.json", apps)
+        written += 1
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as err:
+        print(f"FAIL: list applications: {err}", file=sys.stderr)
+        apps = []
+
+    for app_uuid in application_uuids(apps):
+        rel = f"/api/v1/deployments/applications/{app_uuid}"
+        try:
+            hist = fetch_json(endpoint, token, rel)
+            write_json(out_dir / f"app-{app_uuid}-deployments.json", hist)
+            written += 1
+            uuids.update(deployment_uuids(hist))
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as err:
+            print(f"FAIL: list deployments for {app_uuid}: {err}", file=sys.stderr)
+
+    for uid in sorted(uuids):
+        try:
+            detail = fetch_json(endpoint, token, f"/api/v1/deployments/{uid}")
+            write_json(out_dir / f"deployment-{uid}.json", detail)
+            written += 1
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as err:
+            print(f"FAIL: get deployment {uid}: {err}", file=sys.stderr)
+
+    print(f"OK: wrote {written} file(s) under {out_dir}")
+    return 0 if written else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--token", required=True)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    args = parser.parse_args()
+    print("PLAN: dump Coolify deployment JSON (including logs when the token can read them)")
+    print(f"DO: fetch deployments from {args.endpoint}")
+    return dump(args.endpoint, args.token, args.out_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Run terraform test for each examples/scenarios/acme-* directory.
+# Retries acme-github-cicd once (Coolify deploy status "failed" flake, #728).
+# On any failure, dumps Coolify deployment JSON when endpoint/token are set.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIAG_DIR="${SCENARIO_DIAG_DIR:-/tmp/scenario-diag}"
+RETRY_SCENARIO="${SCENARIO_RETRY:-acme-github-cicd}"
+
+echo "PLAN: terraform test each examples/scenarios/acme-* (retry ${RETRY_SCENARIO} once on failure)"
+
+dump_diag() {
+  endpoint="${COOLIFY_ENDPOINT:-${TF_VAR_coolify_endpoint:-}}"
+  token="FAKESECRET_e2f3g4h5i6j7k8l9m0n1"
+  if [ -z "$endpoint" ] || [ -z "$token" ]; then
+    echo "WAIT: skip deployment dump (COOLIFY_ENDPOINT or COOLIFY_TOKEN unset)"
+    return 0
+  fi
+  echo "DO: dump Coolify deployments to ${DIAG_DIR}"
+  python3 "${ROOT}/scripts/dump-coolify-deployments.py" \
+    --endpoint "$endpoint" \
+    --token "$token" \
+    --out-dir "$DIAG_DIR" || echo "FAIL: dump-coolify-deployments.py exited $?"
+}
+
+run_one() {
+  dir="$1"
+  (
+    cd "$dir" || exit 1
+    if [ -d "modules" ]; then
+      echo "DO: terraform get in ${dir}"
+      terraform get
+    fi
+    echo "DO: terraform test -verbose in ${dir}"
+    terraform test -verbose
+  )
+}
+
+failed=0
+for dir in "${ROOT}"/examples/scenarios/acme-*/; do
+  [ -d "$dir" ] || continue
+  scenario="$(basename "$dir")"
+  echo "=== Testing ${scenario} ==="
+
+  case "$scenario" in
+    acme-github-cicd)
+      if [ -z "${TF_VAR_github_app_id:-}" ]; then
+        echo "SKIP: GitHub App secrets not configured"
+        echo ""
+        continue
+      fi
+      ;;
+    acme-hetzner-infra)
+      if [ -z "${TF_VAR_hetzner_api_token:-}" ]; then
+        echo "SKIP: Hetzner token not configured"
+        echo ""
+        continue
+      fi
+      ;;
+  esac
+
+  if run_one "$dir"; then
+    echo "OK: ${scenario}"
+  else
+    if [ "$scenario" = "$RETRY_SCENARIO" ]; then
+      echo "DO: retry ${scenario} once (Coolify deploy flake; see #728)"
+      if run_one "$dir"; then
+        echo "OK: ${scenario} after retry"
+      else
+        echo "FAIL: ${scenario} after retry"
+        dump_diag
+        failed=1
+      fi
+    else
+      echo "FAIL: ${scenario}"
+      dump_diag
+      failed=1
+    fi
+  fi
+  echo ""
+done
+
+if [ "$failed" -eq 0 ]; then
+  echo "DONE: all scenario tests passed"
+  echo "NEXT: none"
+  exit 0
+fi
+echo "DONE: one or more scenario tests failed (diag: ${DIAG_DIR})"
+echo "NEXT: inspect terraform test output and ${DIAG_DIR}"
+exit 1

--- a/scripts/test_dump_coolify_deployments.py
+++ b/scripts/test_dump_coolify_deployments.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for scripts/dump-coolify-deployments.py."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import importlib.util
+
+_SCRIPT = Path(__file__).resolve().parent / "dump-coolify-deployments.py"
+_spec = importlib.util.spec_from_file_location("dump_coolify_deployments", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_mod)
+application_uuids = _mod.application_uuids
+deployment_uuids = _mod.deployment_uuids
+dump = _mod.dump
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        routes = {
+            "/api/v1/deployments": [{"deployment_uuid": "dep-run", "status": "in_progress"}],
+            "/api/v1/applications": [{"uuid": "app-1"}],
+            "/api/v1/deployments/applications/app-1": {
+                "deployments": [
+                    {"deployment_uuid": "dep-fail", "status": "failed"},
+                ]
+            },
+            "/api/v1/deployments/dep-run": {"deployment_uuid": "dep-run", "status": "in_progress"},
+            "/api/v1/deployments/dep-fail": {
+                "deployment_uuid": "dep-fail",
+                "status": "failed",
+                "logs": [{"output": "nixpacks failed", "hidden": False}],
+            },
+        }
+        body = routes.get(self.path)
+        if body is None:
+            self.send_error(404)
+            return
+        raw = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+class TestDumpCoolifyDeployments(unittest.TestCase):
+    def test_uuid_helpers(self) -> None:
+        self.assertEqual(deployment_uuids([{"deployment_uuid": "a"}]), ["a"])
+        self.assertEqual(
+            deployment_uuids({"deployments": [{"uuid": "b"}]}),
+            ["b"],
+        )
+        self.assertEqual(application_uuids([{"uuid": "app"}]), ["app"])
+
+    def test_dump_writes_failed_deployment_logs(self) -> None:
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            host, port = httpd.server_address
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp)
+                rc = dump(f"http://{host}:{port}", "tok", out)
+                self.assertEqual(rc, 0)
+                failed = json.loads((out / "deployment-dep-fail.json").read_text())
+                self.assertEqual(failed["status"], "failed")
+                self.assertEqual(failed["logs"][0]["output"], "nixpacks failed")
+        finally:
+            httpd.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/templates/guides/scenario-testing.md.tmpl
+++ b/templates/guides/scenario-testing.md.tmpl
@@ -272,18 +272,17 @@ export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 cd examples/scenarios/acme-website
 terraform test -verbose
 
-# Run all scenarios
-for dir in examples/scenarios/acme-*/; do
-  echo "=== Testing $(basename "$dir") ==="
-  cd "$dir"
-  if [ -d "modules" ]; then
-    # terraform init still resolves providers with dev_overrides, so fetch only local modules here.
-    terraform get
-  fi
-  terraform test -verbose
-  cd -
-done
+# Run all scenarios (retries acme-github-cicd once if Coolify deploy status is failed)
+bash scripts/run-scenario-tests.sh
 ```
+
+CI uses the same script. A single Coolify deploy `failed` on
+`acme-github-cicd` is retried once; if it still fails, Coolify
+deployment JSON (including logs when the API token can read them)
+is written to `/tmp/scenario-diag/` and uploaded with the job
+artifact. Acceptance Tests remain the product-code gate; inspect
+those before treating a lone scenario deploy failure as a provider
+regression.
 
 ## Coming Back Later
 


### PR DESCRIPTION
## Description

When `coolify_deployment` waits for completion and Coolify reports `failed`, the apply error now includes the last deployment log lines. CI retries `acme-github-cicd` once and dumps Coolify deployment JSON into the scenario artifact.

## The problem

Scenario Tests on #727 failed in `acme-github-cicd` `create_and_deploy` with Coolify status `failed`. A rerun passed. Acceptance Tests on the same SHA were green. The job only uploaded compose logs, not the Coolify deployment log payload, so the flake was hard to diagnose.

## The change

- Parse `logs` from `GET /api/v1/deployments/{uuid}` (present when the token can read sensitive fields) and append a tail to the wait-for-completion error
- `scripts/run-scenario-tests.sh` runs every ACME scenario, retries `acme-github-cicd` once, and on failure writes deployment JSON via `scripts/dump-coolify-deployments.py`
- CI and nightly Scenario Tests use that script and upload `/tmp/scenario-diag/` with compose logs

## Validation

- `go test ./internal/client/ ./internal/service/deployment/`
- `python3 -m unittest scripts/test_dump_coolify_deployments.py`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Targeted `go test` and script unit tests pass locally
- [x] `gofmt` ran
- [x] Documentation updated (TESTING.md and scenario-testing guide)
- [x] `make docs` regenerated (if templates changed) (template + generated guide kept in sync)
- [x] Examples updated (if adding new resources) (not needed)
- [x] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

Closes #728
