### PR TITLE
docs: rewrite API coverage with use-this-instead

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -3,327 +3,1288 @@
 <!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->
 <!-- Run: make api-coverage -->
 
-**Route inventory**: source-derived contract `testdata/contracts/coolify-v4.json` (`routes[]`)  
-**Field source of truth**: same contract (`models` / endpoint allow lists)  
-**Not inventory**: OpenAPI under `testdata/specs/` (partial upstream path list; do not treat as Coolify API completeness)  
+This page answers: **which Coolify HTTP routes does the provider wrap, and what do I use when it does not?**
+
+It is a **route inventory** against Coolify source (`testdata/contracts/coolify-v4.json`). It is not a field catalog, and it does not say which Coolify **version** you need.
+
+- **Which Coolify version for each resource and field:** [Coolify Version Support](docs/guides/coolify-version-support.md)
+- **Resource and attribute docs:** [docs/](docs/) (also on the Terraform Registry)
+- **Field-level gaps** (numeric FKs, UI-only columns on an existing GET) live in `internal/spectest/contract_skips.go`, not in this route list.
+
 **Coverage**: 242 covered / 296 registry entries (81.8%)  
 **Planned**: 0 | **Skipped**: 54  
 **Registry size**: 296 (contract routes + allowlisted extras)
 
-## Covered
+## What Terraform does not wrap
 
