### PR TITLE
ci: rebalance unit-test shards and cache tool binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,11 +135,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Three shards: pins multi-minute packages (application/service/redis)
-        # onto separate runners so the critical path drops from ~14m to ~8-9m.
-        shard: [0, 1, 2]
+        # Four shards: exclusive pin of the four heaviest packages, then
+        # round-robin the rest. Three shards stacked extra heavies onto
+        # application (Test(0) 10.5m vs ~6m).
+        shard: [0, 1, 2, 3]
     env:
-      UNIT_SHARD_COUNT: "3"
+      UNIT_SHARD_COUNT: "4"
     steps:
       - name: Harden runner
         if: runner.os == 'Linux'
@@ -261,6 +262,11 @@ jobs:
           pattern: coverage-shard-*
           path: coverage-shards
           merge-multiple: true
+      - name: Cache gocover-cobertura
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/gocover-cobertura
+          key: gocover-cobertura-1.5.0-${{ runner.os }}-${{ runner.arch }}
       - name: Merge coverage and summarize
         run: |
           set -euo pipefail
@@ -277,8 +283,13 @@ jobs:
             tail -n +2 "$f" >> coverage.out || true
           done
           go tool cover -func=coverage.out | tail -1
-          go install github.com/boumenot/gocover-cobertura@v1.5.0
-          gocover-cobertura < coverage.out > coverage.xml
+          BIN_DIR="${HOME}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          if [ ! -x "$BIN_DIR/gocover-cobertura" ]; then
+            GOBIN="$BIN_DIR" go install github.com/boumenot/gocover-cobertura@v1.5.0
+          fi
+          "$BIN_DIR/gocover-cobertura" < coverage.out > coverage.xml
       - name: Upload coverage
         if: >-
           always() &&
@@ -328,11 +339,23 @@ jobs:
       - name: Verify module checksums
         if: ${{ !cancelled() }}
         run: go mod verify
