### PR TITLE
fix: floor acc skips, shared env key validation, and docs counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 67 data sources, 1380+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 67 data sources, 1390+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1380+ tests (unit + acceptance)
+- 1390+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -155,6 +155,8 @@ counts-check: ## Verify AGENTS.md, README.md, and TESTING.md resource/data sourc
 	d_actual=$$(sed -n '/func.*DataSources.*\[\]func.*datasource\.DataSource/,/^}/p' internal/provider/provider.go | grep -o 'New[A-Za-z]*' | wc -l | tr -d ' '); \
 	r_doc=$$(grep -Eo '^[0-9]+ resources' AGENTS.md | grep -Eo '^[0-9]+'); \
 	d_doc=$$(grep -Eo '[0-9]+ data sources' AGENTS.md | grep -Eo '^[0-9]+'); \
+	r_readme=$$(grep -E '^\| Managed resources \| [0-9]+' README.md | grep -Eo '[0-9]+'); \
+	d_readme=$$(grep -E '^\| Data sources \| [0-9]+' README.md | grep -Eo '[0-9]+'); \
 	t_actual=$$(grep -r 'func Test' --include='*_test.go' . | wc -l | tr -d ' '); \
 	t_floor=$$(( (t_actual / 10) * 10 )); \
 	t_agents=$$(grep -Eo '[0-9]+\+ tests' AGENTS.md | head -1 | grep -Eo '^[0-9]+'); \
@@ -162,6 +164,8 @@ counts-check: ## Verify AGENTS.md, README.md, and TESTING.md resource/data sourc
 	ok=true; \
 	if [ "$$r_actual" != "$$r_doc" ]; then echo "AGENTS.md says $$r_doc resources but provider.go has $$r_actual"; ok=false; fi; \
 	if [ "$$d_actual" != "$$d_doc" ]; then echo "AGENTS.md says $$d_doc data sources but provider.go has $$d_actual"; ok=false; fi; \
+	if [ -n "$$r_readme" ] && [ "$$r_actual" != "$$r_readme" ]; then echo "README.md says $$r_readme resources but provider.go has $$r_actual"; ok=false; fi; \
+	if [ -n "$$d_readme" ] && [ "$$d_actual" != "$$d_readme" ]; then echo "README.md says $$d_readme data sources but provider.go has $$d_actual"; ok=false; fi; \
 	if [ -n "$$t_agents" ] && [ "$$t_agents" -gt "$$t_floor" ]; then echo "AGENTS.md says $$t_agents+ tests but actual is $$t_actual (floor $$t_floor)"; ok=false; fi; \
 	if [ -n "$$t_readme" ] && [ "$$t_readme" -gt "$$t_floor" ]; then echo "README.md says $$t_readme+ tests but actual is $$t_actual (floor $$t_floor)"; ok=false; fi; \
 	j_actual=$$(sed -n '/^jobs:/,$$p' .github/workflows/ci.yml | grep -cE '^  [a-z][a-z_-]*:' | tr -d ' '); \

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 | `coolify_server_proxy` | Manage server proxy settings (Coolify >= v4.3.0) |
 | `coolify_server_log_drain` | Manage server log drains (Coolify >= v4.3.0) |
 | `coolify_server_cloudflare_tunnel` | Manage server Cloudflare tunnel (Coolify >= v4.3.0) |
-| `coolify_server_sentinel` | Manage Sentinel host metrics settings (Coolify >= v4.1.1) |
+| `coolify_server_sentinel` | Manage Sentinel host metrics settings (Coolify >= v4.3.0) |
 | `coolify_server_docker_cleanup` | Manage Docker cleanup schedule (Coolify >= v4.3.0) |
 | `coolify_application_destination` | Attach an extra destination to an application (Coolify >= v4.2.0) |
 | `coolify_notification_email` | Team email notification settings (Coolify >= v4.3.0) |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 
 | Area | Coverage |
 |---|---|
-| Managed resources | 45 |
-| Data sources | 62 |
+| Managed resources | 56 |
+| Data sources | 67 |
 | Tests | 1380+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 67 |
