### PR TITLE
ci: split application unit tests and overlap Coolify boot

### DIFF
--- a/.github/actions/setup-coolify/action.yml
+++ b/.github/actions/setup-coolify/action.yml
@@ -24,21 +24,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Start SSH server with root access
+    - name: Wait for Coolify images (or pull now)
       shell: bash
+      env:
+        COOLIFY_DATA_DIR: ${{ inputs.coolify-data-dir }}
+        COOLIFY_IMAGE_TAG: ${{ inputs.coolify-image-tag }}
       run: |
-        sudo systemctl enable ssh
-        sudo systemctl start ssh
-        ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -q
-        cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
-        chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
-        sudo sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
-        sudo systemctl restart ssh
-        sudo mkdir -p /root/.ssh
-        sudo cp ~/.ssh/authorized_keys /root/.ssh/authorized_keys
-        sudo chmod 700 /root/.ssh
-        sudo chmod 600 /root/.ssh/authorized_keys
-        ssh -o StrictHostKeyChecking=no root@localhost echo "Root SSH OK"
+        set -euo pipefail
+        # Early job steps may have already run prepare-pull-bg so Go/Terraform
+        # setup overlaps the image pull. If not, do prepare+ssh+pull here.
+        if [ -d /tmp/coolify-pull ]; then
+          bash scripts/ci-coolify-boot.sh wait-pull
+        else
+          bash scripts/ci-coolify-boot.sh prepare
+          bash scripts/ci-coolify-boot.sh ssh
+          bash scripts/ci-coolify-boot.sh pull
+        fi
 
     - name: Start Coolify
       shell: bash
@@ -46,57 +47,8 @@ runs:
         COOLIFY_DATA_DIR: ${{ inputs.coolify-data-dir }}
         COOLIFY_IMAGE_TAG: ${{ inputs.coolify-image-tag }}
       run: |
-        mkdir -p "$COOLIFY_DATA_DIR"/{source,ssh/{keys,mux},applications,databases,backups,services,proxy,webhooks-during-maintenance}
-        mkdir -p "$COOLIFY_DATA_DIR/proxy/dynamic"
-        cd "$COOLIFY_DATA_DIR/source"
-        curl -fsSL https://cdn.coollabs.io/coolify/docker-compose.yml -o docker-compose.yml
-        curl -fsSL https://cdn.coollabs.io/coolify/docker-compose.prod.yml -o docker-compose.prod.yml
-        curl -fsSL https://cdn.coollabs.io/coolify/.env.production -o .env
-        sed -i "s|/data/coolify|$COOLIFY_DATA_DIR|g" docker-compose.yml docker-compose.prod.yml .env
-        sed -i "s|APP_ID=.*|APP_ID=$(openssl rand -hex 16)|g" .env
-        sed -i "s|APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|g" .env
-        sed -i "s|DB_PASSWORD=.*|DB_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=')|g" .env
-        sed -i "s|REDIS_PASSWORD=.*|REDIS_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=')|g" .env
-        sed -i "s|PUSHER_APP_ID=.*|PUSHER_APP_ID=$(openssl rand -hex 32)|g" .env
-        sed -i "s|PUSHER_APP_KEY=.*|PUSHER_APP_KEY=$(openssl rand -hex 32)|g" .env
-        sed -i "s|PUSHER_APP_SECRET=.*|PUSHER_APP_SECRET=$(openssl rand -hex 32)|g" .env
-        # Pin Coolify image tag (compose uses ${LATEST_IMAGE:-latest}).
-        # edge = v4.x tip with VolumeBackupsController (#10946); not in tag v4.2.0.
-        if grep -qE '^LATEST_IMAGE=' .env; then
-          sed -i "s|^LATEST_IMAGE=.*|LATEST_IMAGE=${COOLIFY_IMAGE_TAG}|" .env
-        else
-          echo "LATEST_IMAGE=${COOLIFY_IMAGE_TAG}" >> .env
-        fi
-        echo "Using Coolify image tag: ${COOLIFY_IMAGE_TAG}"
-        ssh-keygen -t ed25519 -f "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal" -N "" -q
-        cat "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub" >> ~/.ssh/authorized_keys
-        sudo sh -c "cat $COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub >> /root/.ssh/authorized_keys"
-        printf 'services:\n  coolify:\n    extra_hosts:\n      - "host.docker.internal:host-gateway"\n' \
-          > docker-compose.override.yml
-        sudo chown -R 9999:9999 "$COOLIFY_DATA_DIR/ssh"
-        docker network create --attachable coolify
-        docker compose --env-file .env \
-          -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.override.yml \
-          up -d --pull always --remove-orphans --force-recreate
-
-    - name: Wait for Coolify to be ready
-      shell: bash
-      env:
-        COOLIFY_DATA_DIR: ${{ inputs.coolify-data-dir }}
-      run: |
-        echo "Waiting for Coolify web interface..."
-        for i in $(seq 1 36); do
-          if curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/register 2>/dev/null | grep -qE "200|302"; then
-            echo "Coolify is ready (attempt $i)"
-            break
-          fi
-          if [ "$i" -eq 36 ]; then
-            echo "::error::Coolify not ready after 3 minutes"
-            docker compose -f "$COOLIFY_DATA_DIR/source/docker-compose.yml" logs --tail=50
-            exit 1
-          fi
-          sleep 5
-        done
+        set -euo pipefail
+        bash scripts/ci-coolify-boot.sh up
 
     - name: Cache Playwright browsers
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -106,11 +58,10 @@ runs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('.github/requirements/playwright.txt') }}
 
