### PR TITLE
ci: shard acceptance tests across two Coolify jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
               - 'scripts/ci-unit-packages.sh'
+              - 'scripts/ci-acc-packages.sh'
               - 'scripts/ci-coolify-boot.sh'
               - '.codecov.yml'
               - '.goreleaser.yml'
@@ -730,12 +731,19 @@ jobs:
         needs.changes.outputs.scripts == 'true' ||
         github.event_name == 'workflow_dispatch'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two Coolify instances. Application acc is pinned on shard 0;
+        # service acc on shard 1; remaining TestAcc packages round-robin.
+        shard: [0, 1]
     permissions:
       contents: read
       # Playwright browser cache save in setup-coolify.
       actions: write
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
+      ACC_SHARD_COUNT: "2"
     steps:
       - name: Harden runner
         if: runner.os == 'Linux'
@@ -811,17 +819,22 @@ jobs:
           set +a
           export TF_ACC=1
 
+          mapfile -t pkgs < <(bash scripts/ci-acc-packages.sh "${{ matrix.shard }}" "${ACC_SHARD_COUNT}")
+          echo "Acc shard ${{ matrix.shard }}/${ACC_SHARD_COUNT}: ${#pkgs[@]} packages"
+          printf '  %s\n' "${pkgs[@]}"
+          pkg_list="${pkgs[*]}"
+
           mkdir -p test-results
           gotestsum \
             --format pkgname \
-            --junitfile test-results/acceptance.xml \
-            --packages ./internal/service/... \
+            --junitfile "test-results/acceptance-shard-${{ matrix.shard }}.xml" \
+            --packages "$pkg_list" \
             -- -run TestAcc -race -count=1 -timeout=30m -parallel=1
       - name: Upload acceptance test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: acceptance-test-results
+          name: acceptance-test-results-shard-${{ matrix.shard }}
           path: test-results/
           retention-days: 14
 
@@ -834,7 +847,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: coolify-logs-acceptance-tests
+          name: coolify-logs-acceptance-tests-shard-${{ matrix.shard }}
           path: /tmp/coolify-logs.txt
           retention-days: 7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,8 +232,8 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 Detect Changes, DCO (PR only), Test (4 package shards), Coverage (merge shards),
 Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
-Acceptance Tests, Scenario Tests, Contract Freshness (weekly only), CI (gate).
-Acceptance Tests bootstrap a fresh Coolify instance on ubuntu-latest and run the full suite.
+Acceptance Tests (2 shards), Scenario Tests, Contract Freshness (weekly only), CI (gate).
+Acceptance Tests boot two Coolify instances and split TestAcc packages across them.
 Scenario Tests bootstrap Coolify and run `terraform test` against it.
 A separate Dependabot Auto-Merge workflow auto-merges minor/patch PRs.
 An Issue Triage workflow auto-labels new issues (`needs-triage` or `ready`).