-| Tests | 1380+ unit and acceptance tests |
+| Tests | 1390+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -331,7 +331,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1380+ tests, race detector enabled)
+make test                                       # Run unit tests (1390+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/TESTING.md
+++ b/TESTING.md
@@ -391,7 +391,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 | `coolify_server_proxy` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.3.0; destroy leaves remote config |
 | `coolify_server_log_drain` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.3.0; destroy disables drains |
 | `coolify_server_cloudflare_tunnel` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.3.0 |
-| `coolify_server_sentinel` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.1.1 |
+| `coolify_server_sentinel` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.3.0 |
 | `coolify_server_docker_cleanup` | Unit | Yes | Yes | Yes | Requires Coolify >= v4.3.0; destroy leaves schedule |
 | `coolify_application_destination` | Unit | Yes | N/A | Yes | Extra destination only; requires Coolify >= v4.2.0 |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -461,7 +461,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 45/45 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 142
+- **Total acceptance test functions**: 143
 
 ### Testing strategies for edge cases
 

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -91,6 +91,8 @@ needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
 | `coolify_notification_telegram` | Team Telegram notification settings |
 | `coolify_notification_webhook` | Team generic webhook notification settings |
 | `coolify_notification_pushover` | Team Pushover notification settings |
+| `coolify_server_sentinel` | Sentinel host metrics agent (GET/PATCH `/servers/{uuid}/sentinel`) |
+| `coolify_environment` `description` | Create still works on 4.1.x without description; PATCH description is 4.3.0+ |
 
 Server host version probes (`compose_version`, `docker_version`, and `*_checked_at`)
 on `coolify_server` / cloud server resources and `coolify_server` / `coolify_servers`

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -33,7 +33,7 @@ resource "coolify_environment" "example" {
 
 ### Optional
 
-- `description` (String) A description of the environment. Sent on PATCH after create (Coolify create rejects description) and on subsequent updates.
+- `description` (String) A description of the environment. Sent on PATCH after create (Coolify create rejects description) and on subsequent updates. Requires Coolify >= v4.3.0; omit on older instances or create fails with a 404 on the PATCH.
 
 ### Read-Only
 

--- a/docs/resources/server_sentinel.md
+++ b/docs/resources/server_sentinel.md
@@ -3,12 +3,12 @@
 page_title: "coolify_server_sentinel Resource - coolify"
 subcategory: ""
 description: |-
-  Manages Coolify Sentinel (host metrics agent) settings for a server. Available on Coolify >= v4.1.1. Destroy sets is_sentinel_enabled to false.
+  Manages Coolify Sentinel (host metrics agent) settings for a server. Requires Coolify >= v4.3.0 (GET/PATCH /servers/{uuid}/sentinel). Destroy sets is_sentinel_enabled to false.
 ---
 
 # coolify_server_sentinel (Resource)
 
-Manages Coolify Sentinel (host metrics agent) settings for a server. Available on Coolify >= v4.1.1. Destroy sets is_sentinel_enabled to false.
+Manages Coolify Sentinel (host metrics agent) settings for a server. Requires Coolify >= v4.3.0 (GET/PATCH `/servers/{uuid}/sentinel`). Destroy sets is_sentinel_enabled to false.
 
 ## Example Usage
 

--- a/docs/resources/shared_environment_variable.md
+++ b/docs/resources/shared_environment_variable.md
@@ -25,7 +25,7 @@ resource "coolify_shared_environment_variable" "team" {
 
 ### Required
 
-- `key` (String) Variable name. Changing this forces a new resource.
+- `key` (String) Variable name. Letters, digits, underscores, and dots; must start with a letter or underscore. Hyphens are rejected by Coolify. Changing this forces a new resource.
 - `scope` (String) One of `team`, `project`, `environment`, or `server`. Changing this forces a new resource.
 
 ### Optional

--- a/internal/service/environment/resource.go
+++ b/internal/service/environment/resource.go
@@ -74,7 +74,7 @@ func (r *environmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: "A description of the environment. Sent on PATCH after create (Coolify create rejects description) and on subsequent updates.",
+				MarkdownDescription: "A description of the environment. Sent on PATCH after create (Coolify create rejects description) and on subsequent updates. Requires Coolify >= v4.3.0; omit on older instances or create fails with a 404 on the PATCH.",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/service/environment/resource_acc_test.go
+++ b/internal/service/environment/resource_acc_test.go
@@ -13,6 +13,8 @@ func TestAccEnvironmentResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
+	// Description is applied via PATCH /projects/{uuid}/environments/{name}, which landed in Coolify 4.3.0.
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 	name := acctest.RandomWithPrefix("tf-acc-env")
 
 	resource.Test(t, resource.TestCase{
@@ -84,6 +86,49 @@ resource "coolify_environment" "test" {
 	})
 }
 
+// TestAccEnvironmentResource_CreateNameOnly covers create/import on Coolify
+// versions that lack PATCH environment (floor 4.1.2). Description is omitted
+// so Create does not issue a follow-up PATCH.
+func TestAccEnvironmentResource_CreateNameOnly(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	name := acctest.RandomWithPrefix("tf-acc-env-name")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.AccCheckDestroy("coolify_project", "/api/v1/projects/"),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigProviderBlock() + fmt.Sprintf(`
+resource "coolify_project" "test" {
+  name = %[1]q
+}
+
+resource "coolify_environment" "test" {
+  project_uuid = coolify_project.test.uuid
+  name         = "staging"
+}
+`, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coolify_environment.test", "id"),
+					resource.TestCheckResourceAttr("coolify_environment.test", "name", "staging"),
+				),
+			},
+			{
+				ResourceName:            "coolify_environment.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"description"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["coolify_environment.test"]
+					return rs.Primary.Attributes["project_uuid"] + ":" + rs.Primary.Attributes["name"], nil
+				},
+			},
+		},
+	})
+}
+
 func TestAccEnvironmentDataSources(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
@@ -103,7 +148,6 @@ resource "coolify_project" "test" {
 resource "coolify_environment" "test" {
   project_uuid = coolify_project.test.uuid
   name         = "ds-test"
-  description  = "data source test"
 }
 
 data "coolify_environment" "test" {

--- a/internal/service/gitlabapp/data_source_test.go
+++ b/internal/service/gitlabapp/data_source_test.go
@@ -1,0 +1,108 @@
+package gitlabapp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestGitLabAppDataSource_Read(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/gitlab-apps", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+		  {"id":7,"uuid":"gggg0001-0001-4000-8000-000000000001","name":"corp-gitlab","html_url":"https://gitlab.example.com","api_url":"https://gitlab.example.com/api/v4"}
+		]`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "coolify_gitlab_app" "by_id" {
+  id = 7
+}
+
+data "coolify_gitlab_app" "by_uuid" {
+  uuid = "gggg0001-0001-4000-8000-000000000001"
+}
+
+data "coolify_gitlab_apps" "all" {}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.coolify_gitlab_app.by_id", "name", "corp-gitlab"),
+					resource.TestCheckResourceAttr("data.coolify_gitlab_app.by_id", "html_url", "https://gitlab.example.com"),
+					resource.TestCheckResourceAttr("data.coolify_gitlab_app.by_uuid", "id", "7"),
+					resource.TestCheckResourceAttr("data.coolify_gitlab_apps.all", "apps.#", "1"),
+					resource.TestCheckResourceAttr("data.coolify_gitlab_apps.all", "apps.0.name", "corp-gitlab"),
+				),
+			},
+		},
+	})
+}
+
+func TestGitLabAppDataSource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/gitlab-apps", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "coolify_gitlab_app" "test" {
+  id = 7
+}
+`,
+			ExpectError: regexp.MustCompile(`Error reading GitLab App`),
+		}},
+	})
+}
+
+func TestGitLabAppsListDataSource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/gitlab-apps", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "coolify_gitlab_apps" "all" {}
+`,
+			ExpectError: regexp.MustCompile(`Error listing GitLab Apps`),
+		}},
+	})
+}
+
+func TestGitLabAppDataSource_MissingLookup(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.NewServeMux()))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "coolify_gitlab_app" "test" {}
+`,
+			ExpectError: regexp.MustCompile(`set id or uuid`),
+		}},
+	})
+}