-    - name: Bootstrap Coolify test fixtures
+    - name: Install Playwright (overlaps Coolify boot)
       shell: bash
-      env:
-        COOLIFY_ENV_FILE: ${{ inputs.coolify-env-file }}
       run: |
+        set -euo pipefail
         pip install --require-hashes -r .github/requirements/playwright.txt
         if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
           # Browsers cached; still need OS deps (not in the browser cache).
@@ -118,6 +69,21 @@ runs:
         else
           playwright install --with-deps chromium
         fi
+
+    - name: Wait for Coolify to be ready
+      shell: bash
+      env:
+        COOLIFY_DATA_DIR: ${{ inputs.coolify-data-dir }}
+      run: |
+        set -euo pipefail
+        bash scripts/ci-coolify-boot.sh wait-ready
+
+    - name: Bootstrap Coolify test fixtures
+      shell: bash
+      env:
+        COOLIFY_ENV_FILE: ${{ inputs.coolify-env-file }}
+      run: |
+        set -euo pipefail
         ./scripts/setup-coolify-test.sh
 
     - name: Verify Coolify API health
@@ -125,6 +91,7 @@ runs:
       env:
         COOLIFY_ENV_FILE: ${{ inputs.coolify-env-file }}
       run: |
+        set -euo pipefail
         set -a; source "$COOLIFY_ENV_FILE"; set +a
         HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
           -H "Authorization: Bearer $COOLIFY_TOKEN" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
               - 'examples/**/*.tf'
             ci:
               - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+              - 'scripts/ci-unit-packages.sh'
+              - 'scripts/ci-coolify-boot.sh'
               - '.codecov.yml'
               - '.goreleaser.yml'
               - 'GNUmakefile'
@@ -136,8 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         # Four shards: exclusive pin of the four heaviest packages, then
-        # round-robin the rest. Three shards stacked extra heavies onto
-        # application (Test(0) 10.5m vs ~6m).
+        # round-robin the rest. Application UnitTests are compiled twice
+        # (shards 0 and 1) with complementary ci_app_a / ci_app_b tags.
         shard: [0, 1, 2, 3]
     env:
       UNIT_SHARD_COUNT: "4"