--- a/scripts/ci-acc-packages.sh
+++ b/scripts/ci-acc-packages.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Emit Go package import paths that contain TestAcc tests for one CI
+# acceptance-test shard.
+#
+# Usage:
+#   scripts/ci-acc-packages.sh <shard_index> <shard_count>
+#
+# Design:
+# - Only packages under ./internal/service/... with a TestAcc function.
+#   Matches the existing CI gotestsum --packages ./internal/service/... filter.
+# - Pin the heaviest acc packages onto different shards first.
+# - Round-robin the rest so new packages do not all land on shard 0.
+#
+# Exit non-zero if a shard would be empty (misconfiguration).
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <shard_index> <shard_count>" >&2
+  exit 2
+fi
+
+shard="$1"
+count="$2"
+
+if ! [[ "$shard" =~ ^[0-9]+$ && "$count" =~ ^[0-9]+$ ]]; then
+  echo "error: shard_index and shard_count must be non-negative integers" >&2
+  exit 2
+fi
+if (( count < 1 || shard < 0 || shard >= count )); then
+  echo "error: need 0 <= shard_index < shard_count (got shard=$shard count=$count)" >&2
+  exit 2
+fi
+
+# Heaviest acceptance packages by TestAcc surface and Coolify work
+# (application CRUD + integration, compose services, then databases).
+# Only the first $count existing entries are exclusive pins.
+heavy_pins=(
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/application"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/service"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/postgresql"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/environmentvariable"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/deployment"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/scheduledtask"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/githubapp"
+  "github.com/coolify-terraform/terraform-provider-coolify/internal/service/storage"
+)
+
+all_pkgs_file="$(mktemp)"
+acc_pkgs_file="$(mktemp)"
+selected_file="$(mktemp)"
+assigned_file="$(mktemp)"
+trap 'rm -f "$all_pkgs_file" "$acc_pkgs_file" "$selected_file" "$assigned_file"' EXIT
+
+go list ./internal/service/... | LC_ALL=C sort >"$all_pkgs_file"
+module="$(go list -m)"
+
+pkg_has_testacc() {
+  local pkg="$1"
+  local rel="${pkg#"$module"/}"
+  local files=()
+  local f
+  # nullglob: packages without _test.go must not leave a literal glob.
+  shopt -s nullglob
+  files=("$rel"/*_test.go)
+  shopt -u nullglob
+  if (( ${#files[@]} == 0 )); then
+    return 1
+  fi
+  for f in "${files[@]}"; do
+    if grep -qE '^func TestAcc' "$f"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+while IFS= read -r pkg; do
+  if pkg_has_testacc "$pkg"; then
+    printf '%s\n' "$pkg" >>"$acc_pkgs_file"
+  fi
+done <"$all_pkgs_file"
+
+if [[ ! -s "$acc_pkgs_file" ]]; then
+  echo "error: no TestAcc packages found under ./internal/service/..." >&2
+  exit 1
+fi
+
+pkg_in_acc() {
+  grep -Fxq "$1" "$acc_pkgs_file"
+}
+
+# 1) Exclusive pin: first `count` existing heavies, one per shard.
+pin_i=0
+for pkg in "${heavy_pins[@]}"; do
+  if ! pkg_in_acc "$pkg"; then
+    continue
+  fi
+  if (( pin_i >= count )); then
+    break
+  fi
+  printf '%s\n' "$pkg" >>"$assigned_file"
+  if (( pin_i == shard )); then
+    printf '%s\n' "$pkg" >>"$selected_file"
+  fi
+  pin_i=$((pin_i + 1))
+done
+
+# 2) Remaining acc packages: stable sorted order, round-robin into shards.
+rest_i=0
+while IFS= read -r pkg; do
+  if grep -Fxq "$pkg" "$assigned_file" 2>/dev/null; then
+    continue
+  fi
+  target=$((rest_i % count))
+  rest_i=$((rest_i + 1))
+  if (( target == shard )); then
+    printf '%s\n' "$pkg" >>"$selected_file"
+  fi
+done <"$acc_pkgs_file"
+
+if [[ ! -s "$selected_file" ]]; then
+  echo "error: shard $shard of $count selected zero packages" >&2
+  exit 1
+fi
+
+cat "$selected_file"

--- a/scripts/test_ci_acc_packages.py
+++ b/scripts/test_ci_acc_packages.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ci-acc-packages.sh."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci-acc-packages.sh"
+MODULE = "github.com/coolify-terraform/terraform-provider-coolify"
+
+
+def run_shard(shard: int, count: int) -> list[str]:
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), str(shard), str(count)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    return [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+def acc_packages() -> list[str]:
+    listed = subprocess.run(
+        ["go", "list", "./internal/service/..."],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    out: list[str] = []
+    for pkg in listed:
+        rel = Path(pkg.removeprefix(MODULE + "/"))
+        if any(
+            "func TestAcc" in line
+            for test in (ROOT / rel).glob("*_test.go")
+            for line in test.read_text(encoding="utf-8").splitlines()
+        ):
+            out.append(pkg)
+    return sorted(out)
+
+
+class TestCIAccPackages(unittest.TestCase):
+    def test_script_is_executable(self) -> None:
+        self.assertTrue(SCRIPT.stat().st_mode & stat.S_IXUSR)
+
+    def test_two_shards_partition_all_acc_packages(self) -> None:
+        shards = [run_shard(i, 2) for i in range(2)]
+        union: list[str] = []
+        for s in shards:
+            self.assertGreater(len(s), 0, "shard must not be empty")
+            union.extend(s)
+        want = acc_packages()
+        self.assertGreater(len(want), 10)
+        self.assertEqual(sorted(union), want)
+        self.assertEqual(len(union), len(set(union)), "packages must not overlap shards")
+
+    def test_application_and_service_land_on_distinct_shards(self) -> None:
+        app = f"{MODULE}/internal/service/application"
+        svc = f"{MODULE}/internal/service/service"
+        shard0 = set(run_shard(0, 2))
+        shard1 = set(run_shard(1, 2))
+        self.assertIn(app, shard0)
+        self.assertNotIn(app, shard1)
+        self.assertIn(svc, shard1)
+        self.assertNotIn(svc, shard0)
+
+    def test_only_service_packages_with_testacc(self) -> None:
+        for pkg in run_shard(0, 2) + run_shard(1, 2):
+            self.assertTrue(
+                pkg.startswith(f"{MODULE}/internal/service/"),
+                pkg,
+            )
+            self.assertNotIn("/tools", pkg)
+
+    def test_bad_args(self) -> None:
+        bad = [[], ["0"], ["0", "0"], ["2", "2"], ["x", "2"]]
+        for args in bad:
+            with self.subTest(args=args):
+                proc = subprocess.run(
+                    ["bash", str(SCRIPT), *args],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(proc.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Split PR/main Acceptance Tests across two GitHub-hosted runners so the remaining ~9 minute `TestAcc` wall can overlap.

## Problem

After #732, Coolify boot is ~1.5-2 minutes. Acceptance stays ~11 minutes because `gotestsum --packages ./internal/service/... -run TestAcc` is ~9 minutes on one runner. See #733.

## Change

- `scripts/ci-acc-packages.sh` lists only `internal/service` packages that define `TestAcc`.
- Exclusive pins: application on shard 0, service on shard 1. Everything else round-robins.
- Each shard boots its own Coolify (same `setup-coolify` path as today).
- Artifact names are per-shard.
- Nightly stays one full suite per Coolify image so we do not double that matrix.

Keep `-parallel=1` inside a package (TSAN + terraform fork). Package-level `-p` is unchanged.

## Validation

- `python3 -m unittest scripts/test_ci_acc_packages.py`: partition, exclusive pins, bad args
- `shellcheck` on the new script
- Local shard lists cover every TestAcc service package with no overlap

Closes #733