--- a/internal/service/gitlabapp/resource_test.go
+++ b/internal/service/gitlabapp/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"sync"
 	"testing"
 
@@ -131,6 +132,28 @@ resource "coolify_gitlab_app" "test" {
 				acctest.CheckPathDisappears(srv.URL, "/api/v1/gitlab-apps/7"),
 			),
 			ExpectNonEmptyPlan: true,
+		}},
+	})
+}
+
+func TestGitLabAppResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/gitlab-apps", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Validation failed."}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_gitlab_app" "test" {
+  name     = "corp-gitlab"
+  html_url = "https://gitlab.example.com"
+}`,
+			ExpectError: regexp.MustCompile(`Error creating GitLab App`),
 		}},
 	})
 }

--- a/internal/service/serversentinel/resource.go
+++ b/internal/service/serversentinel/resource.go
@@ -44,7 +44,7 @@ func (r *res) Metadata(_ context.Context, req resource.MetadataRequest, resp *re
 
 func (r *res) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages Coolify Sentinel (host metrics agent) settings for a server. Available on Coolify >= v4.1.1. Destroy sets is_sentinel_enabled to false.",
+		MarkdownDescription: "Manages Coolify Sentinel (host metrics agent) settings for a server. Requires Coolify >= v4.3.0 (GET/PATCH `/servers/{uuid}/sentinel`). Destroy sets is_sentinel_enabled to false.",
 		Attributes: map[string]schema.Attribute{
 			"server_uuid":                           schema.StringAttribute{Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}, Validators: []validator.String{validate.UUID()}},
 			"is_sentinel_enabled":                   schema.BoolAttribute{Optional: true, Computed: true},

--- a/internal/service/serversentinel/resource_acc_test.go
+++ b/internal/service/serversentinel/resource_acc_test.go
@@ -12,7 +12,8 @@ func TestAccServerSentinelResource_CRUD(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.TestAccPreCheck(t)
-	acctest.AccTestSkipIfCoolifyBelow(t, "4.1.1")
+	// GET/PATCH /servers/{uuid}/sentinel landed in Coolify 4.3.0 (absent from 4.1.2/4.2.0 contracts).
+	acctest.AccTestSkipIfCoolifyBelow(t, "4.3.0")
 	serverUUID := acctest.AccTestServerUUID(t)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/sharedenv/resource.go
+++ b/internal/service/sharedenv/resource.go
@@ -3,6 +3,7 @@ package sharedenv
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -57,10 +58,17 @@ func (r *sharedEnvResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"scope": schema.StringAttribute{Required: true, MarkdownDescription: "One of `team`, `project`, `environment`, or `server`. Changing this forces a new resource.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 				Validators:    []validator.String{stringvalidator.OneOf("team", "project", "environment", "server")}},
-			"project_uuid":  schema.StringAttribute{Optional: true, MarkdownDescription: "Required for project and environment scopes.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"environment":   schema.StringAttribute{Optional: true, MarkdownDescription: "Environment name or UUID. Required for environment scope.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"server_uuid":   schema.StringAttribute{Optional: true, MarkdownDescription: "Required for server scope.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
-			"key":           schema.StringAttribute{Required: true, MarkdownDescription: "Variable name. Changing this forces a new resource.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"project_uuid": schema.StringAttribute{Optional: true, MarkdownDescription: "Required for project and environment scopes.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"environment":  schema.StringAttribute{Optional: true, MarkdownDescription: "Environment name or UUID. Required for environment scope.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"server_uuid":  schema.StringAttribute{Optional: true, MarkdownDescription: "Required for server scope.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"key": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Variable name. Letters, digits, underscores, and dots; must start with a letter or underscore. Hyphens are rejected by Coolify. Changing this forces a new resource.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*$`), "must be a valid environment variable name (letters, digits, underscores, dots; cannot start with a digit; hyphens are not allowed)"),
+				},
+			},
 			"value":         schema.StringAttribute{Optional: true, Sensitive: true, MarkdownDescription: "Variable value. Preserved when GET omits it."},
 			"is_literal":    schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
 			"is_multiline":  schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},