@@ -199,15 +202,29 @@ jobs:
           mapfile -t pkgs < <(bash scripts/ci-unit-packages.sh "${{ matrix.shard }}" "${UNIT_SHARD_COUNT}")
           echo "Shard ${{ matrix.shard }}/${UNIT_SHARD_COUNT}: ${#pkgs[@]} packages"
           printf '  %s\n' "${pkgs[@]}"
+          # Complementary application test-file slices. Other packages ignore
+          # these tags. Without a tag (shards 2/3) application is not selected.
+          extra_tags=()
+          case "${{ matrix.shard }}" in
+            0) extra_tags=(-tags=ci_app_a) ;;
+            1) extra_tags=(-tags=ci_app_b) ;;
+          esac
+          if [ "${#extra_tags[@]}" -gt 0 ]; then
+            echo "Application split tags: ${extra_tags[*]}"
+          fi
           # gotestsum --packages wants a space-separated list (not commas).
           pkg_list="${pkgs[*]}"
+          test_args=(-race -cover -coverprofile="coverage/coverage-shard-${{ matrix.shard }}.out" -count=1 -p 4 -parallel=1 -timeout=15m)
+          if [ "${#extra_tags[@]}" -gt 0 ]; then
+            test_args=("${extra_tags[@]}" "${test_args[@]}")
+          fi
           gotestsum \
             --format pkgname \
             --junitfile "test-results/unit-shard-${{ matrix.shard }}.xml" \
             --rerun-fails \
             --rerun-fails-max-failures=5 \
             --packages "$pkg_list" \
-            -- -race -cover -coverprofile="coverage/coverage-shard-${{ matrix.shard }}.out" -count=1 -p 4 -parallel=1 -timeout=15m
+            -- "${test_args[@]}"
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -619,6 +636,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Start Coolify image pull
+        env:
+          COOLIFY_DATA_DIR: /home/runner/coolify-data
+        run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -724,6 +745,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Start Coolify image pull
+        env:
+          COOLIFY_DATA_DIR: /home/runner/coolify-data
+        run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -143,6 +143,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Start Coolify image pull
+        env:
+          COOLIFY_DATA_DIR: /home/runner/coolify-data
+          COOLIFY_IMAGE_TAG: ${{ matrix.coolify_image }}
+        run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -257,6 +262,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Start Coolify image pull
+        env:
+          COOLIFY_DATA_DIR: /home/runner/coolify-data
+          COOLIFY_IMAGE_TAG: edge
+        run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/test-cloud-bootstrap.yml
+++ b/.github/workflows/test-cloud-bootstrap.yml
@@ -22,6 +22,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Start Coolify image pull
+        env:
+          COOLIFY_DATA_DIR: /home/runner/coolify-data
+        run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
 
       - uses: ./.github/actions/setup-coolify
 

