### PR TITLE
feat: expose Coolify 4.3.3 tip GET fields

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -28,4 +28,6 @@ data "coolify_project" "example" {
 ### Read-Only
 
 - `description` (String) A description of the project.
+- `icon_path` (String) Storage path of the project icon uploaded in the Coolify UI. Read-only. Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3; omitted from the list endpoint and older instances.
+- `icon_storage_type` (String) Icon storage backend (`local` or `s3`). Read-only. Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3.
 - `name` (String) The name of the project.

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -27,6 +27,7 @@ data "coolify_server" "example" {
 
 ### Read-Only
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only. Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server.
 - `concurrent_builds` (Number) How many deployments can run in parallel on this server.

--- a/docs/data-sources/servers.md
+++ b/docs/data-sources/servers.md
@@ -45,6 +45,7 @@ Required:
 
 Read-Only:
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only. Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server.
 - `concurrent_builds` (Number) How many deployments can run in parallel on this server.

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -99,6 +99,15 @@ on `coolify_server` / cloud server resources and `coolify_server` / `coolify_ser
 data sources are populated on Coolify **≥ 4.3.2** after Coolify probes the host.
 Empty on older instances.
 
+Volume-backup CPU share (`backup_compression_cpu_percentage`) is a computed
+GET-only server setting on Coolify tip/nightly **4.3.3**. It is not on the
+public server PATCH allow list. Empty on older instances.
+
+Project icon attributes (`icon_path`, `icon_storage_type`) are computed on
+`coolify_project` and `data.coolify_project` from GET `/projects/{uuid}` on
+Coolify tip/nightly **4.3.3**. They are not writable and are omitted from
+`GET /projects` (list). Empty on older instances.
+
 ## Application attributes by Coolify version
 
 Application resources share one schema. Attributes that Coolify only accepts

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -32,6 +32,8 @@ resource "coolify_project" "example" {
 
 ### Read-Only
 
+- `icon_path` (String) Storage path of the project icon uploaded in the Coolify UI. Read-only; not on Project create/update allow list. Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3; omitted from the list endpoint and older instances.
+- `icon_storage_type` (String) Icon storage backend (`local` or `s3`). Read-only. Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3.
 - `uuid` (String) The unique identifier of the project.
 
 ## Import

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -64,6 +64,7 @@ resource "coolify_server" "example" {
 
 ### Read-Only
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only (not on public server PATCH). Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.

--- a/docs/resources/server_digitalocean.md
+++ b/docs/resources/server_digitalocean.md
@@ -73,6 +73,7 @@ variable "digitalocean_token" {
 
 ### Read-Only
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only (not on public server PATCH). Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -74,6 +74,7 @@ resource "coolify_server_hetzner" "example" {
 
 ### Read-Only
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only (not on public server PATCH). Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.

--- a/docs/resources/server_vultr.md
+++ b/docs/resources/server_vultr.md
@@ -73,6 +73,7 @@ variable "vultr_token" {
 
 ### Read-Only
 
+- `backup_compression_cpu_percentage` (Number) CPU percentage Coolify uses when compressing volume backups. Read-only (not on public server PATCH). Present on Coolify tip/nightly 4.3.3; empty on older instances.
 - `compose_version` (String) Docker Compose version reported by Coolify for this server (host probe). Read-only; Populated on Coolify >= v4.3.2 when the host has been probed. Empty on older instances.
 - `compose_version_checked_at` (String) When Coolify last checked the Compose version on this server. Read-only.
 - `delete_unused_networks` (Boolean) Whether to delete unused Docker networks during cleanup.

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -11,6 +11,11 @@ type Project struct {
 	UUID        string `json:"uuid"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	// Icon fields are returned on GET /projects/{uuid} via serializeApiResponse
+	// (Coolify tip/nightly 4.3.3). They are not on create/update $allowedFields
+	// and are omitted from GET /projects (list selects id,name,description,uuid).
+	IconPath        string `json:"icon_path,omitempty"`
+	IconStorageType string `json:"icon_storage_type,omitempty"`
 }
 
 type CreateProjectInput struct {

--- a/internal/client/projects_test.go
+++ b/internal/client/projects_test.go
@@ -1,0 +1,42 @@
+package client_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProject_IconJSON(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"uuid": "proj-1",
+		"name": "acme",
+		"description": "demo",
+		"icon_path": "project-icons/acme.png",
+		"icon_storage_type": "local"
+	}`)
+	var p client.Project
+	require.NoError(t, json.Unmarshal(raw, &p))
+	assert.Equal(t, "project-icons/acme.png", p.IconPath)
+	assert.Equal(t, "local", p.IconStorageType)
+
+	out, err := json.Marshal(p)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &m))
+	assert.Equal(t, "project-icons/acme.png", m["icon_path"])
+	assert.Equal(t, "local", m["icon_storage_type"])
+	_, hasFK := m["icon_s3_storage_id"]
+	assert.False(t, hasFK)
+}
+
+func TestProject_IconJSONAbsent(t *testing.T) {
+	t.Parallel()
+	var p client.Project
+	require.NoError(t, json.Unmarshal([]byte(`{"uuid":"p","name":"n"}`), &p))
+	assert.Empty(t, p.IconPath)
+	assert.Empty(t, p.IconStorageType)
+}

--- a/internal/client/servers.go
+++ b/internal/client/servers.go
@@ -56,6 +56,9 @@ type ServerSettings struct {
 	ComposeVersionCheckedAt string `json:"compose_version_checked_at,omitempty"`
 	DockerVersion           string `json:"docker_version,omitempty"`
 	DockerVersionCheckedAt  string `json:"docker_version_checked_at,omitempty"`
+	// CPU share for volume-backup compression (Coolify tip/nightly 4.3.3).
+	// Pointer so older GET payloads without the column stay null, not 0.
+	BackupCompressionCPUPercentage *int `json:"backup_compression_cpu_percentage,omitempty"`
 }
 
 type Server struct {

--- a/internal/client/servers_settings_test.go
+++ b/internal/client/servers_settings_test.go
@@ -21,13 +21,16 @@ func TestServerSettings_VersionProbeJSON(t *testing.T) {
 		"compose_version": "2.29.1",
 		"compose_version_checked_at": "2026-08-13T12:00:00.000000Z",
 		"docker_version": "27.0.3",
-		"docker_version_checked_at": "2026-08-13T12:00:01.000000Z"
+		"docker_version_checked_at": "2026-08-13T12:00:01.000000Z",
+		"backup_compression_cpu_percentage": 40
 	}`)
 	var s client.ServerSettings
 	require.NoError(t, json.Unmarshal(raw, &s))
 	assert.Equal(t, "2.29.1", s.ComposeVersion)
 	assert.Equal(t, "27.0.3", s.DockerVersion)
 	assert.Contains(t, s.ComposeVersionCheckedAt, "2026-08-13")
+	require.NotNil(t, s.BackupCompressionCPUPercentage)
+	assert.Equal(t, 40, *s.BackupCompressionCPUPercentage)
 
 	out, err := json.Marshal(s)
 	require.NoError(t, err)
@@ -35,4 +38,12 @@ func TestServerSettings_VersionProbeJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &m))
 	assert.Equal(t, "2.29.1", m["compose_version"])
 	assert.Equal(t, "27.0.3", m["docker_version"])
