### PR TITLE
fix: bump Go 1.26.5 to 1.26.6 for stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coolify-terraform/terraform-provider-coolify
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8


### PR DESCRIPTION
## Summary

Unblock main CI Lint after #732. `govulncheck` started failing on six Go standard-library CVEs that exist in 1.26.5 and are fixed in 1.26.6.

## Problem

Post-merge run [31750084775](https://github.com/coolify-terraform/terraform-provider-coolify/actions/runs/31750084775) failed Govulncheck:

- GO-2026-6218 `net/url`
- GO-2026-6091 `html/template`
- GO-2026-6090 `crypto/tls`
- GO-2026-6089 `net/http`
- GO-2026-6088 `encoding/xml`
- GO-2026-5972 `encoding/asn1`

This is not a #732 product regression. The advisory landed (or the vuln DB updated) between the PR Lint job and the main Lint job.

## Change

`go.mod`: `go 1.26.5` to `go 1.26.6`. CI already uses `go-version-file: go.mod`.

## Validation

Local `GOTOOLCHAIN=go1.26.6 govulncheck ./...`: no vulnerabilities found.

Release PR #687 is untouched.