+      - name: Cache govulncheck
+        if: ${{ !cancelled() }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/govulncheck
+          key: govulncheck-1.3.0-${{ runner.os }}-${{ runner.arch }}
       - name: Govulncheck
         if: ${{ !cancelled() }}
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
+          set -euo pipefail
+          BIN_DIR="${HOME}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          if [ ! -x "$BIN_DIR/govulncheck" ]; then
+            GOBIN="$BIN_DIR" go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          fi
+          "$BIN_DIR/govulncheck" ./...
       # goreleaser-action downloads the binary from GitHub releases; CDN
       # flakes (socket hang up) should not fail the whole Lint job. Real
       # .goreleaser.yml breakage still surfaces on the release workflow.
@@ -446,6 +469,12 @@ jobs:
             echo "::error::Trivy scan failed (tried fresh download and cached DB)"
             exit 1
           fi
+      - name: Cache gitleaks
+        if: ${{ !cancelled() }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/gitleaks
+          key: gitleaks-8.30.1-${{ runner.os }}-${{ runner.arch }}
       # Download can flake (empty archive / socket hang from GitHub releases).
       # Retry to a temp file before tar; do not pipe curl into tar.
       - name: Gitleaks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## CI
 
 10 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
-Detect Changes, DCO (PR only), Test (3 package shards), Coverage (merge shards),
+Detect Changes, DCO (PR only), Test (4 package shards), Coverage (merge shards),
 Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
 Acceptance Tests, Scenario Tests, Contract Freshness (weekly only), CI (gate).

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,7 +21,7 @@ acctest) with higher in-package parallelism, then plugin packages
 packages fork the Terraform binary under `resource.UnitTest`; higher
 in-package parallelism under `-race` has caused TSAN segfaults.
 
-CI shards unit tests across 3 runners (`scripts/ci-unit-packages.sh`) so
+CI shards unit tests across 4 runners (`scripts/ci-unit-packages.sh`) so
 the heaviest packages (application, service, redis) do not serialize the
 critical path.
 

--- a/scripts/ci-unit-packages.sh
+++ b/scripts/ci-unit-packages.sh
@@ -33,7 +33,10 @@ if (( count < 1 || shard < 0 || shard >= count )); then
 fi
 
 # Heaviest UnitTest packages by recent CI package wall time.
-# Keep the three multi-minute packages on separate shards when count>=3.
+# Only the first $count entries are exclusive pins (one per shard). Remaining
+# names fall through to the general round-robin so application does not also
+# carry scheduledtask+storage+deployment on a 3-wide matrix (PR #729 Test(0)
+# was 10.5m vs ~6m for the other shards).
 heavy_pins=(
   "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
   "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service"
@@ -64,18 +67,20 @@ pkg_in_module() {
   grep -Fxq "$1" "$all_pkgs_file"
 }
 
-# 1) Place heavy pins round-robin so application→0, service→1, redis→2.
+# 1) Exclusive pin: first `count` existing heavies, one per shard.
 pin_i=0
 for pkg in "${heavy_pins[@]}"; do
   if ! pkg_in_module "$pkg"; then
     continue
   fi
-  target=$((pin_i % count))
-  pin_i=$((pin_i + 1))
+  if (( pin_i >= count )); then
+    break
+  fi
   printf '%s\n' "$pkg" >>"$assigned_file"
-  if (( target == shard )); then
+  if (( pin_i == shard )); then
     printf '%s\n' "$pkg" >>"$selected_file"
   fi
+  pin_i=$((pin_i + 1))
 done
 
 # 2) Remaining packages: stable sorted order, round-robin into shards.

--- a/scripts/test_ci_unit_packages.py
+++ b/scripts/test_ci_unit_packages.py
@@ -47,6 +47,35 @@ class TestCIUnitPackages(unittest.TestCase):
         self.assertEqual(sorted(union), all_pkgs)
         self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
 
+    def test_four_shards_partition_all_packages(self) -> None:
+        shards = [run_shard(i, 4) for i in range(4)]
+        union: list[str] = []
+        for s in shards:
+            self.assertGreater(len(s), 0, "shard must not be empty")
+            union.extend(s)
+        all_pkgs = subprocess.run(
+            ["go", "list", "./..."],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        all_pkgs = sorted(p for p in all_pkgs if "/tools" not in p)
+        self.assertEqual(sorted(union), all_pkgs)
+        self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
+
+    def test_application_not_stacked_with_next_heavies(self) -> None:
+        app = "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
+        stacked = {
+            # Previously forced onto shard 0 by pinning every 3rd heavy.
+            "github.com/coolify-terraform/terraform-provider-coolify/internal/service/scheduledtask",
+            "github.com/coolify-terraform/terraform-provider-coolify/internal/service/storage",
+        }
+        shard0 = set(run_shard(0, 3))
+        self.assertIn(app, shard0)
+        for pkg in stacked:
+            self.assertNotIn(pkg, shard0, f"{pkg} must not share shard 0 with application")
+
     def test_heavy_packages_land_on_distinct_shards(self) -> None:
         heavy = {
             "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application": 0,


### PR DESCRIPTION
## Description

Speeds the CI critical path by stopping extra heavy packages from stacking on the application unit-test shard, using 4 shards, and caching tool binaries.

## The problem

On #729, wall clock was about 12 minutes. Test (0) took 10.5 minutes while Test (1) and Test (2) took about 6 minutes. The shard script round-robined every "heavy" package, so application shared a runner with scheduledtask, storage, deployment, and server.

Acceptance Tests are a similar 10.5 minutes (Coolify bootstrap) and already run in parallel. Lint (1.5m) and Validate (2.5m) are not on the critical path.

## The change

- Exclusive-pin only the first N heaviest packages (one per shard). Remaining packages round-robin.
- Four test shards so the next heaviest packages also get their own runner.
- Cache `govulncheck`, `gitleaks`, and `gocover-cobertura` binaries (same pattern as gotestsum).

## Validation

- `python3 -m unittest scripts/test_ci_unit_packages.py`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Shard script unit tests pass locally
- [x] `gofmt` ran (not needed)
- [x] Documentation updated (AGENTS.md, TESTING.md)
- [x] `make docs` regenerated (if templates changed) (not needed)
- [x] Examples updated (if adding new resources) (not needed)
- [x] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