+	assert.Equal(t, float64(40), m["backup_compression_cpu_percentage"])
+}
+
+func TestServerSettings_BackupCompressionAbsent(t *testing.T) {
+	t.Parallel()
+	var s client.ServerSettings
+	require.NoError(t, json.Unmarshal([]byte(`{"concurrent_builds":1}`), &s))
+	assert.Nil(t, s.BackupCompressionCPUPercentage)
 }

--- a/internal/service/digitalocean/resource.go
+++ b/internal/service/digitalocean/resource.go
@@ -104,6 +104,7 @@ type digitalOceanServerResourceModel struct {
 	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
 	DockerVersion                     types.String `tfsdk:"docker_version"`
 	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
+	BackupCompressionCPUPercentage    types.Int64  `tfsdk:"backup_compression_cpu_percentage"`
 }
 
 // NewResource returns a new DigitalOcean server resource.
@@ -374,6 +375,7 @@ func (m *digitalOceanServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
 		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
 		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
+		BackupCompressionCPUPercentage: &m.BackupCompressionCPUPercentage,
 	}
 }
 

--- a/internal/service/hetzner/resource.go
+++ b/internal/service/hetzner/resource.go
@@ -102,6 +102,7 @@ type hetznerServerResourceModel struct {
 	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
 	DockerVersion                     types.String `tfsdk:"docker_version"`
 	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
+	BackupCompressionCPUPercentage    types.Int64  `tfsdk:"backup_compression_cpu_percentage"`
 }
 
 // NewResource returns a new Hetzner server resource.