--- a/internal/service/application/data_source_list_test.go
+++ b/internal/service/application/data_source_list_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_b
+
 package application_test
 
 import (

--- a/internal/service/application/data_source_logs_test.go
+++ b/internal/service/application/data_source_logs_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_b
+
 package application_test
 
 import (

--- a/internal/service/application/data_source_test.go
+++ b/internal/service/application/data_source_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_b
+
 package application_test
 
 import (

--- a/internal/service/application/resource_docker_test.go
+++ b/internal/service/application/resource_docker_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_a
+
 package application_test
 
 import (

--- a/internal/service/application/resource_dockerfile_test.go
+++ b/internal/service/application/resource_dockerfile_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_a
+
 package application_test
 
 import (

--- a/internal/service/application/resource_github_app_test.go
+++ b/internal/service/application/resource_github_app_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_b
+
 package application_test
 
 import (

--- a/internal/service/application/resource_private_git_test.go
+++ b/internal/service/application/resource_private_git_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_a
+
 package application_test
 
 import (

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -1,3 +1,5 @@
+//go:build !ci_app_b
+
 package application_test
 
 import (
@@ -1597,18 +1599,6 @@ func TestApplicationResource_PreviewBuildSecretsStopGrace(t *testing.T) {
 
 func testApplicationResourceConfig(endpoint, attrs string) string {
 	return acctest.TestResourceConfig(endpoint, "coolify_application", "test", attrs)
-}
-
-func decodeRequestBodyMap(t *testing.T, w http.ResponseWriter, r *http.Request) (map[string]interface{}, bool) {
-	t.Helper()
-
-	var requestBody map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-		t.Errorf("decoding %s %s request body: %v", r.Method, r.URL.Path, err)
-		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
-		return nil, false
-	}
-	return requestBody, true
 }
 
 func TestApplicationResource_InvalidPortsExposes(t *testing.T) {

--- a/internal/service/application/testing_helpers_test.go
+++ b/internal/service/application/testing_helpers_test.go
@@ -1,0 +1,23 @@
+package application_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// decodeRequestBodyMap is shared by application resource unit tests that
+// assert on Create/Update JSON. It lives in an untagged file so CI can
+// compile complementary application test slices (ci_app_a / ci_app_b)
+// without dropping the helper.
+func decodeRequestBodyMap(t *testing.T, w http.ResponseWriter, r *http.Request) (map[string]interface{}, bool) {
+	t.Helper()
+
+	var requestBody map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		t.Errorf("decoding %s %s request body: %v", r.Method, r.URL.Path, err)
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return nil, false
+	}
+	return requestBody, true
+}

--- a/scripts/ci-coolify-boot.sh
+++ b/scripts/ci-coolify-boot.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Coolify CI bootstrap steps. Designed so image pull can overlap Go/Terraform
+# setup in the caller, and SSH setup can overlap the pull.
+#
+# Usage:
+#   scripts/ci-coolify-boot.sh <step>
+#
+# Steps:
+#   prepare         Create data dirs, download compose, write .env + override
+#   ssh             Enable root SSH to localhost for Coolify server validation
+#   pull            docker compose pull (foreground)
+#   pull-bg         Start pull in the background; write /tmp/coolify-pull.exit
+#   wait-pull       Wait for pull-bg (or no-op if pull already finished)
+#   up              docker compose up -d --remove-orphans (no --pull/--force)
+#   wait-ready      Poll http://localhost:8000/register until 200/302
+#   prepare-pull-bg prepare + ssh + pull-bg (early job step after checkout)
+#
+# Env:
+#   COOLIFY_DATA_DIR     default /home/runner/coolify-data
+#   COOLIFY_IMAGE_TAG    default edge
+#   COOLIFY_PULL_DIR     marker dir, default /tmp/coolify-pull
+#   COOLIFY_READY_TRIES  default 90 (2s each => 3 minutes)
+set -euo pipefail
+
+STEP="${1:-}"
+if [[ -z "$STEP" ]]; then
+  echo "usage: $0 <prepare|ssh|pull|pull-bg|wait-pull|up|wait-ready|prepare-pull-bg>" >&2
+  exit 2
+fi
+
+COOLIFY_DATA_DIR="${COOLIFY_DATA_DIR:-/home/runner/coolify-data}"
+COOLIFY_IMAGE_TAG="${COOLIFY_IMAGE_TAG:-edge}"
+PULL_DIR="${COOLIFY_PULL_DIR:-/tmp/coolify-pull}"
+SOURCE_DIR="$COOLIFY_DATA_DIR/source"
+READY_TRIES="${COOLIFY_READY_TRIES:-90}"
+
+log() { printf '%s\n' "$1"; }
+
+compose() {
+  docker compose --env-file .env \
+    -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.override.yml \
+    "$@"
+}
+
+step_prepare() {
+  log "PLAN: write Coolify compose files under $SOURCE_DIR (tag=${COOLIFY_IMAGE_TAG})"
+  log "DO: create data directories"
+  mkdir -p "$COOLIFY_DATA_DIR"/{source,ssh/{keys,mux},applications,databases,backups,services,proxy,webhooks-during-maintenance}
+  mkdir -p "$COOLIFY_DATA_DIR/proxy/dynamic"
+  mkdir -p "$SOURCE_DIR"
+  cd "$SOURCE_DIR"
+
+  log "DO: download compose manifests"
+  curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+    https://cdn.coollabs.io/coolify/docker-compose.yml -o docker-compose.yml
+  curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+    https://cdn.coollabs.io/coolify/docker-compose.prod.yml -o docker-compose.prod.yml
+  curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+    https://cdn.coollabs.io/coolify/.env.production -o .env
+
+  sed -i "s|/data/coolify|$COOLIFY_DATA_DIR|g" docker-compose.yml docker-compose.prod.yml .env
+  sed -i "s|APP_ID=.*|APP_ID=$(openssl rand -hex 16)|g" .env
+  sed -i "s|APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|g" .env
+  sed -i "s|DB_PASSWORD=.*|DB_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=')|g" .env
+  sed -i "s|REDIS_PASSWORD=.*|REDIS_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=')|g" .env
+  sed -i "s|PUSHER_APP_ID=.*|PUSHER_APP_ID=$(openssl rand -hex 32)|g" .env
+  sed -i "s|PUSHER_APP_KEY=.*|PUSHER_APP_KEY=$(openssl rand -hex 32)|g" .env
+  sed -i "s|PUSHER_APP_SECRET=.*|PUSHER_APP_SECRET=$(openssl rand -hex 32)|g" .env
+  if grep -qE '^LATEST_IMAGE=' .env; then
+    sed -i "s|^LATEST_IMAGE=.*|LATEST_IMAGE=${COOLIFY_IMAGE_TAG}|" .env
+  else
+    echo "LATEST_IMAGE=${COOLIFY_IMAGE_TAG}" >> .env
+  fi
+  log "OK: Coolify image tag ${COOLIFY_IMAGE_TAG}"
+
+  if [[ ! -f "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal" ]]; then
+    ssh-keygen -t ed25519 -f "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal" -N "" -q
+  fi
+  mkdir -p ~/.ssh
+  cat "$COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub" >> ~/.ssh/authorized_keys
+  if [[ -d /root/.ssh ]]; then
+    sudo sh -c "cat $COOLIFY_DATA_DIR/ssh/keys/id.root@host.docker.internal.pub >> /root/.ssh/authorized_keys"
+  fi
+  printf 'services:\n  coolify:\n    extra_hosts:\n      - "host.docker.internal:host-gateway"\n' \
+    > docker-compose.override.yml
+  sudo chown -R 9999:9999 "$COOLIFY_DATA_DIR/ssh"
+  docker network create --attachable coolify >/dev/null 2>&1 || true
+  log "OK: prepare complete"
+}
+
+step_ssh() {
+  log "PLAN: enable passwordless root SSH on localhost"
+  log "DO: start sshd and install runner key"
+  sudo systemctl enable ssh
+  sudo systemctl start ssh
+  if [[ ! -f ~/.ssh/id_ed25519 ]]; then
+    ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -q
+  fi
+  mkdir -p ~/.ssh
+  cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+  chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys
+  sudo sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+  sudo systemctl restart ssh
+  sudo mkdir -p /root/.ssh
+  sudo cp ~/.ssh/authorized_keys /root/.ssh/authorized_keys
+  sudo chmod 700 /root/.ssh
+  sudo chmod 600 /root/.ssh/authorized_keys
+  ssh -o StrictHostKeyChecking=no -o BatchMode=yes root@localhost echo "Root SSH OK"
+  log "OK: root SSH works"
+}
+
+step_pull() {
+  log "PLAN: pull Coolify images (no container recreate)"
+  cd "$SOURCE_DIR"
+  log "DO: docker compose pull"
+  compose pull
+  log "OK: images pulled"
+}
+
+step_pull_bg() {
+  log "PLAN: start Coolify image pull in background"
+  mkdir -p "$PULL_DIR"
+  rm -f "$PULL_DIR/exit" "$PULL_DIR/log"
+  cd "$SOURCE_DIR"
+  log "DO: nohup docker compose pull (markers in $PULL_DIR)"
+  # Marker file so wait-pull can poll across GitHub Actions steps (wait(1)
+  # only works for children of the same shell). $1/$2 expand in the child.
+  # shellcheck disable=SC2016
+  nohup bash -c '
+    set +e
+    cd "$1"
+    docker compose --env-file .env \
+      -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.override.yml \
+      pull
+    echo $? > "$2/exit"
+  ' bash "$SOURCE_DIR" "$PULL_DIR" >"$PULL_DIR/log" 2>&1 &
+  echo $! >"$PULL_DIR/pid"
+  log "OK: pull started pid=$(cat "$PULL_DIR/pid")"
+  log "NEXT: call wait-pull after overlapping setup"
+}
+
+step_wait_pull() {
+  log "PLAN: wait for background Coolify image pull"
+  if [[ ! -d "$PULL_DIR" ]]; then
+    log "OK: no background pull (caller will pull in the foreground)"
+    return 0
+  fi
+  if [[ -f "$PULL_DIR/exit" ]]; then
+    local rc
+    rc="$(cat "$PULL_DIR/exit")"
+    if [[ "$rc" != "0" ]]; then
+      log "FAIL: background pull already exited $rc"
+      tail -n 50 "$PULL_DIR/log" || true
+      exit "$rc"
+    fi
+    log "OK: background pull already finished"
+    return 0
+  fi
+  local i=0
+  while [[ ! -f "$PULL_DIR/exit" ]]; do
+    i=$((i + 1))
+    if (( i % 5 == 0 )); then
+      log "WAIT: docker compose pull still running (${i}s)"
+    fi
+    if (( i > 600 )); then
+      log "FAIL: pull did not finish in 10 minutes"
+      tail -n 80 "$PULL_DIR/log" || true
+      exit 1
+    fi
+    sleep 1
+  done
+  local rc
+  rc="$(cat "$PULL_DIR/exit")"
+  if [[ "$rc" != "0" ]]; then
+    log "FAIL: docker compose pull exited $rc"
+    tail -n 80 "$PULL_DIR/log" || true
+    exit "$rc"
+  fi
+  log "OK: background pull finished"
+}
+
+step_up() {
+  log "PLAN: start Coolify stack from already-pulled images"
+  cd "$SOURCE_DIR"
+  log "DO: docker compose up -d --remove-orphans"
+  compose up -d --remove-orphans
+  log "OK: compose up returned"
+}
+
+step_wait_ready() {
+  log "PLAN: poll Coolify /register until HTTP 200 or 302"
+  local i
+  for i in $(seq 1 "$READY_TRIES"); do
+    if curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/register 2>/dev/null | grep -qE "200|302"; then
+      log "OK: Coolify is ready (attempt $i)"
+      return 0
+    fi
+    if (( i % 5 == 0 )); then
+      log "WAIT: /register not ready (attempt $i/$READY_TRIES)"
+    fi
+    sleep 2
+  done
+  log "FAIL: Coolify not ready after $READY_TRIES attempts"
+  docker compose -f "$SOURCE_DIR/docker-compose.yml" logs --tail=50 || true
+  exit 1
+}
+
+step_prepare_pull_bg() {
+  step_prepare
+  step_ssh
+  step_pull_bg
+}
+
+case "$STEP" in
+  prepare) step_prepare ;;
+  ssh) step_ssh ;;
+  pull) step_pull ;;
+  pull-bg) step_pull_bg ;;
+  wait-pull) step_wait_pull ;;
+  up) step_up ;;
+  wait-ready) step_wait_ready ;;
+  prepare-pull-bg) step_prepare_pull_bg ;;
+  *)
+    echo "error: unknown step '$STEP'" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/ci-unit-packages.sh
+++ b/scripts/ci-unit-packages.sh
@@ -37,8 +37,13 @@ fi
 # names fall through to the general round-robin so application does not also
 # carry scheduledtask+storage+deployment on a 3-wide matrix (PR #729 Test(0)
 # was 10.5m vs ~6m for the other shards).