--- a/internal/service/sharedenv/resource_test.go
+++ b/internal/service/sharedenv/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -272,4 +273,23 @@ resource "coolify_shared_environment_variable" "test" {
 			}
 		})
 	}
+}
+
+func TestSharedEnvResource_RejectsHyphenKey(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.NewServeMux()))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_shared_environment_variable" "test" {
+  scope = "team"
+  key   = "GLOBAL-FLAG"
+  value = "on"
+}`,
+			ExpectError: regexp.MustCompile(`hyphens are not allowed`),
+		}},
+	})
 }

--- a/internal/spectest/contract_skips.go
+++ b/internal/spectest/contract_skips.go
@@ -124,6 +124,11 @@ var scheduledTaskCoverageSkips = skipMap(
 
 var projectCoverageSkips = skipMap(
 	skipInternal("team_id", "FK"),
+	// Coolify tip (2026-08-13): UI-only project icons via Livewire + ProjectIconStorageService.
+	// Not on Project::$fillable or ProjectController create/update $allowedFields (name, description only).
+	skipInternal("icon_path", "UI-only project icon storage path; no public API write"),
+	skipInternal("icon_storage_type", "UI-only project icon disk (local/s3); no public API write"),
+	skipInternal("icon_s3_storage_id", "UI-only project icon S3 FK; no public API write"),
 )
 
 var githubAppCoverageSkips = skipMap(
@@ -164,6 +169,9 @@ var serverSettingCoverageSkips = skipMap(
 	skipNA("is_usable", "on Server entity, not Settings"),
 	skipNA("sentinel_metrics_refresh_rate_in_seconds", "old contract name; superseded by sentinel_metrics_refresh_rate_seconds"),
 	skipNA("sentinel_push_interval_in_seconds", "old contract name; superseded by sentinel_push_interval_seconds"),
+	// Coolify tip (2026-08-14): Livewire Server/Advanced + VolumeBackupJob only.
+	// Not on ServersController create/update $allowedFields.
+	skipInternal("backup_compression_cpu_percentage", "UI-only ServerSetting; not on ServersController allow list"),
 	// Remaining settings fields covered on client.ServerSettings + read-only server schema.
 )
 

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -91,6 +91,8 @@ needs Coolify >= 4.2.0; see [Connecting Resources](connecting-resources).
 | `coolify_notification_telegram` | Team Telegram notification settings |
 | `coolify_notification_webhook` | Team generic webhook notification settings |
 | `coolify_notification_pushover` | Team Pushover notification settings |
+| `coolify_server_sentinel` | Sentinel host metrics agent (GET/PATCH `/servers/{uuid}/sentinel`) |
+| `coolify_environment` `description` | Create still works on 4.1.x without description; PATCH description is 4.3.0+ |
 
 Server host version probes (`compose_version`, `docker_version`, and `*_checked_at`)
 on `coolify_server` / cloud server resources and `coolify_server` / `coolify_servers`


### PR DESCRIPTION
## Summary

Batch from one MPI cycle: stop floor 4.1.2 nightly acc from failing on 4.3-only routes, reject hyphenated shared env keys before apply, and keep README counts in lockstep with the provider.

## Problem

- Coolify Nightly Acc on 4.1.2 failed: environment description PATCH and Sentinel GET/PATCH only exist from Coolify 4.3.0. Schema/docs said Sentinel was 4.1.1.
- Shared env keys with hyphens reached the API and 422'd. Application env vars already validated this at plan time.
- README At a Glance still said 45 resources / 62 data sources after API parity landed at 56 / 67. `counts-check` never looked at that table.
- GitLab App (#752) had CRUD unit tests but no create-error or data-source coverage.

## Change

- Gate description CRUD acc at 4.3.0; add name-only environment acc for the floor; drop description from environment data-source acc.
- Gate Sentinel acc at 4.3.0 and correct schema, README, TESTING, and version-support docs.
- Classify #719 tip fields (`icon_*`, `backup_compression_cpu_percentage`) as UI-only and skip them in contract coverage.
- Validate shared env keys with Coolify's `ENVIRONMENT_VARIABLE_KEY_PATTERN`.
- Add GitLab App CreateAPIError plus singular/list data source unit tests.
- Teach `counts-check` to compare the README At a Glance table.

## Validation

- `make ci` (build, lint, test, validate, docs-check, counts-check, contract-compat, govulncheck, goreleaser-check, modverify)
- Targeted: `go test ./internal/service/environment/ ./internal/service/serversentinel/ ./internal/service/gitlabapp/ ./internal/service/sharedenv/ ./internal/spectest/`

## Issue reference

Ref #719 (channel watch stays open until pin/nightly/stable/tip align; tip drift classified, not a pin bump)