-| Endpoint | Terraform Resource / Data Source | Since |
-|----------|----------------------------------|-------|
-| `DELETE /applications/{uuid}` | `coolify_application + variants` | v0.1.0 |
-| `DELETE /applications/{uuid}/destinations/{destination_uuid}` | `coolify_application_destination` | v0.1.15 |
-| `DELETE /applications/{uuid}/envs/{env_uuid}` | `coolify_environment_variable` | v0.1.0 |
-| `DELETE /applications/{uuid}/previews/{pull_request_id}` | `client.DeletePreviewDeployment` | v0.2.0 |
-| `DELETE /applications/{uuid}/scheduled-tasks/{task_uuid}` | `coolify_scheduled_task` | v0.2.0 |
-| `DELETE /applications/{uuid}/storages/{storage_uuid}` | `coolify_storage` | v0.2.0 |
-| `DELETE /applications/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
-| `DELETE /applications/{uuid}/tags/{tag_uuid}` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `DELETE /cloud-init-scripts/{uuid}` | `coolify_cloud_init_script` | v0.1.15 |
-| `DELETE /cloud-tokens/{uuid}` | `coolify_cloud_token` | v0.2.0 |
-| `DELETE /databases/{uuid}` | `coolify_*_database` | v0.1.0 |
-| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}` | `coolify_database_backup` | v0.1.0 |
-| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}` | `client.DeleteBackupExecution` | v0.2.0 |
-| `DELETE /databases/{uuid}/envs/{env_uuid}` | `coolify_environment_variable` | v0.2.0 |
-| `DELETE /databases/{uuid}/storages/{storage_uuid}` | `coolify_storage` | v0.2.0 |
-| `DELETE /databases/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
-| `DELETE /databases/{uuid}/tags/{tag_uuid}` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `DELETE /destinations/{uuid}` | `coolify_destination` | v0.2.0 |
-| `DELETE /github-apps/{github_app_id}` | `coolify_github_app` | v0.2.0 |
-| `DELETE /gitlab-apps/{gitlab_app_id}` | `coolify_gitlab_app` | v0.1.15 |
-| `DELETE /projects/{uuid}` | `coolify_project` | v0.1.0 |
-| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}` | `coolify_environment` | v0.2.0 |
-| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `DELETE /projects/{uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `DELETE /s3-storages/{uuid}` | `coolify_s3_storage` | v0.1.13 |
-| `DELETE /security/keys/{uuid}` | `coolify_private_key` | v0.1.0 |
-| `DELETE /servers/{uuid}` | `coolify_server` | v0.1.0 |
-| `DELETE /servers/{uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `DELETE /services/{uuid}` | `coolify_service` | v0.1.0 |
-| `DELETE /services/{uuid}/envs/{env_uuid}` | `coolify_environment_variable` | v0.1.0 |
-| `DELETE /services/{uuid}/scheduled-tasks/{task_uuid}` | `coolify_scheduled_task` | v0.2.0 |
-| `DELETE /services/{uuid}/storages/{storage_uuid}` | `coolify_storage` | v0.2.0 |
-| `DELETE /services/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
-| `DELETE /services/{uuid}/tags/{tag_uuid}` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `DELETE /tags/{uuid}` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `DELETE /team/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `GET /applications` | `data.coolify_applications` | v0.1.0 |
-| `GET /applications/{uuid}` | `data.coolify_application` | v0.1.0 |
-| `GET /applications/{uuid}/destinations` | `coolify_application_destination` | v0.1.15 |
-| `GET /applications/{uuid}/envs` | `data.coolify_environment_variables` | v0.1.0 |
-| `GET /applications/{uuid}/logs` | `data.coolify_application_logs` | v0.2.0 |
-| `GET /applications/{uuid}/restart` | `coolify_deployment` | v0.1.0 |
-| `GET /applications/{uuid}/scheduled-tasks` | `data.coolify_scheduled_tasks` | v0.2.0 |
-| `GET /applications/{uuid}/scheduled-tasks/{task_uuid}/executions` | `data.coolify_task_executions` | v0.2.0 |
-| `GET /applications/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `GET /applications/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `GET /applications/{uuid}/storages` | `data.coolify_storages` | v0.2.0 |
-| `GET /applications/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `GET /cloud-init-scripts` | `coolify_cloud_init_script` | v0.1.15 |
-| `GET /cloud-init-scripts/{uuid}` | `coolify_cloud_init_script` | v0.1.15 |
-| `GET /cloud-tokens` | `data.coolify_cloud_tokens` | v0.2.0 |
-| `GET /cloud-tokens/{uuid}` | `data.coolify_cloud_token` | v0.2.0 |
-| `GET /databases` | `data.coolify_databases` | v0.1.0 |
-| `GET /databases/{uuid}` | `data.coolify_database` | v0.1.0 |
-| `GET /databases/{uuid}/backups` | `coolify_database_backup` | v0.1.0 |
-| `GET /databases/{uuid}/backups/{scheduled_backup_uuid}/executions` | `data.coolify_backup_executions` | v0.2.0 |
-| `GET /databases/{uuid}/envs` | `data.coolify_environment_variables` | v0.2.0 |
-| `GET /databases/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
-| `GET /databases/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `GET /databases/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `GET /databases/{uuid}/storages` | `data.coolify_storages` | v0.2.0 |
-| `GET /databases/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `GET /deploy` | `client.Deploy` | v0.2.0 |
-| `GET /deployments` | `data.coolify_deployments` | v0.2.0 |
-| `GET /deployments/applications/{uuid}` | `data.coolify_deployments` | v0.2.0 |
-| `GET /deployments/{uuid}` | `coolify_deployment` | v0.1.0 |
-| `GET /destinations` | `data.coolify_destinations` | v0.2.0 |
-| `GET /destinations/{uuid}` | `data.coolify_destination` | v0.2.0 |
-| `GET /digitalocean/images` | `data.coolify_digitalocean_images` | v0.2.0 |
-| `GET /digitalocean/regions` | `data.coolify_digitalocean_regions` | v0.2.0 |
-| `GET /digitalocean/sizes` | `data.coolify_digitalocean_sizes` | v0.2.0 |
-| `GET /digitalocean/ssh-keys` | `data.coolify_digitalocean_ssh_keys` | v0.2.0 |
-| `GET /disable` | `client.DisableAPI` | v0.2.0 |
-| `GET /enable` | `client.EnableAPI` | v0.2.0 |
-| `GET /github-apps` | `data.coolify_github_apps` | v0.2.0 |
-| `GET /github-apps/{github_app_id}/repositories` | `data.coolify_github_app_repositories` | v0.2.0 |
-| `GET /github-apps/{github_app_id}/repositories/{owner}/{repo}/branches` | `data.coolify_github_app_branches` | v0.2.0 |
-| `GET /gitlab-apps` | `coolify_gitlab_app` | v0.1.15 |
-| `GET /health` | `data.coolify_health` | v0.2.0 |
-| `GET /hetzner/images` | `data.coolify_hetzner_images` | v0.2.0 |
-| `GET /hetzner/locations` | `data.coolify_hetzner_locations` | v0.2.0 |
-| `GET /hetzner/server-types` | `data.coolify_hetzner_server_types` | v0.2.0 |
-| `GET /hetzner/ssh-keys` | `data.coolify_hetzner_ssh_keys` | v0.2.0 |
-| `GET /notifications/discord` | `coolify_notification_discord` | v0.1.14 |
-| `GET /notifications/email` | `coolify_notification_email` | v0.1.14 |
-| `GET /notifications/pushover` | `coolify_notification_pushover` | v0.1.14 |
-| `GET /notifications/slack` | `coolify_notification_slack` | v0.1.14 |
-| `GET /notifications/telegram` | `coolify_notification_telegram` | v0.1.14 |
-| `GET /notifications/webhook` | `coolify_notification_webhook` | v0.1.14 |
-| `GET /projects` | `data.coolify_projects` | v0.1.0 |
-| `GET /projects/{uuid}` | `data.coolify_project` | v0.1.0 |
-| `GET /projects/{uuid}/environments` | `data.coolify_environments` | v0.2.0 |
-| `GET /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `GET /projects/{uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `GET /projects/{uuid}/{environment_name_or_uuid}` | `data.coolify_environment` | v0.2.0 |
-| `GET /resources` | `data.coolify_resources` | v0.2.0 |
-| `GET /s3-storages` | `data.coolify_s3_storages` | v0.1.13 |
-| `GET /s3-storages/{uuid}` | `data.coolify_s3_storage` | v0.1.13 |
-| `GET /security/keys` | `data.coolify_private_keys` | v0.1.0 |
-| `GET /security/keys/{uuid}` | `data.coolify_private_key` | v0.1.0 |
-| `GET /servers` | `data.coolify_servers` | v0.1.0 |
-| `GET /servers/{server_uuid}/destinations` | `data.coolify_destinations` | v0.2.0 |
-| `GET /servers/{uuid}` | `data.coolify_server` | v0.1.0 |
-| `GET /servers/{uuid}/cloudflare-tunnel` | `coolify_server_cloudflare_tunnel` | v0.1.15 |
-| `GET /servers/{uuid}/docker-cleanup` | `coolify_server_docker_cleanup` | v0.1.15 |
-| `GET /servers/{uuid}/domains` | `data.coolify_server_domains` | v0.1.0 |
-| `GET /servers/{uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `GET /servers/{uuid}/log-drains` | `coolify_server_log_drain` | v0.1.15 |
-| `GET /servers/{uuid}/proxy` | `coolify_server_proxy` | v0.1.15 |
-| `GET /servers/{uuid}/resources` | `data.coolify_server_resources` | v0.1.0 |
-| `GET /servers/{uuid}/sentinel` | `coolify_server_sentinel` | v0.1.15 |
-| `GET /servers/{uuid}/validate` | `data.coolify_server_validation` | v0.2.0 |
-| `GET /services` | `data.coolify_services` | v0.1.0 |
-| `GET /services/{uuid}` | `data.coolify_service` | v0.1.0 |
-| `GET /services/{uuid}/envs` | `data.coolify_environment_variables` | v0.2.0 |
-| `GET /services/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
-| `GET /services/{uuid}/scheduled-tasks` | `data.coolify_scheduled_tasks` | v0.2.0 |
-| `GET /services/{uuid}/scheduled-tasks/{task_uuid}/executions` | `data.coolify_task_executions` | v0.2.0 |
-| `GET /services/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `GET /services/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `GET /services/{uuid}/storages` | `data.coolify_storages` | v0.2.0 |
-| `GET /services/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `GET /tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `GET /team/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `GET /teams` | `data.coolify_teams` | v0.2.0 |
-| `GET /teams/current` | `data.coolify_team_members` | v0.2.0 |
-| `GET /teams/current/members` | `data.coolify_team_members` | v0.2.0 |
-| `GET /teams/{id}` | `data.coolify_team` | v0.1.0 |
-| `GET /teams/{id}/members` | `data.coolify_team_members` | v0.2.0 |
-| `GET /version` | `data.coolify_version` | v0.1.0 |
-| `GET /vultr/os` | `data.coolify_vultr_os` | v0.2.0 |
-| `GET /vultr/plans` | `data.coolify_vultr_plans` | v0.2.0 |
-| `GET /vultr/regions` | `data.coolify_vultr_regions` | v0.2.0 |
-| `GET /vultr/ssh-keys` | `data.coolify_vultr_ssh_keys` | v0.2.0 |
-| `PATCH /applications/{uuid}` | `coolify_application + variants` | v0.1.0 |
-| `PATCH /applications/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
-| `PATCH /applications/{uuid}/envs/bulk` | `client.BulkUpdateEnvVars` | v0.2.0 |
-| `PATCH /applications/{uuid}/scheduled-tasks/{task_uuid}` | `coolify_scheduled_task` | v0.2.0 |
-| `PATCH /applications/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `PATCH /cloud-init-scripts/{uuid}` | `coolify_cloud_init_script` | v0.1.15 |
-| `PATCH /cloud-tokens/{uuid}` | `coolify_cloud_token` | v0.2.0 |
-| `PATCH /databases/{uuid}` | `coolify_*_database` | v0.1.0 |
-| `PATCH /databases/{uuid}/backups/{scheduled_backup_uuid}` | `coolify_database_backup` | v0.1.0 |
-| `PATCH /databases/{uuid}/envs` | `coolify_environment_variable` | v0.2.0 |
-| `PATCH /databases/{uuid}/envs/bulk` | `client.BulkUpdateEnvVars` | v0.2.0 |
-| `PATCH /databases/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `PATCH /destinations/{uuid}` | `coolify_destination` | v0.1.15 |
-| `PATCH /github-apps/{github_app_id}` | `coolify_github_app` | v0.2.0 |
-| `PATCH /gitlab-apps/{gitlab_app_id}` | `coolify_gitlab_app` | v0.1.15 |
-| `PATCH /notifications/discord` | `coolify_notification_discord` | v0.1.14 |
-| `PATCH /notifications/email` | `coolify_notification_email` | v0.1.14 |
-| `PATCH /notifications/pushover` | `coolify_notification_pushover` | v0.1.14 |
-| `PATCH /notifications/slack` | `coolify_notification_slack` | v0.1.14 |
-| `PATCH /notifications/telegram` | `coolify_notification_telegram` | v0.1.14 |
-| `PATCH /notifications/webhook` | `coolify_notification_webhook` | v0.1.14 |
-| `PATCH /projects/{uuid}` | `coolify_project` | v0.1.0 |
-| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}` | `coolify_environment` | v0.1.15 |
-| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `PATCH /projects/{uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `PATCH /s3-storages/{uuid}` | `coolify_s3_storage` | v0.1.13 |
-| `PATCH /security/keys/{uuid}` | `coolify_private_key` | v0.1.0 |
-| `PATCH /servers/{uuid}` | `coolify_server` | v0.1.0 |
-| `PATCH /servers/{uuid}/cloudflare-tunnel` | `coolify_server_cloudflare_tunnel` | v0.1.15 |
-| `PATCH /servers/{uuid}/docker-cleanup` | `coolify_server_docker_cleanup` | v0.1.15 |
-| `PATCH /servers/{uuid}/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `PATCH /servers/{uuid}/log-drains` | `coolify_server_log_drain` | v0.1.15 |
-| `PATCH /servers/{uuid}/proxy` | `coolify_server_proxy` | v0.1.15 |
-| `PATCH /servers/{uuid}/sentinel` | `coolify_server_sentinel` | v0.1.15 |
-| `PATCH /services/{uuid}` | `coolify_service` | v0.1.0 |
-| `PATCH /services/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
-| `PATCH /services/{uuid}/envs/bulk` | `client.BulkUpdateEnvVars` | v0.2.0 |
-| `PATCH /services/{uuid}/scheduled-tasks/{task_uuid}` | `coolify_scheduled_task` | v0.2.0 |
-| `PATCH /services/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `PATCH /tags/{uuid}` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `PATCH /team/envs/{env_id}` | `coolify_shared_environment_variable` | v0.1.15 |
-| `POST /applications/dockerfile` | `coolify_application_dockerfile` | v0.2.0 |
-| `POST /applications/dockerimage` | `coolify_application_docker_image` | v0.1.0 |
-| `POST /applications/private-deploy-key` | `coolify_application_private_git` | v0.1.0 |
-| `POST /applications/private-github-app` | `coolify_application_github_app` | v0.2.0 |
-| `POST /applications/public` | `coolify_application` | v0.1.0 |
-| `POST /applications/{uuid}/destinations` | `coolify_application_destination` | v0.1.15 |
-| `POST /applications/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
-| `POST /applications/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
-| `POST /applications/{uuid}/scheduled-tasks` | `coolify_scheduled_task` | v0.2.0 |
-| `POST /applications/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `POST /applications/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `POST /applications/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `POST /applications/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `POST /cloud-init-scripts` | `coolify_cloud_init_script` | v0.1.15 |
-| `POST /cloud-tokens` | `coolify_cloud_token` | v0.2.0 |
-| `POST /cloud-tokens/{uuid}/validate` | `client.ValidateCloudToken` | v0.2.0 |
-| `POST /databases/clickhouse` | `coolify_database_clickhouse` | v0.1.0 |
-| `POST /databases/dragonfly` | `coolify_database_dragonfly` | v0.1.0 |
-| `POST /databases/keydb` | `coolify_database_keydb` | v0.1.0 |
-| `POST /databases/mariadb` | `coolify_database_mariadb` | v0.1.0 |
-| `POST /databases/mongodb` | `coolify_database_mongodb` | v0.1.0 |
-| `POST /databases/mysql` | `coolify_database_mysql` | v0.1.0 |
-| `POST /databases/postgresql` | `coolify_database_postgresql` | v0.1.0 |
-| `POST /databases/redis` | `coolify_database_redis` | v0.1.0 |
-| `POST /databases/{uuid}/backups` | `coolify_database_backup` | v0.1.0 |
-| `POST /databases/{uuid}/envs` | `coolify_environment_variable` | v0.2.0 |
-| `POST /databases/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
-| `POST /databases/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `POST /databases/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `POST /databases/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `POST /databases/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `POST /deploy` | `client.Deploy` | v0.2.0 |
-| `POST /deployments/{uuid}/cancel` | `client.CancelDeployment` | v0.2.0 |
-| `POST /disable` | `coolify_api_settings` | v0.2.0 |
-| `POST /enable` | `coolify_api_settings` | v0.2.0 |
-| `POST /github-apps` | `coolify_github_app` | v0.2.0 |
-| `POST /gitlab-apps` | `coolify_gitlab_app` | v0.1.15 |
-| `POST /mcp/disable` | `coolify_api_settings (mcp_enabled)` | v0.4.0 |
-| `POST /mcp/enable` | `coolify_api_settings (mcp_enabled)` | v0.4.0 |
-| `POST /projects` | `coolify_project` | v0.1.0 |
-| `POST /projects/{uuid}/environments` | `coolify_environment` | v0.2.0 |
-| `POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `POST /projects/{uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `POST /s3-storages` | `coolify_s3_storage` | v0.1.13 |
-| `POST /s3-storages/{uuid}/validate` | `coolify_s3_storage_validate` | v0.1.14 |
-| `POST /security/keys` | `coolify_private_key` | v0.1.0 |
-| `POST /servers` | `coolify_server` | v0.1.0 |
-| `POST /servers/digitalocean` | `coolify_server_digitalocean` | v0.2.0 |
-| `POST /servers/hetzner` | `coolify_server_hetzner` | v0.2.0 |
-| `POST /servers/vultr` | `coolify_server_vultr` | v0.2.0 |
-| `POST /servers/{server_uuid}/destinations` | `coolify_destination` | v0.2.0 |
-| `POST /servers/{uuid}/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `POST /servers/{uuid}/validate` | `coolify_server_validate` | v0.2.0 |
-| `POST /services` | `coolify_service` | v0.1.0 |
-| `POST /services/{uuid}/envs` | `coolify_environment_variable` | v0.1.0 |
-| `POST /services/{uuid}/restart` | `coolify_resource_action` | v0.3.0 |
-| `POST /services/{uuid}/scheduled-tasks` | `coolify_scheduled_task` | v0.2.0 |
-| `POST /services/{uuid}/start` | `coolify_resource_action` | v0.3.0 |
-| `POST /services/{uuid}/stop` | `coolify_resource_action` | v0.3.0 |
-| `POST /services/{uuid}/storages` | `coolify_storage` | v0.2.0 |
-| `POST /services/{uuid}/tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `POST /tags` | `coolify_tag + coolify_resource_tag` | v0.1.15 |
-| `POST /team/envs` | `coolify_shared_environment_variable` | v0.1.15 |
-| `PUT /applications/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
-| `PUT /databases/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
-| `PUT /servers/{uuid}/proxy/configuration` | `coolify_server_proxy` | v0.1.15 |
-| `PUT /services/{uuid}/storages/{storage_uuid}/backups` | `coolify_storage_backup` | v0.1.9 |
+Terraform models desired durable state. Coolify also exposes one-shot buttons, log streams, URL aliases, and control-plane actions. Those routes are skipped on purpose.
 
-## Planned
+### Clone, migrate, and move
 
-Ordered by priority (1 = most needed by users).
+Coolify can copy or relocate an existing app, database, service, or server in one API call. Terraform then either owns two objects or loses the original.
 
-| Priority | Endpoint | Notes |
-|----------|----------|-------|
+**Use this instead:** `coolify_application` (and variants), `coolify_database_*`, `coolify_service`, or `coolify_server` to create the destination. For a one-time move, use the Coolify UI.
 
-## Intentionally Skipped
+| Route |
+|-------|
+| `POST /applications/{uuid}/clone` |
+| `POST /applications/{uuid}/migrate` |
+| `POST /applications/{uuid}/move` |
+| `POST /databases/{uuid}/clone` |
+| `POST /databases/{uuid}/migrate` |
+| `POST /databases/{uuid}/move` |
+| `POST /servers/{uuid}/migrate` |
+| `POST /services/{uuid}/clone` |
+| `POST /services/{uuid}/migrate` |
+| `POST /services/{uuid}/move` |
 
-These endpoints are intentionally not modeled directly in Terraform.
+### Run now (backup or scheduled task)
 
-| Endpoint | Reason |
-|----------|--------|
-| `GET /applications/{uuid}/rollback-images` | Application rollback/images; operational, not TF lifecycle |
-| `GET /databases/{uuid}/logs` | Resource logs streaming; not durable TF state |
-| `GET /hetzner/firewalls` | Hetzner firewalls/networks list; not required for coolify_server_hetzner |
-| `GET /hetzner/networks` | Hetzner firewalls/networks list; not required for coolify_server_hetzner |
-| `GET /servers/{uuid}/docker-cleanup/executions` | Server operational/control-plane API; not modeled as TF resources |
-| `GET /servers/{uuid}/export` | Server operational/control-plane API; not modeled as TF resources |
-| `GET /services/{uuid}/applications` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/applications/{app_uuid}` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/applications/{app_uuid}/logs` | Resource logs streaming; not durable TF state |
-| `GET /services/{uuid}/applications/{app_uuid}/restart` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/applications/{app_uuid}/start` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/applications/{app_uuid}/stop` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/databases` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/databases/{database_uuid}` | Nested service components; coolify_service manages the compose service unit |
-| `GET /services/{uuid}/databases/{database_uuid}/logs` | Resource logs streaming; not durable TF state |
-| `GET /services/{uuid}/logs` | Resource logs streaming; not durable TF state |
-| `GET /team` | Alias of /teams/current*; use data.coolify_team / team_members |
-| `GET /team/members` | Alias of /teams/current*; use data.coolify_team / team_members |
-| `PATCH /services/{uuid}/applications/{app_uuid}` | Nested service components; coolify_service manages the compose service unit |
-| `PATCH /services/{uuid}/databases/{database_uuid}` | Nested service components; coolify_service manages the compose service unit |
-| `POST /applications/dockercompose` | Deprecated alias: use POST /services instead because this flow creates a Service, not an Application |
-| `POST /applications/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /applications/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /applications/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /applications/{uuid}/rollback` | Application rollback/images; operational, not TF lifecycle |
-| `POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute` | One-shot task execute; coolify_scheduled_task manages definition only |
-| `POST /applications/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
-| `POST /databases/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /databases/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /databases/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /databases/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
-| `POST /feedback` | Coolify product feedback endpoint; not TF |
-| `POST /sentinel/push` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/import` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/{uuid}/claim` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/{uuid}/cloudflare-tunnel/disable` | Operational enable/disable; coolify_server_cloudflare_tunnel uses PATCH settings |
-| `POST /servers/{uuid}/cloudflare-tunnel/enable` | Operational enable/disable; coolify_server_cloudflare_tunnel uses PATCH settings |
-| `POST /servers/{uuid}/docker-cleanup/run` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/{uuid}/export/mailbox` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /servers/{uuid}/proxy/restart` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /servers/{uuid}/transfer/complete` | Server operational/control-plane API; not modeled as TF resources |
-| `POST /services/{uuid}/applications/{app_uuid}/logs` | Resource logs streaming; not durable TF state |
-| `POST /services/{uuid}/applications/{app_uuid}/restart` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/applications/{app_uuid}/start` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/applications/{app_uuid}/stop` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/clone` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /services/{uuid}/databases/{database_uuid}/restart` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/databases/{database_uuid}/start` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/databases/{database_uuid}/stop` | Nested service app/DB lifecycle; manage via parent coolify_service |
-| `POST /services/{uuid}/migrate` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /services/{uuid}/move` | One-shot clone/migrate/move; not Terraform lifecycle |
-| `POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute` | One-shot task execute; coolify_scheduled_task manages definition only |
-| `POST /services/{uuid}/storages/{storage_uuid}/backups/run` | One-shot volume backup run; coolify_storage_backup manages schedule only |
+These POSTs fire a single backup or task execution. They are not a schedule you can keep in state.
+
+**Use this instead:** `coolify_storage_backup` or `coolify_database_backup` for the schedule. `coolify_scheduled_task` for the task definition. Trigger a run from the Coolify UI when you need one now.
+
+| Route |
+|-------|
+| `POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute` |
+| `POST /applications/{uuid}/storages/{storage_uuid}/backups/run` |
+| `POST /databases/{uuid}/storages/{storage_uuid}/backups/run` |
+| `POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute` |
+| `POST /services/{uuid}/storages/{storage_uuid}/backups/run` |
+
+### Rollback and prior images
+
+Listing rollback images and posting a rollback is an operational recovery step, not desired state.
+
+**Use this instead:** The Coolify UI. There is no `coolify_rollback` resource.
+
+| Route |
+|-------|
+| `GET /applications/{uuid}/rollback-images` |
+| `POST /applications/{uuid}/rollback` |
+
+### Log streams
+
+Log endpoints stream runtime output. That is not durable Terraform state.
+
+**Use this instead:** `data.coolify_application_logs` for application logs. Database and service log streams stay in the Coolify UI.
+
+| Route |
+|-------|
+| `GET /databases/{uuid}/logs` |
+| `GET /services/{uuid}/applications/{app_uuid}/logs` |
+| `GET /services/{uuid}/databases/{database_uuid}/logs` |
+| `GET /services/{uuid}/logs` |
+| `POST /services/{uuid}/applications/{app_uuid}/logs` |
+
+### Nested compose service apps and databases
+
+A catalog `coolify_service` owns the whole compose stack. Coolify also exposes each inner app and database as its own API object.
+
+**Use this instead:** `coolify_service` for the stack. Do not manage inner `/services/{uuid}/applications/...` or `/services/{uuid}/databases/...` as separate resources.
+
+| Route |
+|-------|
+| `GET /services/{uuid}/applications` |
+| `GET /services/{uuid}/applications/{app_uuid}` |
+| `GET /services/{uuid}/applications/{app_uuid}/restart` |
+| `GET /services/{uuid}/applications/{app_uuid}/start` |
+| `GET /services/{uuid}/applications/{app_uuid}/stop` |
+| `GET /services/{uuid}/databases` |
+| `GET /services/{uuid}/databases/{database_uuid}` |
+| `PATCH /services/{uuid}/applications/{app_uuid}` |
+| `PATCH /services/{uuid}/databases/{database_uuid}` |
+| `POST /services/{uuid}/applications/{app_uuid}/restart` |
+| `POST /services/{uuid}/applications/{app_uuid}/start` |
+| `POST /services/{uuid}/applications/{app_uuid}/stop` |
+| `POST /services/{uuid}/databases/{database_uuid}/restart` |
+| `POST /services/{uuid}/databases/{database_uuid}/start` |
+| `POST /services/{uuid}/databases/{database_uuid}/stop` |
+
+### Server control-plane actions
+
+Export, import, claim, transfer, Sentinel push, proxy restart, and one-shot docker cleanup are operator actions, not server settings.
+
+**Use this instead:** `coolify_server_proxy`, `coolify_server_sentinel`, `coolify_server_docker_cleanup`, and `coolify_server_cloudflare_tunnel` for settings. Use the Coolify UI for export, claim, transfer, and run-now cleanup.
+
+| Route |
+|-------|
+| `GET /servers/{uuid}/docker-cleanup/executions` |
+| `GET /servers/{uuid}/export` |
+| `POST /sentinel/push` |
+| `POST /servers/import` |
+| `POST /servers/{uuid}/claim` |
+| `POST /servers/{uuid}/docker-cleanup/run` |
+| `POST /servers/{uuid}/export/mailbox` |
+| `POST /servers/{uuid}/proxy/restart` |
+| `POST /servers/{uuid}/transfer/complete` |
+
+### Cloudflare tunnel enable and disable POSTs
+
+Coolify also has POST enable/disable routes. The provider writes tunnel settings with PATCH.
+
+**Use this instead:** `coolify_server_cloudflare_tunnel`.
+
+| Route |
+|-------|
+| `POST /servers/{uuid}/cloudflare-tunnel/disable` |
+| `POST /servers/{uuid}/cloudflare-tunnel/enable` |
+
+### Team URL aliases
+
+`GET /team` and `GET /team/members` are aliases of `/teams/current` and `/teams/current/members`.
+
+**Use this instead:** `data.coolify_team` and `data.coolify_team_members`.
+
+| Route |
+|-------|
+| `GET /team` |
+| `GET /team/members` |
+
+### Deprecated docker-compose create
+
+`POST /applications/dockercompose` creates a Service, not an Application. Coolify kept the path as a deprecated alias.
+
+**Use this instead:** `coolify_service` (`POST /services`).
+
+| Route |
+|-------|
+| `POST /applications/dockercompose` |
+
+### Hetzner firewalls and networks lists
+
+Coolify can list Hetzner firewalls and networks when provisioning. Those lists are not required to manage `coolify_server_hetzner`.
+
+**Use this instead:** `coolify_server_hetzner` for the server. Manage Hetzner firewalls and networks outside this provider if you need them.
+
+| Route |
+|-------|
+| `GET /hetzner/firewalls` |
+| `GET /hetzner/networks` |
+
+### Product feedback
+
+`POST /feedback` is a Coolify product endpoint, not infrastructure.
+
+**Use this instead:** Nothing in Terraform. Send feedback through Coolify.
+
+| Route |
+|-------|
+| `POST /feedback` |
+
+## Routes by Terraform resource
+
+A row here means the provider calls that Coolify route. `client.*` helpers are used from resources or are not a standalone resource.
+
+### `client.BulkUpdateEnvVars`
+
+| Route | Since |
+|-------|-------|
+| `PATCH /applications/{uuid}/envs/bulk` | v0.2.0 |
+| `PATCH /databases/{uuid}/envs/bulk` | v0.2.0 |
+| `PATCH /services/{uuid}/envs/bulk` | v0.2.0 |
+
+### `client.CancelDeployment`
+
+| Route | Since |
+|-------|-------|
+| `POST /deployments/{uuid}/cancel` | v0.2.0 |
+
+### `client.DeleteBackupExecution`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}` | v0.2.0 |
+
+### `client.DeletePreviewDeployment`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/previews/{pull_request_id}` | v0.2.0 |
+
+### `client.Deploy`
+
+| Route | Since |
+|-------|-------|
+| `GET /deploy` | v0.2.0 |
+| `POST /deploy` | v0.2.0 |
+
+### `client.DisableAPI`
+
+| Route | Since |
+|-------|-------|
+| `GET /disable` | v0.2.0 |
+
+### `client.EnableAPI`
+
+| Route | Since |
+|-------|-------|
+| `GET /enable` | v0.2.0 |
+
+### `client.ValidateCloudToken`
+
+| Route | Since |
+|-------|-------|
+| `POST /cloud-tokens/{uuid}/validate` | v0.2.0 |
+
+### `coolify_*_database`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /databases/{uuid}` | v0.1.0 |
+| `PATCH /databases/{uuid}` | v0.1.0 |
+
+### `coolify_api_settings`
+
+| Route | Since |
+|-------|-------|
+| `POST /disable` | v0.2.0 |
+| `POST /enable` | v0.2.0 |
+
+### `coolify_api_settings (mcp_enabled)`
+
+| Route | Since |
+|-------|-------|
+| `POST /mcp/disable` | v0.4.0 |
+| `POST /mcp/enable` | v0.4.0 |
+
+### `coolify_application`
+
+| Route | Since |
+|-------|-------|
+| `POST /applications/public` | v0.1.0 |
+
+### `coolify_application + variants`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}` | v0.1.0 |
+| `PATCH /applications/{uuid}` | v0.1.0 |
+
+### `coolify_application_destination`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/destinations/{destination_uuid}` | v0.1.15 |
+| `GET /applications/{uuid}/destinations` | v0.1.15 |
+| `POST /applications/{uuid}/destinations` | v0.1.15 |
+
+### `coolify_application_docker_image`
+
+| Route | Since |
+|-------|-------|
+| `POST /applications/dockerimage` | v0.1.0 |
+
+### `coolify_application_dockerfile`
+
+| Route | Since |
+|-------|-------|
+| `POST /applications/dockerfile` | v0.2.0 |
+
+### `coolify_application_github_app`
+
+| Route | Since |
+|-------|-------|
+| `POST /applications/private-github-app` | v0.2.0 |
+
+### `coolify_application_private_git`
+
+| Route | Since |
+|-------|-------|
+| `POST /applications/private-deploy-key` | v0.1.0 |
+
+### `coolify_cloud_init_script`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /cloud-init-scripts/{uuid}` | v0.1.15 |
+| `GET /cloud-init-scripts` | v0.1.15 |
+| `GET /cloud-init-scripts/{uuid}` | v0.1.15 |
+| `PATCH /cloud-init-scripts/{uuid}` | v0.1.15 |
+| `POST /cloud-init-scripts` | v0.1.15 |
+
+### `coolify_cloud_token`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /cloud-tokens/{uuid}` | v0.2.0 |
+| `PATCH /cloud-tokens/{uuid}` | v0.2.0 |
+| `POST /cloud-tokens` | v0.2.0 |
+
+### `coolify_database_backup`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}` | v0.1.0 |
+| `GET /databases/{uuid}/backups` | v0.1.0 |
+| `PATCH /databases/{uuid}/backups/{scheduled_backup_uuid}` | v0.1.0 |
+| `POST /databases/{uuid}/backups` | v0.1.0 |
+
+### `coolify_database_clickhouse`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/clickhouse` | v0.1.0 |
+
+### `coolify_database_dragonfly`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/dragonfly` | v0.1.0 |
+
+### `coolify_database_keydb`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/keydb` | v0.1.0 |
+
+### `coolify_database_mariadb`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/mariadb` | v0.1.0 |
+
+### `coolify_database_mongodb`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/mongodb` | v0.1.0 |
+
+### `coolify_database_mysql`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/mysql` | v0.1.0 |
+
+### `coolify_database_postgresql`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/postgresql` | v0.1.0 |
+
+### `coolify_database_redis`
+
+| Route | Since |
+|-------|-------|
+| `POST /databases/redis` | v0.1.0 |
+
+### `coolify_deployment`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/restart` | v0.1.0 |
+| `GET /deployments/{uuid}` | v0.1.0 |
+
+### `coolify_destination`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /destinations/{uuid}` | v0.2.0 |
+| `PATCH /destinations/{uuid}` | v0.1.15 |
+| `POST /servers/{server_uuid}/destinations` | v0.2.0 |
+
+### `coolify_environment`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}` | v0.2.0 |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}` | v0.1.15 |
+| `POST /projects/{uuid}/environments` | v0.2.0 |
+
+### `coolify_environment_variable`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/envs/{env_uuid}` | v0.1.0 |
+| `DELETE /databases/{uuid}/envs/{env_uuid}` | v0.2.0 |
+| `DELETE /services/{uuid}/envs/{env_uuid}` | v0.1.0 |
+| `PATCH /applications/{uuid}/envs` | v0.1.0 |
+| `PATCH /databases/{uuid}/envs` | v0.2.0 |
+| `PATCH /services/{uuid}/envs` | v0.1.0 |
+| `POST /applications/{uuid}/envs` | v0.1.0 |
+| `POST /databases/{uuid}/envs` | v0.2.0 |
+| `POST /services/{uuid}/envs` | v0.1.0 |
+
+### `coolify_github_app`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /github-apps/{github_app_id}` | v0.2.0 |
+| `PATCH /github-apps/{github_app_id}` | v0.2.0 |
+| `POST /github-apps` | v0.2.0 |
+
+### `coolify_gitlab_app`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /gitlab-apps/{gitlab_app_id}` | v0.1.15 |
+| `GET /gitlab-apps` | v0.1.15 |
+| `PATCH /gitlab-apps/{gitlab_app_id}` | v0.1.15 |
+| `POST /gitlab-apps` | v0.1.15 |
+
+### `coolify_notification_discord`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/discord` | v0.1.14 |
+| `PATCH /notifications/discord` | v0.1.14 |
+
+### `coolify_notification_email`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/email` | v0.1.14 |
+| `PATCH /notifications/email` | v0.1.14 |
+
+### `coolify_notification_pushover`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/pushover` | v0.1.14 |
+| `PATCH /notifications/pushover` | v0.1.14 |
+
+### `coolify_notification_slack`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/slack` | v0.1.14 |
+| `PATCH /notifications/slack` | v0.1.14 |
+
+### `coolify_notification_telegram`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/telegram` | v0.1.14 |
+| `PATCH /notifications/telegram` | v0.1.14 |
+
+### `coolify_notification_webhook`
+
+| Route | Since |
+|-------|-------|
+| `GET /notifications/webhook` | v0.1.14 |
+| `PATCH /notifications/webhook` | v0.1.14 |
+
+### `coolify_private_key`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /security/keys/{uuid}` | v0.1.0 |
+| `PATCH /security/keys/{uuid}` | v0.1.0 |
+| `POST /security/keys` | v0.1.0 |
+
+### `coolify_project`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /projects/{uuid}` | v0.1.0 |
+| `PATCH /projects/{uuid}` | v0.1.0 |
+| `POST /projects` | v0.1.0 |
+
+### `coolify_resource_action`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/start` | v0.3.0 |
+| `GET /applications/{uuid}/stop` | v0.3.0 |
+| `GET /databases/{uuid}/restart` | v0.3.0 |
+| `GET /databases/{uuid}/start` | v0.3.0 |
+| `GET /databases/{uuid}/stop` | v0.3.0 |
+| `GET /services/{uuid}/restart` | v0.3.0 |
+| `GET /services/{uuid}/start` | v0.3.0 |
+| `GET /services/{uuid}/stop` | v0.3.0 |
+| `POST /applications/{uuid}/restart` | v0.3.0 |
+| `POST /applications/{uuid}/start` | v0.3.0 |
+| `POST /applications/{uuid}/stop` | v0.3.0 |
+| `POST /databases/{uuid}/restart` | v0.3.0 |
+| `POST /databases/{uuid}/start` | v0.3.0 |
+| `POST /databases/{uuid}/stop` | v0.3.0 |
+| `POST /services/{uuid}/restart` | v0.3.0 |
+| `POST /services/{uuid}/start` | v0.3.0 |
+| `POST /services/{uuid}/stop` | v0.3.0 |
+
+### `coolify_s3_storage`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /s3-storages/{uuid}` | v0.1.13 |
+| `PATCH /s3-storages/{uuid}` | v0.1.13 |
+| `POST /s3-storages` | v0.1.13 |
+
+### `coolify_s3_storage_validate`
+
+| Route | Since |
+|-------|-------|
+| `POST /s3-storages/{uuid}/validate` | v0.1.14 |
+
+### `coolify_scheduled_task`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/scheduled-tasks/{task_uuid}` | v0.2.0 |
+| `DELETE /services/{uuid}/scheduled-tasks/{task_uuid}` | v0.2.0 |
+| `PATCH /applications/{uuid}/scheduled-tasks/{task_uuid}` | v0.2.0 |
+| `PATCH /services/{uuid}/scheduled-tasks/{task_uuid}` | v0.2.0 |
+| `POST /applications/{uuid}/scheduled-tasks` | v0.2.0 |
+| `POST /services/{uuid}/scheduled-tasks` | v0.2.0 |
+
+### `coolify_server`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /servers/{uuid}` | v0.1.0 |
+| `PATCH /servers/{uuid}` | v0.1.0 |
+| `POST /servers` | v0.1.0 |
+
+### `coolify_server_cloudflare_tunnel`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/cloudflare-tunnel` | v0.1.15 |
+| `PATCH /servers/{uuid}/cloudflare-tunnel` | v0.1.15 |
+
+### `coolify_server_digitalocean`
+
+| Route | Since |
+|-------|-------|
+| `POST /servers/digitalocean` | v0.2.0 |
+
+### `coolify_server_docker_cleanup`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/docker-cleanup` | v0.1.15 |
+| `PATCH /servers/{uuid}/docker-cleanup` | v0.1.15 |
+
+### `coolify_server_hetzner`
+
+| Route | Since |
+|-------|-------|
+| `POST /servers/hetzner` | v0.2.0 |
+
+### `coolify_server_log_drain`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/log-drains` | v0.1.15 |
+| `PATCH /servers/{uuid}/log-drains` | v0.1.15 |
+
+### `coolify_server_proxy`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/proxy` | v0.1.15 |
+| `PATCH /servers/{uuid}/proxy` | v0.1.15 |
+| `PUT /servers/{uuid}/proxy/configuration` | v0.1.15 |
+
+### `coolify_server_sentinel`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/sentinel` | v0.1.15 |
+| `PATCH /servers/{uuid}/sentinel` | v0.1.15 |
+
+### `coolify_server_validate`
+
+| Route | Since |
+|-------|-------|
+| `POST /servers/{uuid}/validate` | v0.2.0 |
+
+### `coolify_server_vultr`
+
+| Route | Since |
+|-------|-------|
+| `POST /servers/vultr` | v0.2.0 |
+
+### `coolify_service`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /services/{uuid}` | v0.1.0 |
+| `PATCH /services/{uuid}` | v0.1.0 |
+| `POST /services` | v0.1.0 |
+
+### `coolify_shared_environment_variable`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | v0.1.15 |
+| `DELETE /projects/{uuid}/envs/{env_id}` | v0.1.15 |
+| `DELETE /servers/{uuid}/envs/{env_id}` | v0.1.15 |
+| `DELETE /team/envs/{env_id}` | v0.1.15 |
+| `GET /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | v0.1.15 |
+| `GET /projects/{uuid}/envs` | v0.1.15 |
+| `GET /servers/{uuid}/envs` | v0.1.15 |
+| `GET /team/envs` | v0.1.15 |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | v0.1.15 |
+| `PATCH /projects/{uuid}/envs/{env_id}` | v0.1.15 |
+| `PATCH /servers/{uuid}/envs/{env_id}` | v0.1.15 |
+| `PATCH /team/envs/{env_id}` | v0.1.15 |
+| `POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | v0.1.15 |
+| `POST /projects/{uuid}/envs` | v0.1.15 |
+| `POST /servers/{uuid}/envs` | v0.1.15 |
+| `POST /team/envs` | v0.1.15 |
+
+### `coolify_storage`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/storages/{storage_uuid}` | v0.2.0 |
+| `DELETE /databases/{uuid}/storages/{storage_uuid}` | v0.2.0 |
+| `DELETE /services/{uuid}/storages/{storage_uuid}` | v0.2.0 |
+| `PATCH /applications/{uuid}/storages` | v0.2.0 |
+| `PATCH /databases/{uuid}/storages` | v0.2.0 |
+| `PATCH /services/{uuid}/storages` | v0.2.0 |
+| `POST /applications/{uuid}/storages` | v0.2.0 |
+| `POST /databases/{uuid}/storages` | v0.2.0 |
+| `POST /services/{uuid}/storages` | v0.2.0 |
+
+### `coolify_storage_backup`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+| `DELETE /databases/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+| `DELETE /services/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+| `PUT /applications/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+| `PUT /databases/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+| `PUT /services/{uuid}/storages/{storage_uuid}/backups` | v0.1.9 |
+
+### `coolify_tag + coolify_resource_tag`
+
+| Route | Since |
+|-------|-------|
+| `DELETE /applications/{uuid}/tags/{tag_uuid}` | v0.1.15 |
+| `DELETE /databases/{uuid}/tags/{tag_uuid}` | v0.1.15 |
+| `DELETE /services/{uuid}/tags/{tag_uuid}` | v0.1.15 |
+| `DELETE /tags/{uuid}` | v0.1.15 |
+| `GET /applications/{uuid}/tags` | v0.1.15 |
+| `GET /databases/{uuid}/tags` | v0.1.15 |
+| `GET /services/{uuid}/tags` | v0.1.15 |
+| `GET /tags` | v0.1.15 |
+| `PATCH /tags/{uuid}` | v0.1.15 |
+| `POST /applications/{uuid}/tags` | v0.1.15 |
+| `POST /databases/{uuid}/tags` | v0.1.15 |
+| `POST /services/{uuid}/tags` | v0.1.15 |
+| `POST /tags` | v0.1.15 |
+
+### `data.coolify_application`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}` | v0.1.0 |
+
+### `data.coolify_application_logs`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/logs` | v0.2.0 |
+
+### `data.coolify_applications`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications` | v0.1.0 |
+
+### `data.coolify_backup_executions`
+
+| Route | Since |
+|-------|-------|
+| `GET /databases/{uuid}/backups/{scheduled_backup_uuid}/executions` | v0.2.0 |
+
+### `data.coolify_cloud_token`
+
+| Route | Since |
+|-------|-------|
+| `GET /cloud-tokens/{uuid}` | v0.2.0 |
+
+### `data.coolify_cloud_tokens`
+
+| Route | Since |
+|-------|-------|
+| `GET /cloud-tokens` | v0.2.0 |
+
+### `data.coolify_database`
+
+| Route | Since |
+|-------|-------|
+| `GET /databases/{uuid}` | v0.1.0 |
+
+### `data.coolify_databases`
+
+| Route | Since |
+|-------|-------|
+| `GET /databases` | v0.1.0 |
+
+### `data.coolify_deployments`
+
+| Route | Since |
+|-------|-------|
+| `GET /deployments` | v0.2.0 |
+| `GET /deployments/applications/{uuid}` | v0.2.0 |
+
+### `data.coolify_destination`
+
+| Route | Since |
+|-------|-------|
+| `GET /destinations/{uuid}` | v0.2.0 |
+
+### `data.coolify_destinations`
+
+| Route | Since |
+|-------|-------|
+| `GET /destinations` | v0.2.0 |
+| `GET /servers/{server_uuid}/destinations` | v0.2.0 |
+
+### `data.coolify_digitalocean_images`
+
+| Route | Since |
+|-------|-------|
+| `GET /digitalocean/images` | v0.2.0 |
+
+### `data.coolify_digitalocean_regions`
+
+| Route | Since |
+|-------|-------|
+| `GET /digitalocean/regions` | v0.2.0 |
+
+### `data.coolify_digitalocean_sizes`
+
+| Route | Since |
+|-------|-------|
+| `GET /digitalocean/sizes` | v0.2.0 |
+
+### `data.coolify_digitalocean_ssh_keys`
+
+| Route | Since |
+|-------|-------|
+| `GET /digitalocean/ssh-keys` | v0.2.0 |
+
+### `data.coolify_environment`
+
+| Route | Since |
+|-------|-------|
+| `GET /projects/{uuid}/{environment_name_or_uuid}` | v0.2.0 |
+
+### `data.coolify_environment_variables`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/envs` | v0.1.0 |
+| `GET /databases/{uuid}/envs` | v0.2.0 |
+| `GET /services/{uuid}/envs` | v0.2.0 |
+
+### `data.coolify_environments`
+
+| Route | Since |
+|-------|-------|
+| `GET /projects/{uuid}/environments` | v0.2.0 |
+
+### `data.coolify_github_app_branches`
+
+| Route | Since |
+|-------|-------|
+| `GET /github-apps/{github_app_id}/repositories/{owner}/{repo}/branches` | v0.2.0 |
+
+### `data.coolify_github_app_repositories`
+
+| Route | Since |
+|-------|-------|
+| `GET /github-apps/{github_app_id}/repositories` | v0.2.0 |
+
+### `data.coolify_github_apps`
+
+| Route | Since |
+|-------|-------|
+| `GET /github-apps` | v0.2.0 |
+
+### `data.coolify_health`
+
+| Route | Since |
+|-------|-------|
+| `GET /health` | v0.2.0 |
+
+### `data.coolify_hetzner_images`
+
+| Route | Since |
+|-------|-------|
+| `GET /hetzner/images` | v0.2.0 |
+
+### `data.coolify_hetzner_locations`
+
+| Route | Since |
+|-------|-------|
+| `GET /hetzner/locations` | v0.2.0 |
+
+### `data.coolify_hetzner_server_types`
+
+| Route | Since |
+|-------|-------|
+| `GET /hetzner/server-types` | v0.2.0 |
+
+### `data.coolify_hetzner_ssh_keys`
+
+| Route | Since |
+|-------|-------|
+| `GET /hetzner/ssh-keys` | v0.2.0 |
+
+### `data.coolify_private_key`
+
+| Route | Since |
+|-------|-------|
+| `GET /security/keys/{uuid}` | v0.1.0 |
+
+### `data.coolify_private_keys`
+
+| Route | Since |
+|-------|-------|
+| `GET /security/keys` | v0.1.0 |
+
+### `data.coolify_project`
+
+| Route | Since |
+|-------|-------|
+| `GET /projects/{uuid}` | v0.1.0 |
+
+### `data.coolify_projects`
+
+| Route | Since |
+|-------|-------|
+| `GET /projects` | v0.1.0 |
+
+### `data.coolify_resources`
+
+| Route | Since |
+|-------|-------|
+| `GET /resources` | v0.2.0 |
+
+### `data.coolify_s3_storage`
+
+| Route | Since |
+|-------|-------|
+| `GET /s3-storages/{uuid}` | v0.1.13 |
+
+### `data.coolify_s3_storages`
+
+| Route | Since |
+|-------|-------|
+| `GET /s3-storages` | v0.1.13 |
+
+### `data.coolify_scheduled_tasks`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/scheduled-tasks` | v0.2.0 |
+| `GET /services/{uuid}/scheduled-tasks` | v0.2.0 |
+
+### `data.coolify_server`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}` | v0.1.0 |
+
+### `data.coolify_server_domains`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/domains` | v0.1.0 |
+
+### `data.coolify_server_resources`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/resources` | v0.1.0 |
+
+### `data.coolify_server_validation`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers/{uuid}/validate` | v0.2.0 |
+
+### `data.coolify_servers`
+
+| Route | Since |
+|-------|-------|
+| `GET /servers` | v0.1.0 |
+
+### `data.coolify_service`
+
+| Route | Since |
+|-------|-------|
+| `GET /services/{uuid}` | v0.1.0 |
+
+### `data.coolify_services`
+
+| Route | Since |
+|-------|-------|
+| `GET /services` | v0.1.0 |
+
+### `data.coolify_storages`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/storages` | v0.2.0 |
+| `GET /databases/{uuid}/storages` | v0.2.0 |
+| `GET /services/{uuid}/storages` | v0.2.0 |
+
+### `data.coolify_task_executions`
+
+| Route | Since |
+|-------|-------|
+| `GET /applications/{uuid}/scheduled-tasks/{task_uuid}/executions` | v0.2.0 |
+| `GET /services/{uuid}/scheduled-tasks/{task_uuid}/executions` | v0.2.0 |
+
+### `data.coolify_team`
+
+| Route | Since |
+|-------|-------|
+| `GET /teams/{id}` | v0.1.0 |
+
+### `data.coolify_team_members`
+
+| Route | Since |
+|-------|-------|
+| `GET /teams/current` | v0.2.0 |
+| `GET /teams/current/members` | v0.2.0 |
+| `GET /teams/{id}/members` | v0.2.0 |
+
+### `data.coolify_teams`
+
+| Route | Since |
+|-------|-------|
+| `GET /teams` | v0.2.0 |
+
+### `data.coolify_version`
+
+| Route | Since |
+|-------|-------|
+| `GET /version` | v0.1.0 |
+
+### `data.coolify_vultr_os`
+
+| Route | Since |
+|-------|-------|
+| `GET /vultr/os` | v0.2.0 |
+
+### `data.coolify_vultr_plans`
+
+| Route | Since |
+|-------|-------|
+| `GET /vultr/plans` | v0.2.0 |
+
+### `data.coolify_vultr_regions`
+
+| Route | Since |
+|-------|-------|
+| `GET /vultr/regions` | v0.2.0 |
+
+### `data.coolify_vultr_ssh_keys`
+
+| Route | Since |
+|-------|-------|
+| `GET /vultr/ssh-keys` | v0.2.0 |
+
+## Appendix: all classified routes
+
+Completeness tests use this list. Sorted by `METHOD /path`.
+
+| Route | Status | Resource or skip class |
+|-------|--------|------------------------|
+| `DELETE /applications/{uuid}` | covered | `coolify_application + variants` |
+| `DELETE /applications/{uuid}/destinations/{destination_uuid}` | covered | `coolify_application_destination` |
+| `DELETE /applications/{uuid}/envs/{env_uuid}` | covered | `coolify_environment_variable` |
+| `DELETE /applications/{uuid}/previews/{pull_request_id}` | covered | `client.DeletePreviewDeployment` |
+| `DELETE /applications/{uuid}/scheduled-tasks/{task_uuid}` | covered | `coolify_scheduled_task` |
+| `DELETE /applications/{uuid}/storages/{storage_uuid}` | covered | `coolify_storage` |
+| `DELETE /applications/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
+| `DELETE /applications/{uuid}/tags/{tag_uuid}` | covered | `coolify_tag + coolify_resource_tag` |
+| `DELETE /cloud-init-scripts/{uuid}` | covered | `coolify_cloud_init_script` |
+| `DELETE /cloud-tokens/{uuid}` | covered | `coolify_cloud_token` |
+| `DELETE /databases/{uuid}` | covered | `coolify_*_database` |
+| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}` | covered | `coolify_database_backup` |
+| `DELETE /databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}` | covered | `client.DeleteBackupExecution` |
+| `DELETE /databases/{uuid}/envs/{env_uuid}` | covered | `coolify_environment_variable` |
+| `DELETE /databases/{uuid}/storages/{storage_uuid}` | covered | `coolify_storage` |
+| `DELETE /databases/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
+| `DELETE /databases/{uuid}/tags/{tag_uuid}` | covered | `coolify_tag + coolify_resource_tag` |
+| `DELETE /destinations/{uuid}` | covered | `coolify_destination` |
+| `DELETE /github-apps/{github_app_id}` | covered | `coolify_github_app` |
+| `DELETE /gitlab-apps/{gitlab_app_id}` | covered | `coolify_gitlab_app` |
+| `DELETE /projects/{uuid}` | covered | `coolify_project` |
+| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}` | covered | `coolify_environment` |
+| `DELETE /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `DELETE /projects/{uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `DELETE /s3-storages/{uuid}` | covered | `coolify_s3_storage` |
+| `DELETE /security/keys/{uuid}` | covered | `coolify_private_key` |
+| `DELETE /servers/{uuid}` | covered | `coolify_server` |
+| `DELETE /servers/{uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `DELETE /services/{uuid}` | covered | `coolify_service` |
+| `DELETE /services/{uuid}/envs/{env_uuid}` | covered | `coolify_environment_variable` |
+| `DELETE /services/{uuid}/scheduled-tasks/{task_uuid}` | covered | `coolify_scheduled_task` |
+| `DELETE /services/{uuid}/storages/{storage_uuid}` | covered | `coolify_storage` |
+| `DELETE /services/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
+| `DELETE /services/{uuid}/tags/{tag_uuid}` | covered | `coolify_tag + coolify_resource_tag` |
+| `DELETE /tags/{uuid}` | covered | `coolify_tag + coolify_resource_tag` |
+| `DELETE /team/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `GET /applications` | covered | `data.coolify_applications` |
+| `GET /applications/{uuid}` | covered | `data.coolify_application` |
+| `GET /applications/{uuid}/destinations` | covered | `coolify_application_destination` |
+| `GET /applications/{uuid}/envs` | covered | `data.coolify_environment_variables` |
+| `GET /applications/{uuid}/logs` | covered | `data.coolify_application_logs` |
+| `GET /applications/{uuid}/restart` | covered | `coolify_deployment` |
+| `GET /applications/{uuid}/rollback-images` | skipped | `rollback` |
+| `GET /applications/{uuid}/scheduled-tasks` | covered | `data.coolify_scheduled_tasks` |
+| `GET /applications/{uuid}/scheduled-tasks/{task_uuid}/executions` | covered | `data.coolify_task_executions` |
+| `GET /applications/{uuid}/start` | covered | `coolify_resource_action` |
+| `GET /applications/{uuid}/stop` | covered | `coolify_resource_action` |
+| `GET /applications/{uuid}/storages` | covered | `data.coolify_storages` |
+| `GET /applications/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `GET /cloud-init-scripts` | covered | `coolify_cloud_init_script` |
+| `GET /cloud-init-scripts/{uuid}` | covered | `coolify_cloud_init_script` |
+| `GET /cloud-tokens` | covered | `data.coolify_cloud_tokens` |
+| `GET /cloud-tokens/{uuid}` | covered | `data.coolify_cloud_token` |
+| `GET /databases` | covered | `data.coolify_databases` |
+| `GET /databases/{uuid}` | covered | `data.coolify_database` |
+| `GET /databases/{uuid}/backups` | covered | `coolify_database_backup` |
+| `GET /databases/{uuid}/backups/{scheduled_backup_uuid}/executions` | covered | `data.coolify_backup_executions` |
+| `GET /databases/{uuid}/envs` | covered | `data.coolify_environment_variables` |
+| `GET /databases/{uuid}/logs` | skipped | `logs` |
+| `GET /databases/{uuid}/restart` | covered | `coolify_resource_action` |
+| `GET /databases/{uuid}/start` | covered | `coolify_resource_action` |
+| `GET /databases/{uuid}/stop` | covered | `coolify_resource_action` |
+| `GET /databases/{uuid}/storages` | covered | `data.coolify_storages` |
+| `GET /databases/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `GET /deploy` | covered | `client.Deploy` |
+| `GET /deployments` | covered | `data.coolify_deployments` |
+| `GET /deployments/applications/{uuid}` | covered | `data.coolify_deployments` |
+| `GET /deployments/{uuid}` | covered | `coolify_deployment` |
+| `GET /destinations` | covered | `data.coolify_destinations` |
+| `GET /destinations/{uuid}` | covered | `data.coolify_destination` |
+| `GET /digitalocean/images` | covered | `data.coolify_digitalocean_images` |
+| `GET /digitalocean/regions` | covered | `data.coolify_digitalocean_regions` |
+| `GET /digitalocean/sizes` | covered | `data.coolify_digitalocean_sizes` |
+| `GET /digitalocean/ssh-keys` | covered | `data.coolify_digitalocean_ssh_keys` |
+| `GET /disable` | covered | `client.DisableAPI` |
+| `GET /enable` | covered | `client.EnableAPI` |
+| `GET /github-apps` | covered | `data.coolify_github_apps` |
+| `GET /github-apps/{github_app_id}/repositories` | covered | `data.coolify_github_app_repositories` |
+| `GET /github-apps/{github_app_id}/repositories/{owner}/{repo}/branches` | covered | `data.coolify_github_app_branches` |
+| `GET /gitlab-apps` | covered | `coolify_gitlab_app` |
+| `GET /health` | covered | `data.coolify_health` |
+| `GET /hetzner/firewalls` | skipped | `hetzner-extra` |
+| `GET /hetzner/images` | covered | `data.coolify_hetzner_images` |
+| `GET /hetzner/locations` | covered | `data.coolify_hetzner_locations` |
+| `GET /hetzner/networks` | skipped | `hetzner-extra` |
+| `GET /hetzner/server-types` | covered | `data.coolify_hetzner_server_types` |
+| `GET /hetzner/ssh-keys` | covered | `data.coolify_hetzner_ssh_keys` |
+| `GET /notifications/discord` | covered | `coolify_notification_discord` |
+| `GET /notifications/email` | covered | `coolify_notification_email` |
+| `GET /notifications/pushover` | covered | `coolify_notification_pushover` |
+| `GET /notifications/slack` | covered | `coolify_notification_slack` |
+| `GET /notifications/telegram` | covered | `coolify_notification_telegram` |
+| `GET /notifications/webhook` | covered | `coolify_notification_webhook` |
+| `GET /projects` | covered | `data.coolify_projects` |
+| `GET /projects/{uuid}` | covered | `data.coolify_project` |
+| `GET /projects/{uuid}/environments` | covered | `data.coolify_environments` |
+| `GET /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `GET /projects/{uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `GET /projects/{uuid}/{environment_name_or_uuid}` | covered | `data.coolify_environment` |
+| `GET /resources` | covered | `data.coolify_resources` |
+| `GET /s3-storages` | covered | `data.coolify_s3_storages` |
+| `GET /s3-storages/{uuid}` | covered | `data.coolify_s3_storage` |
+| `GET /security/keys` | covered | `data.coolify_private_keys` |
+| `GET /security/keys/{uuid}` | covered | `data.coolify_private_key` |
+| `GET /servers` | covered | `data.coolify_servers` |
+| `GET /servers/{server_uuid}/destinations` | covered | `data.coolify_destinations` |
+| `GET /servers/{uuid}` | covered | `data.coolify_server` |
+| `GET /servers/{uuid}/cloudflare-tunnel` | covered | `coolify_server_cloudflare_tunnel` |
+| `GET /servers/{uuid}/docker-cleanup` | covered | `coolify_server_docker_cleanup` |
+| `GET /servers/{uuid}/docker-cleanup/executions` | skipped | `control-plane` |
+| `GET /servers/{uuid}/domains` | covered | `data.coolify_server_domains` |
+| `GET /servers/{uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `GET /servers/{uuid}/export` | skipped | `control-plane` |
+| `GET /servers/{uuid}/log-drains` | covered | `coolify_server_log_drain` |
+| `GET /servers/{uuid}/proxy` | covered | `coolify_server_proxy` |
+| `GET /servers/{uuid}/resources` | covered | `data.coolify_server_resources` |
+| `GET /servers/{uuid}/sentinel` | covered | `coolify_server_sentinel` |
+| `GET /servers/{uuid}/validate` | covered | `data.coolify_server_validation` |
+| `GET /services` | covered | `data.coolify_services` |
+| `GET /services/{uuid}` | covered | `data.coolify_service` |
+| `GET /services/{uuid}/applications` | skipped | `nested-service` |
+| `GET /services/{uuid}/applications/{app_uuid}` | skipped | `nested-service` |
+| `GET /services/{uuid}/applications/{app_uuid}/logs` | skipped | `logs` |
+| `GET /services/{uuid}/applications/{app_uuid}/restart` | skipped | `nested-service` |
+| `GET /services/{uuid}/applications/{app_uuid}/start` | skipped | `nested-service` |
+| `GET /services/{uuid}/applications/{app_uuid}/stop` | skipped | `nested-service` |
+| `GET /services/{uuid}/databases` | skipped | `nested-service` |
+| `GET /services/{uuid}/databases/{database_uuid}` | skipped | `nested-service` |
+| `GET /services/{uuid}/databases/{database_uuid}/logs` | skipped | `logs` |
+| `GET /services/{uuid}/envs` | covered | `data.coolify_environment_variables` |
+| `GET /services/{uuid}/logs` | skipped | `logs` |
+| `GET /services/{uuid}/restart` | covered | `coolify_resource_action` |
+| `GET /services/{uuid}/scheduled-tasks` | covered | `data.coolify_scheduled_tasks` |
+| `GET /services/{uuid}/scheduled-tasks/{task_uuid}/executions` | covered | `data.coolify_task_executions` |
+| `GET /services/{uuid}/start` | covered | `coolify_resource_action` |
+| `GET /services/{uuid}/stop` | covered | `coolify_resource_action` |
+| `GET /services/{uuid}/storages` | covered | `data.coolify_storages` |
+| `GET /services/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `GET /tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `GET /team` | skipped | `alias` |
+| `GET /team/envs` | covered | `coolify_shared_environment_variable` |
+| `GET /team/members` | skipped | `alias` |
+| `GET /teams` | covered | `data.coolify_teams` |
+| `GET /teams/current` | covered | `data.coolify_team_members` |
+| `GET /teams/current/members` | covered | `data.coolify_team_members` |
+| `GET /teams/{id}` | covered | `data.coolify_team` |
+| `GET /teams/{id}/members` | covered | `data.coolify_team_members` |
+| `GET /version` | covered | `data.coolify_version` |
+| `GET /vultr/os` | covered | `data.coolify_vultr_os` |
+| `GET /vultr/plans` | covered | `data.coolify_vultr_plans` |
+| `GET /vultr/regions` | covered | `data.coolify_vultr_regions` |
+| `GET /vultr/ssh-keys` | covered | `data.coolify_vultr_ssh_keys` |
+| `PATCH /applications/{uuid}` | covered | `coolify_application + variants` |
+| `PATCH /applications/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `PATCH /applications/{uuid}/envs/bulk` | covered | `client.BulkUpdateEnvVars` |
+| `PATCH /applications/{uuid}/scheduled-tasks/{task_uuid}` | covered | `coolify_scheduled_task` |
+| `PATCH /applications/{uuid}/storages` | covered | `coolify_storage` |
+| `PATCH /cloud-init-scripts/{uuid}` | covered | `coolify_cloud_init_script` |
+| `PATCH /cloud-tokens/{uuid}` | covered | `coolify_cloud_token` |
+| `PATCH /databases/{uuid}` | covered | `coolify_*_database` |
+| `PATCH /databases/{uuid}/backups/{scheduled_backup_uuid}` | covered | `coolify_database_backup` |
+| `PATCH /databases/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `PATCH /databases/{uuid}/envs/bulk` | covered | `client.BulkUpdateEnvVars` |
+| `PATCH /databases/{uuid}/storages` | covered | `coolify_storage` |
+| `PATCH /destinations/{uuid}` | covered | `coolify_destination` |
+| `PATCH /github-apps/{github_app_id}` | covered | `coolify_github_app` |
+| `PATCH /gitlab-apps/{gitlab_app_id}` | covered | `coolify_gitlab_app` |
+| `PATCH /notifications/discord` | covered | `coolify_notification_discord` |
+| `PATCH /notifications/email` | covered | `coolify_notification_email` |
+| `PATCH /notifications/pushover` | covered | `coolify_notification_pushover` |
+| `PATCH /notifications/slack` | covered | `coolify_notification_slack` |
+| `PATCH /notifications/telegram` | covered | `coolify_notification_telegram` |
+| `PATCH /notifications/webhook` | covered | `coolify_notification_webhook` |
+| `PATCH /projects/{uuid}` | covered | `coolify_project` |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}` | covered | `coolify_environment` |
+| `PATCH /projects/{uuid}/environments/{environment_name_or_uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `PATCH /projects/{uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `PATCH /s3-storages/{uuid}` | covered | `coolify_s3_storage` |
+| `PATCH /security/keys/{uuid}` | covered | `coolify_private_key` |
+| `PATCH /servers/{uuid}` | covered | `coolify_server` |
+| `PATCH /servers/{uuid}/cloudflare-tunnel` | covered | `coolify_server_cloudflare_tunnel` |
+| `PATCH /servers/{uuid}/docker-cleanup` | covered | `coolify_server_docker_cleanup` |
+| `PATCH /servers/{uuid}/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `PATCH /servers/{uuid}/log-drains` | covered | `coolify_server_log_drain` |
+| `PATCH /servers/{uuid}/proxy` | covered | `coolify_server_proxy` |
+| `PATCH /servers/{uuid}/sentinel` | covered | `coolify_server_sentinel` |
+| `PATCH /services/{uuid}` | covered | `coolify_service` |
+| `PATCH /services/{uuid}/applications/{app_uuid}` | skipped | `nested-service` |
+| `PATCH /services/{uuid}/databases/{database_uuid}` | skipped | `nested-service` |
+| `PATCH /services/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `PATCH /services/{uuid}/envs/bulk` | covered | `client.BulkUpdateEnvVars` |
+| `PATCH /services/{uuid}/scheduled-tasks/{task_uuid}` | covered | `coolify_scheduled_task` |
+| `PATCH /services/{uuid}/storages` | covered | `coolify_storage` |
+| `PATCH /tags/{uuid}` | covered | `coolify_tag + coolify_resource_tag` |
+| `PATCH /team/envs/{env_id}` | covered | `coolify_shared_environment_variable` |
+| `POST /applications/dockercompose` | skipped | `deprecated` |
+| `POST /applications/dockerfile` | covered | `coolify_application_dockerfile` |
+| `POST /applications/dockerimage` | covered | `coolify_application_docker_image` |
+| `POST /applications/private-deploy-key` | covered | `coolify_application_private_git` |
+| `POST /applications/private-github-app` | covered | `coolify_application_github_app` |
+| `POST /applications/public` | covered | `coolify_application` |
+| `POST /applications/{uuid}/clone` | skipped | `clone-move` |
+| `POST /applications/{uuid}/destinations` | covered | `coolify_application_destination` |
+| `POST /applications/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `POST /applications/{uuid}/migrate` | skipped | `clone-move` |
+| `POST /applications/{uuid}/move` | skipped | `clone-move` |
+| `POST /applications/{uuid}/restart` | covered | `coolify_resource_action` |
+| `POST /applications/{uuid}/rollback` | skipped | `rollback` |
+| `POST /applications/{uuid}/scheduled-tasks` | covered | `coolify_scheduled_task` |
+| `POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute` | skipped | `run-now` |
+| `POST /applications/{uuid}/start` | covered | `coolify_resource_action` |
+| `POST /applications/{uuid}/stop` | covered | `coolify_resource_action` |
+| `POST /applications/{uuid}/storages` | covered | `coolify_storage` |
+| `POST /applications/{uuid}/storages/{storage_uuid}/backups/run` | skipped | `run-now` |
+| `POST /applications/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `POST /cloud-init-scripts` | covered | `coolify_cloud_init_script` |
+| `POST /cloud-tokens` | covered | `coolify_cloud_token` |
+| `POST /cloud-tokens/{uuid}/validate` | covered | `client.ValidateCloudToken` |
+| `POST /databases/clickhouse` | covered | `coolify_database_clickhouse` |
+| `POST /databases/dragonfly` | covered | `coolify_database_dragonfly` |
+| `POST /databases/keydb` | covered | `coolify_database_keydb` |
+| `POST /databases/mariadb` | covered | `coolify_database_mariadb` |
+| `POST /databases/mongodb` | covered | `coolify_database_mongodb` |
+| `POST /databases/mysql` | covered | `coolify_database_mysql` |
+| `POST /databases/postgresql` | covered | `coolify_database_postgresql` |
+| `POST /databases/redis` | covered | `coolify_database_redis` |
+| `POST /databases/{uuid}/backups` | covered | `coolify_database_backup` |
+| `POST /databases/{uuid}/clone` | skipped | `clone-move` |
+| `POST /databases/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `POST /databases/{uuid}/migrate` | skipped | `clone-move` |
+| `POST /databases/{uuid}/move` | skipped | `clone-move` |
+| `POST /databases/{uuid}/restart` | covered | `coolify_resource_action` |
+| `POST /databases/{uuid}/start` | covered | `coolify_resource_action` |
+| `POST /databases/{uuid}/stop` | covered | `coolify_resource_action` |
+| `POST /databases/{uuid}/storages` | covered | `coolify_storage` |
+| `POST /databases/{uuid}/storages/{storage_uuid}/backups/run` | skipped | `run-now` |
+| `POST /databases/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `POST /deploy` | covered | `client.Deploy` |
+| `POST /deployments/{uuid}/cancel` | covered | `client.CancelDeployment` |
+| `POST /disable` | covered | `coolify_api_settings` |
+| `POST /enable` | covered | `coolify_api_settings` |
+| `POST /feedback` | skipped | `not-infra` |
+| `POST /github-apps` | covered | `coolify_github_app` |
+| `POST /gitlab-apps` | covered | `coolify_gitlab_app` |
+| `POST /mcp/disable` | covered | `coolify_api_settings (mcp_enabled)` |
+| `POST /mcp/enable` | covered | `coolify_api_settings (mcp_enabled)` |
+| `POST /projects` | covered | `coolify_project` |
+| `POST /projects/{uuid}/environments` | covered | `coolify_environment` |
+| `POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `POST /projects/{uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `POST /s3-storages` | covered | `coolify_s3_storage` |
+| `POST /s3-storages/{uuid}/validate` | covered | `coolify_s3_storage_validate` |
+| `POST /security/keys` | covered | `coolify_private_key` |
+| `POST /sentinel/push` | skipped | `control-plane` |
+| `POST /servers` | covered | `coolify_server` |
+| `POST /servers/digitalocean` | covered | `coolify_server_digitalocean` |
+| `POST /servers/hetzner` | covered | `coolify_server_hetzner` |
+| `POST /servers/import` | skipped | `control-plane` |
+| `POST /servers/vultr` | covered | `coolify_server_vultr` |
+| `POST /servers/{server_uuid}/destinations` | covered | `coolify_destination` |
+| `POST /servers/{uuid}/claim` | skipped | `control-plane` |
+| `POST /servers/{uuid}/cloudflare-tunnel/disable` | skipped | `enable-disable` |
+| `POST /servers/{uuid}/cloudflare-tunnel/enable` | skipped | `enable-disable` |
+| `POST /servers/{uuid}/docker-cleanup/run` | skipped | `control-plane` |
+| `POST /servers/{uuid}/envs` | covered | `coolify_shared_environment_variable` |
+| `POST /servers/{uuid}/export/mailbox` | skipped | `control-plane` |
+| `POST /servers/{uuid}/migrate` | skipped | `clone-move` |
+| `POST /servers/{uuid}/proxy/restart` | skipped | `control-plane` |
+| `POST /servers/{uuid}/transfer/complete` | skipped | `control-plane` |
+| `POST /servers/{uuid}/validate` | covered | `coolify_server_validate` |
+| `POST /services` | covered | `coolify_service` |
+| `POST /services/{uuid}/applications/{app_uuid}/logs` | skipped | `logs` |
+| `POST /services/{uuid}/applications/{app_uuid}/restart` | skipped | `nested-service` |
+| `POST /services/{uuid}/applications/{app_uuid}/start` | skipped | `nested-service` |
+| `POST /services/{uuid}/applications/{app_uuid}/stop` | skipped | `nested-service` |
+| `POST /services/{uuid}/clone` | skipped | `clone-move` |
+| `POST /services/{uuid}/databases/{database_uuid}/restart` | skipped | `nested-service` |
+| `POST /services/{uuid}/databases/{database_uuid}/start` | skipped | `nested-service` |
+| `POST /services/{uuid}/databases/{database_uuid}/stop` | skipped | `nested-service` |
+| `POST /services/{uuid}/envs` | covered | `coolify_environment_variable` |
+| `POST /services/{uuid}/migrate` | skipped | `clone-move` |
+| `POST /services/{uuid}/move` | skipped | `clone-move` |
+| `POST /services/{uuid}/restart` | covered | `coolify_resource_action` |
+| `POST /services/{uuid}/scheduled-tasks` | covered | `coolify_scheduled_task` |
+| `POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute` | skipped | `run-now` |
+| `POST /services/{uuid}/start` | covered | `coolify_resource_action` |
+| `POST /services/{uuid}/stop` | covered | `coolify_resource_action` |
+| `POST /services/{uuid}/storages` | covered | `coolify_storage` |
+| `POST /services/{uuid}/storages/{storage_uuid}/backups/run` | skipped | `run-now` |
+| `POST /services/{uuid}/tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `POST /tags` | covered | `coolify_tag + coolify_resource_tag` |
+| `POST /team/envs` | covered | `coolify_shared_environment_variable` |
+| `PUT /applications/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
+| `PUT /databases/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
+| `PUT /servers/{uuid}/proxy/configuration` | covered | `coolify_server_proxy` |
+| `PUT /services/{uuid}/storages/{storage_uuid}/backups` | covered | `coolify_storage_backup` |
 
 ## Unclassified contract routes
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 - [Quick Start](docs/guides/quickstart.md) -- deploy your first app in under 5 minutes
 - [Installation](docs/guides/installation.md) -- install and configure the provider
 - [Coolify Version Support](docs/guides/coolify-version-support.md) -- what works on Coolify 4.1, 4.2, and 4.3
+- [API Coverage](API_COVERAGE.md) -- Coolify HTTP routes the provider wraps, and what to use when it does not
 - [Examples](examples/) -- browse per-resource examples
 - [Scenarios](examples/scenarios/) -- see full-stack ACME Corp setups tested against a real Coolify instance
 - [Import Guide](docs/guides/import.md) -- adopt existing resources without rebuilding
@@ -88,6 +89,7 @@ For a working end-to-end setup, start with the [Quick Start](docs/guides/quickst
 ## Guides
 
 - [Coolify Version Support](docs/guides/coolify-version-support.md) -- what works on Coolify 4.1, 4.2, and 4.3
+- [API Coverage](API_COVERAGE.md) -- Coolify HTTP routes the provider wraps, and what to use when it does not
 - [Core Concepts](docs/guides/concepts.md) -- understand the resource model
 - [Choosing an Application Type](docs/guides/choosing-application-type.md) -- pick the right resource for your deployment method
 - [Connecting Resources](docs/guides/connecting-resources.md) -- wire apps to databases using Coolify's Docker networking

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -9,6 +9,11 @@ description: |-
 
 This guide answers: **which Coolify version do I need for each resource and field?**
 
+For Coolify HTTP routes the provider does not wrap (clone, rollback, log
+streams, one-shot backup run, nested compose apps), see
+[API Coverage](https://github.com/coolify-terraform/terraform-provider-coolify/blob/main/API_COVERAGE.md)
+on GitHub. That page lists each skip class and **what to use instead**.
+
 The provider hard-requires Coolify **v4.1.0 or later** on every `terraform plan` /
 `terraform apply`. Within that floor, some APIs only exist on newer Coolify
 lines. The provider still configures against older supported instances, but it

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ provider "coolify" {
 - **[Quick Start](guides/quickstart)** - Deploy your first application in under 5 minutes
 - **[Installation](guides/installation)** - Detailed setup and configuration options
 - **[Coolify Version Support](guides/coolify-version-support)** - What works on Coolify 4.1, 4.2, and 4.3
+- **[API Coverage](https://github.com/coolify-terraform/terraform-provider-coolify/blob/main/API_COVERAGE.md)** - Coolify HTTP routes the provider wraps, and what to use when it does not
 - **[Concepts](guides/concepts)** - How Coolify resources map to Terraform
 - **[Choosing an Application Type](guides/choosing-application-type)** - Pick the right resource for your deployment method
 - **[Connecting Resources](guides/connecting-resources)** - Wire apps to databases using Coolify's Docker networking

--- a/internal/spectest/coverage_doc.go
+++ b/internal/spectest/coverage_doc.go
@@ -1,0 +1,291 @@
+package spectest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Skip class IDs used by skipped() in coveredEndpoints().
+const (
+	skipCloneMove     = "clone-move"
+	skipRunNow        = "run-now"
+	skipRollback      = "rollback"
+	skipLogs          = "logs"
+	skipNestedService = "nested-service"
+	skipControlPlane  = "control-plane"
+	skipEnableDisable = "enable-disable"
+	skipAlias         = "alias"
+	skipDeprecated    = "deprecated"
+	skipHetznerExtra  = "hetzner-extra"
+	skipFeedback      = "not-infra"
+)
+
+type skipKind struct {
+	id      string
+	title   string
+	why     string
+	instead string
+	order   int
+}
+
+// skipKindCatalog is the user-facing skip taxonomy. Every skipped() kind
+// must appear here or generateCoverageMarkdown fails closed.
+var skipKindCatalog = []skipKind{
+	{
+		id:    skipCloneMove,
+		title: "Clone, migrate, and move",
+		why:   "Coolify can copy or relocate an existing app, database, service, or server in one API call. Terraform then either owns two objects or loses the original.",
+		instead: "`coolify_application` (and variants), `coolify_database_*`, `coolify_service`, or `coolify_server` " +
+			"to create the destination. For a one-time move, use the Coolify UI.",
+		order: 1,
+	},
+	{
+		id:    skipRunNow,
+		title: "Run now (backup or scheduled task)",
+		why:   "These POSTs fire a single backup or task execution. They are not a schedule you can keep in state.",
+		instead: "`coolify_storage_backup` or `coolify_database_backup` for the schedule. " +
+			"`coolify_scheduled_task` for the task definition. Trigger a run from the Coolify UI when you need one now.",
+		order: 2,
+	},
+	{
+		id:      skipRollback,
+		title:   "Rollback and prior images",
+		why:     "Listing rollback images and posting a rollback is an operational recovery step, not desired state.",
+		instead: "The Coolify UI. There is no `coolify_rollback` resource.",
+		order:   3,
+	},
+	{
+		id:    skipLogs,
+		title: "Log streams",
+		why:   "Log endpoints stream runtime output. That is not durable Terraform state.",
+		instead: "`data.coolify_application_logs` for application logs. " +
+			"Database and service log streams stay in the Coolify UI.",
+		order: 4,
+	},
+	{
+		id:    skipNestedService,
+		title: "Nested compose service apps and databases",
+		why:   "A catalog `coolify_service` owns the whole compose stack. Coolify also exposes each inner app and database as its own API object.",
+		instead: "`coolify_service` for the stack. Do not manage inner " +
+			"`/services/{uuid}/applications/...` or `/services/{uuid}/databases/...` as separate resources.",
+		order: 5,
+	},
+	{
+		id:    skipControlPlane,
+		title: "Server control-plane actions",
+		why:   "Export, import, claim, transfer, Sentinel push, proxy restart, and one-shot docker cleanup are operator actions, not server settings.",
+		instead: "`coolify_server_proxy`, `coolify_server_sentinel`, `coolify_server_docker_cleanup`, " +
+			"and `coolify_server_cloudflare_tunnel` for settings. Use the Coolify UI for export, claim, transfer, and run-now cleanup.",
+		order: 6,
+	},
+	{
+		id:      skipEnableDisable,
+		title:   "Cloudflare tunnel enable and disable POSTs",
+		why:     "Coolify also has POST enable/disable routes. The provider writes tunnel settings with PATCH.",
+		instead: "`coolify_server_cloudflare_tunnel`.",
+		order:   7,
+	},
+	{
+		id:      skipAlias,
+		title:   "Team URL aliases",
+		why:     "`GET /team` and `GET /team/members` are aliases of `/teams/current` and `/teams/current/members`.",
+		instead: "`data.coolify_team` and `data.coolify_team_members`.",
+		order:   8,
+	},
+	{
+		id:      skipDeprecated,
+		title:   "Deprecated docker-compose create",
+		why:     "`POST /applications/dockercompose` creates a Service, not an Application. Coolify kept the path as a deprecated alias.",
+		instead: "`coolify_service` (`POST /services`).",
+		order:   9,
+	},
+	{
+		id:      skipHetznerExtra,
+		title:   "Hetzner firewalls and networks lists",
+		why:     "Coolify can list Hetzner firewalls and networks when provisioning. Those lists are not required to manage `coolify_server_hetzner`.",
+		instead: "`coolify_server_hetzner` for the server. Manage Hetzner firewalls and networks outside this provider if you need them.",
+		order:   10,
+	},
+	{
+		id:      skipFeedback,
+		title:   "Product feedback",
+		why:     "`POST /feedback` is a Coolify product endpoint, not infrastructure.",
+		instead: "Nothing in Terraform. Send feedback through Coolify.",
+		order:   11,
+	},
+}
+
+func skipKindByID() map[string]skipKind {
+	out := make(map[string]skipKind, len(skipKindCatalog))
+	for _, k := range skipKindCatalog {
+		out[k.id] = k
+	}
+	return out
+}
+
+type coverageEntry struct {
+	endpoint string
+	status   coverageStatus
+}
+
+func generateCoverageMarkdown(coverage map[string]coverageStatus) (string, error) {
+	kinds := skipKindByID()
+
+	var coveredList, plannedList, skippedList []coverageEntry
+	for ep, s := range coverage {
+		e := coverageEntry{endpoint: ep, status: s}
+		switch s.category {
+		case "covered":
+			coveredList = append(coveredList, e)
+		case "planned":
+			plannedList = append(plannedList, e)
+		case "skipped":
+			if _, ok := kinds[s.resource]; !ok {
+				return "", fmt.Errorf("skipped route %s has unknown kind %q", ep, s.resource)
+			}
+			skippedList = append(skippedList, e)
+		default:
+			return "", fmt.Errorf("route %s has unknown category %q", ep, s.category)
+		}
+	}
+
+	sort.Slice(coveredList, func(i, j int) bool { return coveredList[i].endpoint < coveredList[j].endpoint })
+	sort.Slice(plannedList, func(i, j int) bool {
+		if plannedList[i].status.priority != plannedList[j].status.priority {
+			return plannedList[i].status.priority < plannedList[j].status.priority
+		}
+		return plannedList[i].endpoint < plannedList[j].endpoint
+	})
+	sort.Slice(skippedList, func(i, j int) bool { return skippedList[i].endpoint < skippedList[j].endpoint })
+
+	total := len(coveredList) + len(plannedList) + len(skippedList)
+	pct := float64(len(coveredList)) / float64(total) * 100
+
+	var b strings.Builder
+	b.WriteString("# API Coverage\n\n")
+	b.WriteString("<!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->\n")
+	b.WriteString("<!-- Run: make api-coverage -->\n\n")
+
+	b.WriteString("This page answers: **which Coolify HTTP routes does the provider wrap, and what do I use when it does not?**\n\n")
+	b.WriteString("It is a **route inventory** against Coolify source (`testdata/contracts/coolify-v4.json`). ")
+	b.WriteString("It is not a field catalog, and it does not say which Coolify **version** you need.\n\n")
+	b.WriteString("- **Which Coolify version for each resource and field:** ")
+	b.WriteString("[Coolify Version Support](docs/guides/coolify-version-support.md)\n")
+	b.WriteString("- **Resource and attribute docs:** [docs/](docs/) (also on the Terraform Registry)\n")
+	b.WriteString("- **Field-level gaps** (numeric FKs, UI-only columns on an existing GET) live in ")
+	b.WriteString("`internal/spectest/contract_skips.go`, not in this route list.\n\n")
+
+	fmt.Fprintf(&b, "**Coverage**: %d covered / %d registry entries (%.1f%%)  \n", len(coveredList), total, pct)
+	fmt.Fprintf(&b, "**Planned**: %d | **Skipped**: %d  \n", len(plannedList), len(skippedList))
+	fmt.Fprintf(&b, "**Registry size**: %d (contract routes + allowlisted extras)\n", total)
+
+	writeSkipSections(&b, skippedList)
+	writeCoveredByResource(&b, coveredList)
+
+	if len(plannedList) > 0 {
+		b.WriteString("\n## Planned\n\n")
+		b.WriteString("Ordered by priority (1 = most needed by users).\n\n")
+		b.WriteString("| Priority | Endpoint | Notes |\n")
+		b.WriteString("|----------|----------|-------|\n")
+		for _, e := range plannedList {
+			fmt.Fprintf(&b, "| %d | `%s` | %s |\n", e.status.priority, e.endpoint, e.status.notes)
+		}
+	}
+
+	writeAppendix(&b, coveredList, skippedList, plannedList)
+
+	b.WriteString("\n## Unclassified contract routes\n\n")
+	b.WriteString("_None. All pin contract routes are classified in `coveredEndpoints()`._\n\n")
+	b.WriteString("When `make contract-extract` adds routes, classify them in\n")
+	b.WriteString("`internal/spectest/coverage_test.go` or `TestSpecCoverage_Completeness` fails.\n")
+
+	return b.String(), nil
+}
+
+func writeSkipSections(b *strings.Builder, skipped []coverageEntry) {
+	b.WriteString("\n## What Terraform does not wrap\n\n")
+	b.WriteString("Terraform models desired durable state. Coolify also exposes one-shot buttons, ")
+	b.WriteString("log streams, URL aliases, and control-plane actions. Those routes are skipped on purpose.\n")
+
+	byKind := make(map[string][]string)
+	for _, e := range skipped {
+		byKind[e.status.resource] = append(byKind[e.status.resource], e.endpoint)
+	}
+	for _, eps := range byKind {
+		sort.Strings(eps)
+	}
+
+	catalog := append([]skipKind(nil), skipKindCatalog...)
+	sort.Slice(catalog, func(i, j int) bool { return catalog[i].order < catalog[j].order })
+
+	for _, k := range catalog {
+		eps := byKind[k.id]
+		if len(eps) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, "\n### %s\n\n", k.title)
+		fmt.Fprintf(b, "%s\n\n", k.why)
+		fmt.Fprintf(b, "**Use this instead:** %s\n\n", k.instead)
+		b.WriteString("| Route |\n")
+		b.WriteString("|-------|\n")
+		for _, ep := range eps {
+			fmt.Fprintf(b, "| `%s` |\n", ep)
+		}
+	}
+}
+
+func writeCoveredByResource(b *strings.Builder, covered []coverageEntry) {
+	b.WriteString("\n## Routes by Terraform resource\n\n")
+	b.WriteString("A row here means the provider calls that Coolify route. ")
+	b.WriteString("`client.*` helpers are used from resources or are not a standalone resource.\n")
+
+	type row struct {
+		endpoint, since string
+	}
+	groups := map[string][]row{}
+	var names []string
+	seen := map[string]bool{}
+	for _, e := range covered {
+		name := e.status.resource
+		if name == "" {
+			name = "(unlabeled)"
+		}
+		groups[name] = append(groups[name], row{endpoint: e.endpoint, since: e.status.since})
+		if !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rows := groups[name]
+		sort.Slice(rows, func(i, j int) bool { return rows[i].endpoint < rows[j].endpoint })
+		fmt.Fprintf(b, "\n### `%s`\n\n", name)
+		b.WriteString("| Route | Since |\n")
+		b.WriteString("|-------|-------|\n")
+		for _, r := range rows {
+			fmt.Fprintf(b, "| `%s` | %s |\n", r.endpoint, r.since)
+		}
+	}
+}
+
+func writeAppendix(b *strings.Builder, covered, skipped, planned []coverageEntry) {
+	b.WriteString("\n## Appendix: all classified routes\n\n")
+	b.WriteString("Completeness tests use this list. Sorted by `METHOD /path`.\n\n")
+	b.WriteString("| Route | Status | Resource or skip class |\n")
+	b.WriteString("|-------|--------|------------------------|\n")
+
+	all := make([]coverageEntry, 0, len(covered)+len(skipped)+len(planned))
+	all = append(all, covered...)
+	all = append(all, skipped...)
+	all = append(all, planned...)
+	sort.Slice(all, func(i, j int) bool { return all[i].endpoint < all[j].endpoint })
+	for _, e := range all {
+		label := e.status.resource
+		if e.status.category == "planned" && e.status.notes != "" {
+			label = e.status.notes
+		}
+		fmt.Fprintf(b, "| `%s` | %s | `%s` |\n", e.endpoint, e.status.category, label)
+	}
+}

--- a/internal/spectest/coverage_doc.go
+++ b/internal/spectest/coverage_doc.go
@@ -6,6 +6,15 @@ import (
 	"strings"
 )
 
+// coverageStatus tracks a single API endpoint's provider coverage.
+type coverageStatus struct {
+	category string // "covered", "planned", "skipped"
+	resource string // Terraform resource name, or skip kind id when skipped
+	since    string // provider version that added support (covered only)
+	priority int    // 1=high, 2=medium, 3=low (planned only)
+	notes    string // human-readable context
+}
+
 // Skip class IDs used by skipped() in coveredEndpoints().
 const (
 	skipCloneMove     = "clone-move"

--- a/internal/spectest/coverage_test.go
+++ b/internal/spectest/coverage_test.go
@@ -10,15 +10,6 @@ import (
 	"testing"
 )
 
-// coverageStatus tracks a single API endpoint's provider coverage.
-type coverageStatus struct {
-	category string // "covered", "planned", "skipped"
-	resource string // Terraform resource name or skip reason
-	since    string // provider version that added support (covered only)
-	priority int    // 1=high, 2=medium, 3=low (planned only)
-	notes    string // human-readable context
-}
-
 // contractRoutePin is the pin contract whose routes[] define the coverage inventory.
 const contractRoutePin = "coolify-v4.json"
 

--- a/internal/spectest/coverage_test.go
+++ b/internal/spectest/coverage_test.go
@@ -43,8 +43,8 @@ func coveredEndpoints() map[string]coverageStatus {
 	covered := func(resource, since string) coverageStatus {
 		return coverageStatus{category: "covered", resource: resource, since: since}
 	}
-	skipped := func(reason string) coverageStatus {
-		return coverageStatus{category: "skipped", resource: reason}
+	skipped := func(kind string) coverageStatus {
+		return coverageStatus{category: "skipped", resource: kind}
 	}
 
 	return map[string]coverageStatus{
@@ -73,7 +73,7 @@ func coveredEndpoints() map[string]coverageStatus {
 		// ── Applications ──
 		"GET /applications":                                               covered("data.coolify_applications", "v0.1.0"),
 		"POST /applications/public":                                       covered("coolify_application", "v0.1.0"),
-		"POST /applications/dockercompose":                                {category: "skipped", resource: "Deprecated alias: use POST /services instead because this flow creates a Service, not an Application"},
+		"POST /applications/dockercompose":                                skipped(skipDeprecated),
 		"POST /applications/dockerimage":                                  covered("coolify_application_docker_image", "v0.1.0"),
 		"POST /applications/private-deploy-key":                           covered("coolify_application_private_git", "v0.1.0"),
 		"GET /applications/{uuid}":                                        covered("data.coolify_application", "v0.1.0"),
@@ -231,11 +231,11 @@ func coveredEndpoints() map[string]coverageStatus {
 		"DELETE /tags/{uuid}":                                                           covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"DELETE /team/envs/{env_id}":                                                    covered("coolify_shared_environment_variable", "v0.1.15"),
 		"GET /applications/{uuid}/destinations":                                         covered("coolify_application_destination", "v0.1.15"),
-		"GET /applications/{uuid}/rollback-images":                                      skipped("Application rollback/images; operational, not TF lifecycle"),
+		"GET /applications/{uuid}/rollback-images":                                      skipped(skipRollback),
 		"GET /applications/{uuid}/tags":                                                 covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"GET /cloud-init-scripts":                                                       covered("coolify_cloud_init_script", "v0.1.15"),
 		"GET /cloud-init-scripts/{uuid}":                                                covered("coolify_cloud_init_script", "v0.1.15"),
-		"GET /databases/{uuid}/logs":                                                    skipped("Resource logs streaming; not durable TF state"),
+		"GET /databases/{uuid}/logs":                                                    skipped(skipLogs),
 		"GET /databases/{uuid}/tags":                                                    covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"GET /destinations":                                                             covered("data.coolify_destinations", "v0.2.0"),
 		"GET /destinations/{uuid}":                                                      covered("data.coolify_destination", "v0.2.0"),
@@ -244,8 +244,8 @@ func coveredEndpoints() map[string]coverageStatus {
 		"GET /digitalocean/sizes":                                                       covered("data.coolify_digitalocean_sizes", "v0.2.0"),
 		"GET /digitalocean/ssh-keys":                                                    covered("data.coolify_digitalocean_ssh_keys", "v0.2.0"),
 		"GET /gitlab-apps":                                                              covered("coolify_gitlab_app", "v0.1.15"),
-		"GET /hetzner/firewalls":                                                        skipped("Hetzner firewalls/networks list; not required for coolify_server_hetzner"),
-		"GET /hetzner/networks":                                                         skipped("Hetzner firewalls/networks list; not required for coolify_server_hetzner"),
+		"GET /hetzner/firewalls":                                                        skipped(skipHetznerExtra),
+		"GET /hetzner/networks":                                                         skipped(skipHetznerExtra),
 		"GET /notifications/discord":                                                    covered("coolify_notification_discord", "v0.1.14"),
 		"GET /notifications/email":                                                      covered("coolify_notification_email", "v0.1.14"),
 		"GET /notifications/pushover":                                                   covered("coolify_notification_pushover", "v0.1.14"),
@@ -259,27 +259,27 @@ func coveredEndpoints() map[string]coverageStatus {
 		"GET /servers/{server_uuid}/destinations":                                       covered("data.coolify_destinations", "v0.2.0"),
 		"GET /servers/{uuid}/cloudflare-tunnel":                                         covered("coolify_server_cloudflare_tunnel", "v0.1.15"),
 		"GET /servers/{uuid}/docker-cleanup":                                            covered("coolify_server_docker_cleanup", "v0.1.15"),
-		"GET /servers/{uuid}/docker-cleanup/executions":                                 skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/docker-cleanup/executions":                                 skipped(skipControlPlane),
 		"GET /servers/{uuid}/envs":                                                      covered("coolify_shared_environment_variable", "v0.1.15"),
-		"GET /servers/{uuid}/export":                                                    skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"GET /servers/{uuid}/export":                                                    skipped(skipControlPlane),
 		"GET /servers/{uuid}/log-drains":                                                covered("coolify_server_log_drain", "v0.1.15"),
 		"GET /servers/{uuid}/proxy":                                                     covered("coolify_server_proxy", "v0.1.15"),
 		"GET /servers/{uuid}/sentinel":                                                  covered("coolify_server_sentinel", "v0.1.15"),
-		"GET /services/{uuid}/applications":                                             skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/applications/{app_uuid}":                                  skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/applications/{app_uuid}/logs":                             skipped("Resource logs streaming; not durable TF state"),
-		"GET /services/{uuid}/applications/{app_uuid}/restart":                          skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/applications/{app_uuid}/start":                            skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/applications/{app_uuid}/stop":                             skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/databases":                                                skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/databases/{database_uuid}":                                skipped("Nested service components; coolify_service manages the compose service unit"),
-		"GET /services/{uuid}/databases/{database_uuid}/logs":                           skipped("Resource logs streaming; not durable TF state"),
-		"GET /services/{uuid}/logs":                                                     skipped("Resource logs streaming; not durable TF state"),
+		"GET /services/{uuid}/applications":                                             skipped(skipNestedService),
+		"GET /services/{uuid}/applications/{app_uuid}":                                  skipped(skipNestedService),
+		"GET /services/{uuid}/applications/{app_uuid}/logs":                             skipped(skipLogs),
+		"GET /services/{uuid}/applications/{app_uuid}/restart":                          skipped(skipNestedService),
+		"GET /services/{uuid}/applications/{app_uuid}/start":                            skipped(skipNestedService),
+		"GET /services/{uuid}/applications/{app_uuid}/stop":                             skipped(skipNestedService),
+		"GET /services/{uuid}/databases":                                                skipped(skipNestedService),
+		"GET /services/{uuid}/databases/{database_uuid}":                                skipped(skipNestedService),
+		"GET /services/{uuid}/databases/{database_uuid}/logs":                           skipped(skipLogs),
+		"GET /services/{uuid}/logs":                                                     skipped(skipLogs),
 		"GET /services/{uuid}/tags":                                                     covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"GET /tags":                                                                     covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
-		"GET /team":                                                                     skipped("Alias of /teams/current*; use data.coolify_team / team_members"),
+		"GET /team":                                                                     skipped(skipAlias),
 		"GET /team/envs":                                                                covered("coolify_shared_environment_variable", "v0.1.15"),
-		"GET /team/members":                                                             skipped("Alias of /teams/current*; use data.coolify_team / team_members"),
+		"GET /team/members":                                                             skipped(skipAlias),
 		"GET /vultr/os":                                                                 covered("data.coolify_vultr_os", "v0.2.0"),
 		"GET /vultr/plans":                                                              covered("data.coolify_vultr_plans", "v0.2.0"),
 		"GET /vultr/regions":                                                            covered("data.coolify_vultr_regions", "v0.2.0"),
@@ -303,69 +303,69 @@ func coveredEndpoints() map[string]coverageStatus {
 		"PATCH /servers/{uuid}/log-drains":                                             covered("coolify_server_log_drain", "v0.1.15"),
 		"PATCH /servers/{uuid}/proxy":                                                  covered("coolify_server_proxy", "v0.1.15"),
 		"PATCH /servers/{uuid}/sentinel":                                               covered("coolify_server_sentinel", "v0.1.15"),
-		"PATCH /services/{uuid}/applications/{app_uuid}":                               skipped("Nested service components; coolify_service manages the compose service unit"),
-		"PATCH /services/{uuid}/databases/{database_uuid}":                             skipped("Nested service components; coolify_service manages the compose service unit"),
+		"PATCH /services/{uuid}/applications/{app_uuid}":                               skipped(skipNestedService),
+		"PATCH /services/{uuid}/databases/{database_uuid}":                             skipped(skipNestedService),
 		"PATCH /tags/{uuid}":                                                           covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"PATCH /team/envs/{env_id}":                                                    covered("coolify_shared_environment_variable", "v0.1.15"),
-		"POST /applications/{uuid}/clone":                                              skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /applications/{uuid}/clone":                                              skipped(skipCloneMove),
 		"POST /applications/{uuid}/destinations":                                       covered("coolify_application_destination", "v0.1.15"),
-		"POST /applications/{uuid}/migrate":                                            skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /applications/{uuid}/move":                                               skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /applications/{uuid}/migrate":                                            skipped(skipCloneMove),
+		"POST /applications/{uuid}/move":                                               skipped(skipCloneMove),
 		"POST /applications/{uuid}/restart":                                            covered("coolify_resource_action", "v0.3.0"),
-		"POST /applications/{uuid}/rollback":                                           skipped("Application rollback/images; operational, not TF lifecycle"),
-		"POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute":                skipped("One-shot task execute; coolify_scheduled_task manages definition only"),
+		"POST /applications/{uuid}/rollback":                                           skipped(skipRollback),
+		"POST /applications/{uuid}/scheduled-tasks/{task_uuid}/execute":                skipped(skipRunNow),
 		"POST /applications/{uuid}/start":                                              covered("coolify_resource_action", "v0.3.0"),
 		"POST /applications/{uuid}/stop":                                               covered("coolify_resource_action", "v0.3.0"),
-		"POST /applications/{uuid}/storages/{storage_uuid}/backups/run":                skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /applications/{uuid}/storages/{storage_uuid}/backups/run":                skipped(skipRunNow),
 		"POST /applications/{uuid}/tags":                                               covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"POST /cloud-init-scripts":                                                     covered("coolify_cloud_init_script", "v0.1.15"),
-		"POST /databases/{uuid}/clone":                                                 skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /databases/{uuid}/migrate":                                               skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /databases/{uuid}/move":                                                  skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /databases/{uuid}/clone":                                                 skipped(skipCloneMove),
+		"POST /databases/{uuid}/migrate":                                               skipped(skipCloneMove),
+		"POST /databases/{uuid}/move":                                                  skipped(skipCloneMove),
 		"POST /databases/{uuid}/restart":                                               covered("coolify_resource_action", "v0.3.0"),
 		"POST /databases/{uuid}/start":                                                 covered("coolify_resource_action", "v0.3.0"),
 		"POST /databases/{uuid}/stop":                                                  covered("coolify_resource_action", "v0.3.0"),
-		"POST /databases/{uuid}/storages/{storage_uuid}/backups/run":                   skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /databases/{uuid}/storages/{storage_uuid}/backups/run":                   skipped(skipRunNow),
 		"POST /databases/{uuid}/tags":                                                  covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"POST /deploy":                                                                 covered("client.Deploy", "v0.2.0"),
 		"POST /disable":                                                                covered("coolify_api_settings", "v0.2.0"),
 		"POST /enable":                                                                 covered("coolify_api_settings", "v0.2.0"),
-		"POST /feedback":                                                               skipped("Coolify product feedback endpoint; not TF"),
+		"POST /feedback":                                                               skipped(skipFeedback),
 		"POST /gitlab-apps":                                                            covered("coolify_gitlab_app", "v0.1.15"),
 		"POST /projects/{uuid}/environments/{environment_name_or_uuid}/envs":           covered("coolify_shared_environment_variable", "v0.1.15"),
 		"POST /projects/{uuid}/envs":                                                   covered("coolify_shared_environment_variable", "v0.1.15"),
 		"POST /s3-storages":                                                            covered("coolify_s3_storage", "v0.1.13"),
 		"POST /s3-storages/{uuid}/validate":                                            covered("coolify_s3_storage_validate", "v0.1.14"),
-		"POST /sentinel/push":                                                          skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /sentinel/push":                                                          skipped(skipControlPlane),
 		"POST /servers/digitalocean":                                                   covered("coolify_server_digitalocean", "v0.2.0"),
-		"POST /servers/import":                                                         skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/import":                                                         skipped(skipControlPlane),
 		"POST /servers/vultr":                                                          covered("coolify_server_vultr", "v0.2.0"),
 		"POST /servers/{server_uuid}/destinations":                                     covered("coolify_destination", "v0.2.0"),
-		"POST /servers/{uuid}/claim":                                                   skipped("Server operational/control-plane API; not modeled as TF resources"),
-		"POST /servers/{uuid}/cloudflare-tunnel/disable":                               skipped("Operational enable/disable; coolify_server_cloudflare_tunnel uses PATCH settings"),
-		"POST /servers/{uuid}/cloudflare-tunnel/enable":                                skipped("Operational enable/disable; coolify_server_cloudflare_tunnel uses PATCH settings"),
-		"POST /servers/{uuid}/docker-cleanup/run":                                      skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/claim":                                                   skipped(skipControlPlane),
+		"POST /servers/{uuid}/cloudflare-tunnel/disable":                               skipped(skipEnableDisable),
+		"POST /servers/{uuid}/cloudflare-tunnel/enable":                                skipped(skipEnableDisable),
+		"POST /servers/{uuid}/docker-cleanup/run":                                      skipped(skipControlPlane),
 		"POST /servers/{uuid}/envs":                                                    covered("coolify_shared_environment_variable", "v0.1.15"),
-		"POST /servers/{uuid}/export/mailbox":                                          skipped("Server operational/control-plane API; not modeled as TF resources"),
-		"POST /servers/{uuid}/migrate":                                                 skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /servers/{uuid}/proxy/restart":                                           skipped("Server operational/control-plane API; not modeled as TF resources"),
-		"POST /servers/{uuid}/transfer/complete":                                       skipped("Server operational/control-plane API; not modeled as TF resources"),
+		"POST /servers/{uuid}/export/mailbox":                                          skipped(skipControlPlane),
+		"POST /servers/{uuid}/migrate":                                                 skipped(skipCloneMove),
+		"POST /servers/{uuid}/proxy/restart":                                           skipped(skipControlPlane),
+		"POST /servers/{uuid}/transfer/complete":                                       skipped(skipControlPlane),
 		"POST /servers/{uuid}/validate":                                                covered("coolify_server_validate", "v0.2.0"),
-		"POST /services/{uuid}/applications/{app_uuid}/logs":                           skipped("Resource logs streaming; not durable TF state"),
-		"POST /services/{uuid}/applications/{app_uuid}/restart":                        skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/applications/{app_uuid}/start":                          skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/applications/{app_uuid}/stop":                           skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/clone":                                                  skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /services/{uuid}/databases/{database_uuid}/restart":                      skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/databases/{database_uuid}/start":                        skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/databases/{database_uuid}/stop":                         skipped("Nested service app/DB lifecycle; manage via parent coolify_service"),
-		"POST /services/{uuid}/migrate":                                                skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
-		"POST /services/{uuid}/move":                                                   skipped("One-shot clone/migrate/move; not Terraform lifecycle"),
+		"POST /services/{uuid}/applications/{app_uuid}/logs":                           skipped(skipLogs),
+		"POST /services/{uuid}/applications/{app_uuid}/restart":                        skipped(skipNestedService),
+		"POST /services/{uuid}/applications/{app_uuid}/start":                          skipped(skipNestedService),
+		"POST /services/{uuid}/applications/{app_uuid}/stop":                           skipped(skipNestedService),
+		"POST /services/{uuid}/clone":                                                  skipped(skipCloneMove),
+		"POST /services/{uuid}/databases/{database_uuid}/restart":                      skipped(skipNestedService),
+		"POST /services/{uuid}/databases/{database_uuid}/start":                        skipped(skipNestedService),
+		"POST /services/{uuid}/databases/{database_uuid}/stop":                         skipped(skipNestedService),
+		"POST /services/{uuid}/migrate":                                                skipped(skipCloneMove),
+		"POST /services/{uuid}/move":                                                   skipped(skipCloneMove),
 		"POST /services/{uuid}/restart":                                                covered("coolify_resource_action", "v0.3.0"),
-		"POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute":                    skipped("One-shot task execute; coolify_scheduled_task manages definition only"),
+		"POST /services/{uuid}/scheduled-tasks/{task_uuid}/execute":                    skipped(skipRunNow),
 		"POST /services/{uuid}/start":                                                  covered("coolify_resource_action", "v0.3.0"),
 		"POST /services/{uuid}/stop":                                                   covered("coolify_resource_action", "v0.3.0"),
-		"POST /services/{uuid}/storages/{storage_uuid}/backups/run":                    skipped("One-shot volume backup run; coolify_storage_backup manages schedule only"),
+		"POST /services/{uuid}/storages/{storage_uuid}/backups/run":                    skipped(skipRunNow),
 		"POST /services/{uuid}/tags":                                                   covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"POST /tags":                                                                   covered("coolify_tag + coolify_resource_tag", "v0.1.15"),
 		"POST /team/envs":                                                              covered("coolify_shared_environment_variable", "v0.1.15"),
@@ -477,89 +477,62 @@ func TestSpecCoverage_GenerateDoc(t *testing.T) {
 		t.Skip("set GENERATE_COVERAGE_DOC=1 to regenerate API_COVERAGE.md")
 	}
 
-	coverage := coveredEndpoints()
-
-	type entry struct {
-		endpoint string
-		status   coverageStatus
+	md, err := generateCoverageMarkdown(coveredEndpoints())
+	if err != nil {
+		t.Fatalf("generating API_COVERAGE.md: %v", err)
 	}
-
-	var coveredList, plannedList, skippedList []entry
-	for ep, s := range coverage {
-		e := entry{endpoint: ep, status: s}
-		switch s.category {
-		case "covered":
-			coveredList = append(coveredList, e)
-		case "planned":
-			plannedList = append(plannedList, e)
-		case "skipped":
-			skippedList = append(skippedList, e)
-		}
-	}
-
-	sort.Slice(coveredList, func(i, j int) bool {
-		return coveredList[i].endpoint < coveredList[j].endpoint
-	})
-	sort.Slice(plannedList, func(i, j int) bool {
-		if plannedList[i].status.priority != plannedList[j].status.priority {
-			return plannedList[i].status.priority < plannedList[j].status.priority
-		}
-		return plannedList[i].endpoint < plannedList[j].endpoint
-	})
-	sort.Slice(skippedList, func(i, j int) bool {
-		return skippedList[i].endpoint < skippedList[j].endpoint
-	})
-
-	total := len(coveredList) + len(plannedList) + len(skippedList)
-	pct := float64(len(coveredList)) / float64(total) * 100
-
-	var b strings.Builder
-	b.WriteString("# API Coverage\n\n")
-	b.WriteString("<!-- Auto-generated from internal/spectest/coverage_test.go. Do not edit manually. -->\n")
-	b.WriteString("<!-- Run: make api-coverage -->\n\n")
-	b.WriteString("**Route inventory**: source-derived contract `testdata/contracts/coolify-v4.json` (`routes[]`)  \n")
-	b.WriteString("**Field source of truth**: same contract (`models` / endpoint allow lists)  \n")
-	b.WriteString("**Not inventory**: OpenAPI under `testdata/specs/` (partial upstream path list; do not treat as Coolify API completeness)  \n")
-	fmt.Fprintf(&b, "**Coverage**: %d covered / %d registry entries (%.1f%%)  \n", len(coveredList), total, pct)
-	fmt.Fprintf(&b, "**Planned**: %d | **Skipped**: %d  \n", len(plannedList), len(skippedList))
-	fmt.Fprintf(&b, "**Registry size**: %d (contract routes + allowlisted extras)\n", total)
-
-	// Covered
-	b.WriteString("\n## Covered\n\n")
-	b.WriteString("| Endpoint | Terraform Resource / Data Source | Since |\n")
-	b.WriteString("|----------|----------------------------------|-------|\n")
-	for _, e := range coveredList {
-		fmt.Fprintf(&b, "| `%s` | `%s` | %s |\n", e.endpoint, e.status.resource, e.status.since)
-	}
-
-	// Planned
-	b.WriteString("\n## Planned\n\n")
-	b.WriteString("Ordered by priority (1 = most needed by users).\n\n")
-	b.WriteString("| Priority | Endpoint | Notes |\n")
-	b.WriteString("|----------|----------|-------|\n")
-	for _, e := range plannedList {
-		fmt.Fprintf(&b, "| %d | `%s` | %s |\n", e.status.priority, e.endpoint, e.status.notes)
-	}
-
-	// Skipped
-	b.WriteString("\n## Intentionally Skipped\n\n")
-	b.WriteString("These endpoints are intentionally not modeled directly in Terraform.\n\n")
-	b.WriteString("| Endpoint | Reason |\n")
-	b.WriteString("|----------|--------|\n")
-	for _, e := range skippedList {
-		fmt.Fprintf(&b, "| `%s` | %s |\n", e.endpoint, e.status.resource)
-	}
-
-	b.WriteString("\n## Unclassified contract routes\n\n")
-	b.WriteString("_None. All pin contract routes are classified in `coveredEndpoints()`._\n\n")
-	b.WriteString("When `make contract-extract` adds routes, classify them in\n")
-	b.WriteString("`internal/spectest/coverage_test.go` or `TestSpecCoverage_Completeness` fails.\n")
 
 	outPath := filepath.Join(testdataDir(), "..", "API_COVERAGE.md")
-	if err := os.WriteFile(outPath, []byte(b.String()), 0644); err != nil {
+	if err := os.WriteFile(outPath, []byte(md), 0644); err != nil {
 		t.Fatalf("writing API_COVERAGE.md: %v", err)
 	}
-	t.Logf("Generated %s (%d bytes)", outPath, len(b.String()))
+	t.Logf("Generated %s (%d bytes)", outPath, len(md))
+}
+
+func TestGenerateCoverageMarkdown_Readable(t *testing.T) {
+	t.Parallel()
+	md, err := generateCoverageMarkdown(coveredEndpoints())
+	if err != nil {
+		t.Fatal(err)
+	}
+	needles := []string{
+		"docs/guides/coolify-version-support.md",
+		"**Use this instead:**",
+		"## What Terraform does not wrap",
+		"## Routes by Terraform resource",
+		"## Appendix: all classified routes",
+	}
+	for _, n := range needles {
+		if !strings.Contains(md, n) {
+			t.Errorf("generated doc missing %q", n)
+		}
+	}
+	for ep, s := range coveredEndpoints() {
+		if s.category != "skipped" {
+			continue
+		}
+		if !strings.Contains(md, "`"+ep+"`") {
+			t.Errorf("skipped route %s missing from generated doc", ep)
+		}
+	}
+}
+
+func TestSkipKinds_CoverAllSkipped(t *testing.T) {
+	t.Parallel()
+	kinds := skipKindByID()
+	for ep, s := range coveredEndpoints() {
+		if s.category != "skipped" {
+			continue
+		}
+		k, ok := kinds[s.resource]
+		if !ok {
+			t.Errorf("%s: unknown skip kind %q", ep, s.resource)
+			continue
+		}
+		if k.instead == "" {
+			t.Errorf("skip kind %q has empty instead", s.resource)
+		}
+	}
 }
 
 // loadContractRoutes returns sorted unique "METHOD /path" keys from a contract JSON file

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 This guide answers: **which Coolify version do I need for each resource and field?**
 
+For Coolify HTTP routes the provider does not wrap (clone, rollback, log
+streams, one-shot backup run, nested compose apps), see
+[API Coverage](https://github.com/coolify-terraform/terraform-provider-coolify/blob/main/API_COVERAGE.md)
+on GitHub. That page lists each skip class and **what to use instead**.
+
 The provider hard-requires Coolify **v4.1.0 or later** on every `terraform plan` /
 `terraform apply`. Within that floor, some APIs only exist on newer Coolify
 lines. The provider still configures against older supported instances, but it

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -50,6 +50,7 @@ export COOLIFY_CF_ACCESS_CLIENT_SECRET="your-cf-client-secret"
 - **[Quick Start](guides/quickstart)** - Deploy your first application in under 5 minutes
 - **[Installation](guides/installation)** - Detailed setup and configuration options
 - **[Coolify Version Support](guides/coolify-version-support)** - What works on Coolify 4.1, 4.2, and 4.3
+- **[API Coverage](https://github.com/coolify-terraform/terraform-provider-coolify/blob/main/API_COVERAGE.md)** - Coolify HTTP routes the provider wraps, and what to use when it does not
 - **[Concepts](guides/concepts)** - How Coolify resources map to Terraform
 - **[Choosing an Application Type](guides/choosing-application-type)** - Pick the right resource for your deployment method
 - **[Connecting Resources](guides/connecting-resources)** - Wire apps to databases using Coolify's Docker networking


### PR DESCRIPTION
## Description

Rework `API_COVERAGE.md` so a reader can see **why** a Coolify route is skipped and **what to use instead**.

## Problem

The old page was a 242-row HTTP table sorted by `DELETE` / `GET` / `PATCH`. That is a maintainer completeness dump, not an answer to "can I clone / roll back / run a backup now?" Version support lived in a different guide with no link either way.

## Change

- Intro points at [Coolify Version Support](docs/guides/coolify-version-support.md) (version and fields) and Registry docs (attributes).
- Skip classes lead with why, then **Use this instead**, then the routes.
- Covered routes are grouped by Terraform resource. The raw `METHOD /path` list stays as an appendix for the completeness gate.
- Reciprocal links from the version-support guide, README, and Registry index.

## Validation

- `go test ./internal/spectest/` (completeness + generated-doc checks)
- `make api-coverage-check`
- `make docs`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Documentation updated
- [x] `make docs` regenerated
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