+#
+# On 4+ shards, application is also added to shard 1. CI compiles complementary
+# test-file slices with -tags=ci_app_a (shard 0) and -tags=ci_app_b (shard 1)
+# so the ~10m application UnitTest package is no longer a single-job floor.
+APP_PKG="github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
 heavy_pins=(
-  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
+  "$APP_PKG"
   "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service"
   "github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/redis"
   "github.com/coolify-terraform/terraform-provider-coolify/internal/service/scheduledtask"
@@ -82,6 +87,15 @@ for pkg in "${heavy_pins[@]}"; do
   fi
   pin_i=$((pin_i + 1))
 done
+
+# 2b) Split application across shards 0 and 1 when the matrix is wide enough.
+# Shard 0 already has it from the exclusive pin. Shard 1 runs the complementary
+# test files (see ci.yml -tags=ci_app_b) in the same gotestsum as service.
+if (( count >= 4 && shard == 1 )); then
+  if pkg_in_module "$APP_PKG"; then
+    printf '%s\n' "$APP_PKG" >>"$selected_file"
+  fi
+fi
 
 # 2) Remaining packages: stable sorted order, round-robin into shards.
 rest_i=0

--- a/scripts/test_ci_coolify_boot.py
+++ b/scripts/test_ci_coolify_boot.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ci-coolify-boot.sh (no Docker required)."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci-coolify-boot.sh"
+
+
+def run_boot(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=merged,
+    )
+
+
+class TestCICoolifyBoot(unittest.TestCase):
+    def test_script_is_executable(self) -> None:
+        mode = SCRIPT.stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR, "ci-coolify-boot.sh must be executable")
+
+    def test_usage_without_step(self) -> None:
+        proc = run_boot()
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("usage:", proc.stderr)
+
+    def test_unknown_step(self) -> None:
+        proc = run_boot("not-a-step")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("unknown step", proc.stderr)
+
+    def test_wait_pull_without_marker_is_ok(self) -> None:
+        proc = run_boot("wait-pull", env={"COOLIFY_PULL_DIR": "/tmp/coolify-pull-missing-for-test"})
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("no background pull", proc.stdout)
+
+    def test_wait_ready_fails_fast_when_nothing_listens(self) -> None:
+        proc = run_boot("wait-ready", env={"COOLIFY_READY_TRIES": "2"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("FAIL: Coolify not ready", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_unit_packages.py
+++ b/scripts/test_ci_unit_packages.py
@@ -48,6 +48,7 @@ class TestCIUnitPackages(unittest.TestCase):
         self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
 
     def test_four_shards_partition_all_packages(self) -> None:
+        app = "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
         shards = [run_shard(i, 4) for i in range(4)]
         union: list[str] = []
         for s in shards:
@@ -61,8 +62,15 @@ class TestCIUnitPackages(unittest.TestCase):
             text=True,
         ).stdout.splitlines()
         all_pkgs = sorted(p for p in all_pkgs if "/tools" not in p)
-        self.assertEqual(sorted(union), all_pkgs)
-        self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
+        # Application is intentionally on shards 0 and 1 (complementary
+        # ci_app_a / ci_app_b test-file slices). Other packages stay unique.
+        self.assertIn(app, shards[0])
+        self.assertIn(app, shards[1])
+        self.assertNotIn(app, shards[2])
+        self.assertNotIn(app, shards[3])
+        unique = [p for p in union if p != app]
+        self.assertEqual(len(unique), len(set(unique)), "non-application packages must not overlap shards")
+        self.assertEqual(sorted(set(union)), all_pkgs)
 
     def test_application_not_stacked_with_next_heavies(self) -> None:
         app = "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
@@ -89,6 +97,33 @@ class TestCIUnitPackages(unittest.TestCase):
                 if other == want_shard:
                     continue
                 self.assertNotIn(pkg, run_shard(other, 3))
+
+    def test_application_test_files_have_complementary_build_tags(self) -> None:
+        app_dir = ROOT / "internal" / "service" / "application"
+        tagged_a: list[str] = []
+        tagged_b: list[str] = []
+        untagged: list[str] = []
+        for path in sorted(app_dir.glob("*_test.go")):
+            first = path.read_text(encoding="utf-8").splitlines()[0]
+            if first == "//go:build !ci_app_b":
+                tagged_a.append(path.name)
+            elif first == "//go:build !ci_app_a":
+                tagged_b.append(path.name)
+            elif first.startswith("//go:build"):
+                self.fail(f"{path.name} has unexpected build tag: {first}")
+            else:
+                untagged.append(path.name)
+
+        self.assertIn("resource_test.go", tagged_a)
+        self.assertIn("resource_github_app_test.go", tagged_a)
+        self.assertIn("resource_docker_test.go", tagged_b)
+        self.assertIn("resource_dockerfile_test.go", tagged_b)
+        self.assertIn("resource_private_git_test.go", tagged_b)
+        self.assertIn("testing_helpers_test.go", untagged)
+        helper = (app_dir / "testing_helpers_test.go").read_text(encoding="utf-8")
+        self.assertIn("func decodeRequestBodyMap(", helper)
+        self.assertGreater(len(tagged_a), 0)
+        self.assertGreater(len(tagged_b), 0)
 
     def test_bad_args(self) -> None:
         bad = [


### PR DESCRIPTION
## Summary

Cut the two remaining CI wall-clock floors: the application unit-test package (~10 minutes on Test(0)) and Coolify bootstrap on Acceptance Tests.

## Problem

After #731, Test(0) was still ~10 minutes because `internal/service/application` is one Go package. Extra shards cannot split a single `go test` binary. Acceptance stayed ~10.5 minutes because `setup-coolify` pulled images only after Go/Terraform setup, then ran `docker compose up --pull always --force-recreate` and waited before installing Playwright.

## Change

**1. Split application unit tests across shards 0 and 1**

- Complementary build tags (`ci_app_a` / `ci_app_b`) on the heavy UnitTest files.
- Shared `decodeRequestBodyMap` moved to an untagged helper so both slices compile.
- Shard 1 also selects the application package; `gotestsum -p 4` can run it next to `service`.
- Local `go test` (no tags) still runs the full package.

**2. Speed Coolify boot**

- New `scripts/ci-coolify-boot.sh` with short steps and phase logs.
- Acceptance, scenario, nightly, and cloud-bootstrap jobs start `prepare-pull-bg` right after checkout so image pull overlaps setup-go and Terraform.
- `up -d --remove-orphans` only (no `--pull always`, no `--force-recreate` on a fresh runner).
- Playwright install runs after `up` and before the /register wait, so browser deps overlap Laravel boot.
- Ready poll is every 2s instead of 5s.

## Validation

- `python3 -m unittest` for `test_ci_unit_packages.py` and `test_ci_coolify_boot.py`: pass
- `go test -tags=ci_app_a -list` shows `TestApplicationResource_Create` and `TestGitHubAppApplicationResource_Create`, not the docker/dockerfile/private-git Create tests
- `go test -tags=ci_app_b -list` shows the complementary Create tests
- Both slices compile (`go test -c`)
- `shellcheck` on the new boot script and updated shard script
- `actionlint` only reports the known `code-quality` permission (#445)

Release PR #687 is untouched.