@@ -367,6 +368,7 @@ func (m *hetznerServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
 		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
 		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
+		BackupCompressionCPUPercentage: &m.BackupCompressionCPUPercentage,
 	}
 }
 

--- a/internal/service/project/data_source.go
+++ b/internal/service/project/data_source.go
@@ -26,9 +26,11 @@ type projectDataSource struct {
 
 // projectDataSourceModel maps the data source schema data.
 type projectDataSourceModel struct {
-	UUID        types.String `tfsdk:"uuid"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
+	UUID            types.String `tfsdk:"uuid"`
+	Name            types.String `tfsdk:"name"`
+	Description     types.String `tfsdk:"description"`
+	IconPath        types.String `tfsdk:"icon_path"`
+	IconStorageType types.String `tfsdk:"icon_storage_type"`
 }
 
 // NewDataSource returns a new project data source instance.
@@ -57,6 +59,17 @@ func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				MarkdownDescription: "A description of the project.",
 				Computed:            true,
 			},
+			"icon_path": schema.StringAttribute{
+				MarkdownDescription: "Storage path of the project icon uploaded in the Coolify UI. " +
+					"Read-only. Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3; " +
+					"omitted from the list endpoint and older instances.",
+				Computed: true,
+			},
+			"icon_storage_type": schema.StringAttribute{
+				MarkdownDescription: "Icon storage backend (`local` or `s3`). Read-only. " +
+					"Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3.",
+				Computed: true,
+			},
 		},
 	}
 }
@@ -84,6 +97,8 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	config.UUID = types.StringValue(project.UUID)
 	config.Name = types.StringValue(project.Name)
 	config.Description = flex.StringToFramework(project.Description)
+	config.IconPath = flex.StringToFramework(project.IconPath)
+	config.IconStorageType = flex.StringToFramework(project.IconStorageType)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/internal/service/project/data_source_test.go
+++ b/internal/service/project/data_source_test.go
@@ -36,6 +36,8 @@ data "coolify_project" "test" {
 					),
 					resource.TestCheckResourceAttr("data.coolify_project.test", "name", "ds-test-project"),
 					resource.TestCheckResourceAttr("data.coolify_project.test", "description", "data source test"),
+					resource.TestCheckResourceAttr("data.coolify_project.test", "icon_path", "project-icons/test.png"),
+					resource.TestCheckResourceAttr("data.coolify_project.test", "icon_storage_type", "local"),
 				),
 			},
 		},

--- a/internal/service/project/resource.go
+++ b/internal/service/project/resource.go
@@ -32,9 +32,11 @@ type projectResource struct {
 
 // projectResourceModel maps the resource schema data.
 type projectResourceModel struct {
-	UUID        types.String `tfsdk:"uuid"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
+	UUID            types.String `tfsdk:"uuid"`
+	Name            types.String `tfsdk:"name"`
+	Description     types.String `tfsdk:"description"`
+	IconPath        types.String `tfsdk:"icon_path"`
+	IconStorageType types.String `tfsdk:"icon_storage_type"`
 }
 
 // NewResource returns a new project resource instance.
@@ -68,6 +70,17 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"icon_path": schema.StringAttribute{
+				MarkdownDescription: "Storage path of the project icon uploaded in the Coolify UI. " +
+					"Read-only; not on Project create/update allow list. Present on GET /projects/{uuid} " +
+					"on Coolify tip/nightly 4.3.3; omitted from the list endpoint and older instances.",
+				Computed: true,
+			},
+			"icon_storage_type": schema.StringAttribute{
+				MarkdownDescription: "Icon storage backend (`local` or `s3`). Read-only. " +
+					"Present on GET /projects/{uuid} on Coolify tip/nightly 4.3.3.",
+				Computed: true,
 			},
 		},
 	}
@@ -148,9 +161,7 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	state.UUID = types.StringValue(project.UUID)
-	state.Name = types.StringValue(project.Name)
-	state.Description = flex.StringToFramework(project.Description)
+	flattenProject(project, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -181,9 +192,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	plan.UUID = types.StringValue(project.UUID)
-	plan.Name = types.StringValue(project.Name)
-	plan.Description = flex.StringToFramework(project.Description)
+	flattenProject(project, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -231,9 +240,15 @@ func (r *projectResource) readProject(ctx context.Context, uuid string, model *p
 		return diags
 	}
 
-	model.UUID = types.StringValue(project.UUID)
-	model.Name = types.StringValue(project.Name)
-	model.Description = flex.StringToFramework(project.Description)
+	flattenProject(project, model)
 
 	return diags
+}
+
+func flattenProject(p *client.Project, model *projectResourceModel) {
+	model.UUID = types.StringValue(p.UUID)
+	model.Name = types.StringValue(p.Name)
+	model.Description = flex.StringToFramework(p.Description)
+	model.IconPath = flex.StringToFramework(p.IconPath)
+	model.IconStorageType = flex.StringToFramework(p.IconStorageType)
 }

--- a/internal/service/project/resource_test.go
+++ b/internal/service/project/resource_test.go
@@ -18,9 +18,11 @@ import (
 
 // mockProject stores project data in the mock server.
 type mockProject struct {
-	UUID        string `json:"uuid"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	UUID            string `json:"uuid"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	IconPath        string `json:"icon_path,omitempty"`
+	IconStorageType string `json:"icon_storage_type,omitempty"`
 }
 
 // newMockCoolifyServer creates an httptest.Server that simulates the Coolify API for projects.
@@ -117,9 +119,11 @@ func (s *mockProjectStore) Create(name, description string) *mockProject {
 	defer s.mu.Unlock()
 	s.counter++
 	p := &mockProject{
-		UUID:        fmt.Sprintf("cccc0000-0000-4000-8000-%012d", s.counter),
-		Name:        name,
-		Description: description,
+		UUID:            fmt.Sprintf("cccc0000-0000-4000-8000-%012d", s.counter),
+		Name:            name,
+		Description:     description,
+		IconPath:        "project-icons/test.png",
+		IconStorageType: "local",
 	}
 	s.projects[p.UUID] = p
 	return p
@@ -184,6 +188,8 @@ resource "coolify_project" "test" {
 					resource.TestCheckResourceAttrSet("coolify_project.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_project.test", "name", "my-project"),
 					resource.TestCheckResourceAttr("coolify_project.test", "description", "A test project"),
+					resource.TestCheckResourceAttr("coolify_project.test", "icon_path", "project-icons/test.png"),
+					resource.TestCheckResourceAttr("coolify_project.test", "icon_storage_type", "local"),
 				),
 			},
 			{

--- a/internal/service/server/common.go
+++ b/internal/service/server/common.go
@@ -67,6 +67,7 @@ type ServerCommonPtrs struct {
 	ComposeVersionCheckedAt           *types.String
 	DockerVersion                     *types.String
 	DockerVersionCheckedAt            *types.String
+	BackupCompressionCPUPercentage    *types.Int64
 }
 
 // CommonServerAttrs returns the schema attributes shared by all server
@@ -177,6 +178,7 @@ func addExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
 	addCoreExtendedSettingsAttrs(attrs)
 	addLogdrainSettingsAttrs(attrs)
 	addHostProbeVersionAttrs(attrs)
+	addBackupCompressionAttrs(attrs)
 }
 
 func addCoreExtendedSettingsAttrs(attrs map[string]schema.Attribute) {
@@ -347,6 +349,16 @@ func addHostProbeVersionAttrs(attrs map[string]schema.Attribute) {
 	}
 }
 
+// addBackupCompressionAttrs adds the Coolify tip/nightly 4.3.3 volume-backup
+// CPU share. GET settings include it; public server PATCH does not.
+func addBackupCompressionAttrs(attrs map[string]schema.Attribute) {
+	attrs["backup_compression_cpu_percentage"] = schema.Int64Attribute{
+		MarkdownDescription: "CPU percentage Coolify uses when compressing volume backups. " +
+			"Read-only (not on public server PATCH). Present on Coolify tip/nightly 4.3.3; empty on older instances.",
+		Computed: true,
+	}
+}
+
 // FlattenServerCommon sets the fields shared by all server resource types
 // from the API response.
 func FlattenServerCommon(srv *client.Server, f ServerCommonPtrs) {
@@ -421,6 +433,7 @@ func flattenExtendedSettings(s *client.ServerSettings, f ServerCommonPtrs) {
 	setStringPtr(f.ComposeVersionCheckedAt, s.ComposeVersionCheckedAt)
 	setStringPtr(f.DockerVersion, s.DockerVersion)
 	setStringPtr(f.DockerVersionCheckedAt, s.DockerVersionCheckedAt)
+	setIntPtr(f.BackupCompressionCPUPercentage, s.BackupCompressionCPUPercentage)
 }
 
 func setBoolPtr(dst *types.Bool, v bool) {
@@ -435,6 +448,17 @@ func setStringPtr(dst *types.String, v string) {
 		return
 	}
 	*dst = flex.StringToFramework(v)
+}
+
+func setIntPtr(dst *types.Int64, v *int) {
+	if dst == nil {
+		return
+	}
+	if v == nil {
+		*dst = types.Int64Null()
+		return
+	}
+	*dst = types.Int64Value(int64(*v))
 }
 
 // HasNonDefaultSettings returns true if any settings field in the plan

--- a/internal/service/server/common_test.go
+++ b/internal/service/server/common_test.go
@@ -34,6 +34,7 @@ func newTestPtrs() (ServerCommonPtrs, *testModel) {
 		DeleteUnusedNetworks: &m.DeleteUnusedNetworks, GenerateExactLabels: &m.GenerateExactLabels,
 		ComposeVersion: &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
 		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
+		BackupCompressionCPUPercentage: &m.BackupCompressionCPUPercentage,
 	}, m
 }
 
@@ -64,6 +65,7 @@ type testModel struct {
 	ComposeVersionCheckedAt           types.String
 	DockerVersion                     types.String
 	DockerVersionCheckedAt            types.String
+	BackupCompressionCPUPercentage    types.Int64
 }
 
 var readOnlyExtendedSettingNames = []string{
@@ -86,6 +88,7 @@ var readOnlyExtendedSettingNames = []string{
 	"compose_version_checked_at",
 	"docker_version",
 	"docker_version_checked_at",
+	"backup_compression_cpu_percentage",
 }
 
 var expectedWritableServerUpdateKeys = []string{
@@ -827,11 +830,13 @@ func TestHasNonDefaultSettings_NullFields(t *testing.T) {
 func TestFlattenExtendedSettings_DockerComposeVersions(t *testing.T) {
 	t.Parallel()
 	ptrs, m := newTestPtrs()
+	pct := 40
 	s := &client.ServerSettings{
-		ComposeVersion:          "2.29.1",
-		ComposeVersionCheckedAt: "2026-08-13T12:00:00.000000Z",
-		DockerVersion:           "27.0.3",
-		DockerVersionCheckedAt:  "2026-08-13T12:00:01.000000Z",
+		ComposeVersion:                 "2.29.1",
+		ComposeVersionCheckedAt:        "2026-08-13T12:00:00.000000Z",
+		DockerVersion:                  "27.0.3",
+		DockerVersionCheckedAt:         "2026-08-13T12:00:01.000000Z",
+		BackupCompressionCPUPercentage: &pct,
 	}
 	flattenExtendedSettings(s, ptrs)
 	if m.ComposeVersion.ValueString() != "2.29.1" {
@@ -842,5 +847,17 @@ func TestFlattenExtendedSettings_DockerComposeVersions(t *testing.T) {
 	}
 	if m.ComposeVersionCheckedAt.IsNull() || m.DockerVersionCheckedAt.IsNull() {
 		t.Fatal("checked_at fields should be set")
+	}
+	if m.BackupCompressionCPUPercentage.ValueInt64() != 40 {
+		t.Fatalf("backup_compression_cpu_percentage=%d", m.BackupCompressionCPUPercentage.ValueInt64())
+	}
+}
+
+func TestFlattenExtendedSettings_BackupCompressionAbsent(t *testing.T) {
+	t.Parallel()
+	ptrs, m := newTestPtrs()
+	flattenExtendedSettings(&client.ServerSettings{}, ptrs)
+	if !m.BackupCompressionCPUPercentage.IsNull() {
+		t.Fatalf("expected null backup_compression_cpu_percentage, got %v", m.BackupCompressionCPUPercentage)
 	}
 }

--- a/internal/service/server/data_source.go
+++ b/internal/service/server/data_source.go
@@ -43,6 +43,7 @@ type serverDataSourceModel struct {
 	ComposeVersionCheckedAt              types.String `tfsdk:"compose_version_checked_at"`
 	DockerVersion                        types.String `tfsdk:"docker_version"`
 	DockerVersionCheckedAt               types.String `tfsdk:"docker_version_checked_at"`
+	BackupCompressionCPUPercentage       types.Int64  `tfsdk:"backup_compression_cpu_percentage"`
 }
 
 func serverDataSourceAttributes() map[string]schema.Attribute {
@@ -125,6 +126,11 @@ func serverDataSourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "When Coolify last checked the Docker version on this server.",
 			Computed:            true,
 		},
+		"backup_compression_cpu_percentage": schema.Int64Attribute{
+			MarkdownDescription: "CPU percentage Coolify uses when compressing volume backups. " +
+				"Read-only. Present on Coolify tip/nightly 4.3.3; empty on older instances.",
+			Computed: true,
+		},
 	}
 }
 
@@ -159,6 +165,11 @@ func flattenServerDataSourceModel(srv client.Server) serverDataSourceModel {
 	model.ComposeVersionCheckedAt = flex.StringToFramework(srv.Settings.ComposeVersionCheckedAt)
 	model.DockerVersion = flex.StringToFramework(srv.Settings.DockerVersion)
 	model.DockerVersionCheckedAt = flex.StringToFramework(srv.Settings.DockerVersionCheckedAt)
+	if srv.Settings.BackupCompressionCPUPercentage != nil {
+		model.BackupCompressionCPUPercentage = types.Int64Value(int64(*srv.Settings.BackupCompressionCPUPercentage))
+	} else {
+		model.BackupCompressionCPUPercentage = types.Int64Null()
+	}
 
 	return model
 }

--- a/internal/service/server/data_source_list_test.go
+++ b/internal/service/server/data_source_list_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestServersDataSource(t *testing.T) {
 	t.Parallel()
+	backupPct := 40
 	servers := []client.Server{
 		{
 			UUID:          "srv-list-uuid-1",
@@ -32,7 +33,8 @@ func TestServersDataSource(t *testing.T) {
 				ConnectionTimeout:                    0,
 				ServerDiskUsageNotificationThreshold: 80,
 				ComposeVersion:                       "2.29.1", DockerVersion: "27.0.3",
-				ServerDiskUsageCheckFrequency: "*/5 * * * *",
+				BackupCompressionCPUPercentage: &backupPct,
+				ServerDiskUsageCheckFrequency:  "*/5 * * * *",
 			},
 		},
 		{
@@ -97,6 +99,7 @@ data "coolify_servers" "test" {}`,
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.0.connection_timeout", "10"),
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.0.server_disk_usage_notification_threshold", "80"),
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.0.server_disk_usage_check_frequency", "*/5 * * * *"),
+					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.0.backup_compression_cpu_percentage", "40"),
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.1.concurrent_builds", "4"),
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.1.dynamic_timeout", "7200"),
 					resource.TestCheckResourceAttr("data.coolify_servers.test", "servers.1.deployment_queue_limit", "10"),

--- a/internal/service/server/data_source_test.go
+++ b/internal/service/server/data_source_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestServerDataSource(t *testing.T) {
 	t.Parallel()
+	backupPct := 40
 	srv := &client.Server{
 		UUID:          "cccc0002-0002-4000-8000-000000000001",
 		Name:          "data-source-server",
@@ -32,7 +33,8 @@ func TestServerDataSource(t *testing.T) {
 			ConnectionTimeout:                    0,
 			ServerDiskUsageNotificationThreshold: 80,
 			ComposeVersion:                       "2.29.1", DockerVersion: "27.0.3",
-			ServerDiskUsageCheckFrequency: "*/5 * * * *",
+			BackupCompressionCPUPercentage: &backupPct,
+			ServerDiskUsageCheckFrequency:  "*/5 * * * *",
 		},
 	}
 
@@ -76,6 +78,7 @@ data "coolify_server" "test" {
 					resource.TestCheckResourceAttr("data.coolify_server.test", "server_disk_usage_notification_threshold", "80"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "compose_version", "2.29.1"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "docker_version", "27.0.3"),
+					resource.TestCheckResourceAttr("data.coolify_server.test", "backup_compression_cpu_percentage", "40"),
 					resource.TestCheckResourceAttr("data.coolify_server.test", "server_disk_usage_check_frequency", "*/5 * * * *"),
 				),
 			},

--- a/internal/service/server/resource.go
+++ b/internal/service/server/resource.go
@@ -83,6 +83,7 @@ type serverResourceModel struct {
 	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
 	DockerVersion                     types.String `tfsdk:"docker_version"`
 	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
+	BackupCompressionCPUPercentage    types.Int64  `tfsdk:"backup_compression_cpu_percentage"`
 }
 
 // NewResource returns a new server resource.
@@ -311,6 +312,7 @@ func (m *serverResourceModel) commonPtrs() ServerCommonPtrs {
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
 		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
 		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
+		BackupCompressionCPUPercentage: &m.BackupCompressionCPUPercentage,
 	}
 }
 

--- a/internal/service/vultr/resource.go
+++ b/internal/service/vultr/resource.go
@@ -104,6 +104,7 @@ type vultrServerResourceModel struct {
 	ComposeVersionCheckedAt           types.String `tfsdk:"compose_version_checked_at"`
 	DockerVersion                     types.String `tfsdk:"docker_version"`
 	DockerVersionCheckedAt            types.String `tfsdk:"docker_version_checked_at"`
+	BackupCompressionCPUPercentage    types.Int64  `tfsdk:"backup_compression_cpu_percentage"`
 }
 
 // NewResource returns a new Vultr server resource.
@@ -376,6 +377,7 @@ func (m *vultrServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 		LogdrainNewrelicLicenseKey: &m.LogdrainNewrelicLicenseKey,
 		ComposeVersion:             &m.ComposeVersion, ComposeVersionCheckedAt: &m.ComposeVersionCheckedAt,
 		DockerVersion: &m.DockerVersion, DockerVersionCheckedAt: &m.DockerVersionCheckedAt,
+		BackupCompressionCPUPercentage: &m.BackupCompressionCPUPercentage,
 	}
 }
 

--- a/internal/spectest/contract_skips.go
+++ b/internal/spectest/contract_skips.go
@@ -124,11 +124,9 @@ var scheduledTaskCoverageSkips = skipMap(
 
 var projectCoverageSkips = skipMap(
 	skipInternal("team_id", "FK"),
-	// Coolify tip (2026-08-13): UI-only project icons via Livewire + ProjectIconStorageService.
-	// Not on Project::$fillable or ProjectController create/update $allowedFields (name, description only).
-	skipInternal("icon_path", "UI-only project icon storage path; no public API write"),
-	skipInternal("icon_storage_type", "UI-only project icon disk (local/s3); no public API write"),
-	skipInternal("icon_s3_storage_id", "UI-only project icon S3 FK; no public API write"),
+	// Icon path/type are computed on coolify_project + coolify_project (GET by UUID).
+	// S3 storage id stays internal (numeric FK; no UUID on the project payload).
+	skipInternal("icon_s3_storage_id", "numeric FK for UI icon S3 backend; no public write"),
 )
 
 var githubAppCoverageSkips = skipMap(
@@ -169,10 +167,8 @@ var serverSettingCoverageSkips = skipMap(
 	skipNA("is_usable", "on Server entity, not Settings"),
 	skipNA("sentinel_metrics_refresh_rate_in_seconds", "old contract name; superseded by sentinel_metrics_refresh_rate_seconds"),
 	skipNA("sentinel_push_interval_in_seconds", "old contract name; superseded by sentinel_push_interval_seconds"),
-	// Coolify tip (2026-08-14): Livewire Server/Advanced + VolumeBackupJob only.
-	// Not on ServersController create/update $allowedFields.
-	skipInternal("backup_compression_cpu_percentage", "UI-only ServerSetting; not on ServersController allow list"),
 	// Remaining settings fields covered on client.ServerSettings + read-only server schema.
+	// backup_compression_cpu_percentage is computed on server resources/data sources.
 )
 
 var environmentCoverageSkips = skipMap(

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -99,6 +99,15 @@ on `coolify_server` / cloud server resources and `coolify_server` / `coolify_ser
 data sources are populated on Coolify **≥ 4.3.2** after Coolify probes the host.
 Empty on older instances.
 
+Volume-backup CPU share (`backup_compression_cpu_percentage`) is a computed
+GET-only server setting on Coolify tip/nightly **4.3.3**. It is not on the
+public server PATCH allow list. Empty on older instances.
+
+Project icon attributes (`icon_path`, `icon_storage_type`) are computed on
+`coolify_project` and `data.coolify_project` from GET `/projects/{uuid}` on
+Coolify tip/nightly **4.3.3**. They are not writable and are omitted from
+`GET /projects` (list). Empty on older instances.
+
 ## Application attributes by Coolify version
 
 Application resources share one schema. Attributes that Coolify only accepts


### PR DESCRIPTION
## Description

Expose the Coolify tip/nightly 4.3.3 GET-only fields that the channel watch in #719 reported, without promoting the pinned contract.

## Problem

Tip contract extract vs pin `4.3.2` has four new model columns:

- Project: `icon_path`, `icon_storage_type`, `icon_s3_storage_id`
- ServerSetting: `backup_compression_cpu_percentage`

None of these are on public create/update `$allowedFields`. PATCH would 422. There is still no `v4.3.3` git tag (latest release is `v4.3.2`), so the pin cannot move yet.

## Change

- Computed `icon_path` and `icon_storage_type` on `coolify_project` and `data.coolify_project` (GET `/projects/{uuid}`). List `GET /projects` still omits them.
- Keep `icon_s3_storage_id` as an internal FK skip (no UUID on the project payload).
- Computed `backup_compression_cpu_percentage` on server resources and `coolify_server` / `coolify_servers` data sources. Pointer decode so older GET payloads stay null, not `0`.
- Unit tests for JSON decode, flatten, and data-source read-back.
- Version-support guide notes. Pin stays `4.3.2`.

## Validation

- `make ci` (build, lint, unit tests, docs-check, counts-check, contract-compat, govulncheck)
- Targeted packages: client, project, server, hetzner, digitalocean, vultr, spectest

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally
- [x] `make fmt` ran (gofmt + go mod tidy)
- [x] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

Ref #719
