### PR TITLE
fix: send Hetzner SSH key IDs as JSON arrays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 69 data sources, 1390+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 69 data sources, 1400+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1390+ tests (unit + acceptance)
+- 1400+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 69 data sources, 1400+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 69 data sources, 1410+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1400+ tests (unit + acceptance)
+- 1410+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 69 |
-| Tests | 1390+ unit and acceptance tests |
+| Tests | 1400+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -333,7 +333,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1390+ tests, race detector enabled)
+make test                                       # Run unit tests (1400+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 69 |
-| Tests | 1400+ unit and acceptance tests |
+| Tests | 1410+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -333,7 +333,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1400+ tests, race detector enabled)
+make test                                       # Run unit tests (1410+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/data-sources/hetzner_firewalls.md
+++ b/docs/data-sources/hetzner_firewalls.md
@@ -17,6 +17,15 @@ data "coolify_hetzner_firewalls" "all" {
   cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
 }
 
+data "coolify_hetzner_firewalls" "web" {
+  cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
+
+  filter {
+    name   = "name"
+    values = ["web"]
+  }
+}
+
 output "hetzner_firewall_names" {
   value = [for fw in data.coolify_hetzner_firewalls.all.firewalls : fw.name]
 }

--- a/docs/data-sources/hetzner_networks.md
+++ b/docs/data-sources/hetzner_networks.md
@@ -17,6 +17,15 @@ data "coolify_hetzner_networks" "all" {
   cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
 }
 
+data "coolify_hetzner_networks" "private" {
+  cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
+
+  filter {
+    name   = "name"
+    values = ["acme-private"]
+  }
+}
+
 output "hetzner_network_names" {
   value = [for n in data.coolify_hetzner_networks.all.networks : n.name]
 }

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -221,7 +221,7 @@ removed the resource from Terraform state.
 
 ```
 Error: Error listing Hetzner networks
-listing hetzner networks: unexpected status 404:
+cloud_provider_token_uuid=...: listing hetzner networks: unexpected status 404:
 {"message":"Hetzner cloud provider token not found."}
 ```
 

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -217,6 +217,32 @@ removed the resource from Terraform state.
 - If the resource was intentionally deleted, remove it from your `.tf`
   file and run `terraform apply`
 
+### Hetzner list data source: token not found
+
+```
+Error: Error listing Hetzner networks
+listing hetzner networks: unexpected status 404:
+{"message":"Hetzner cloud provider token not found."}
+```
+
+The same pattern appears for `coolify_hetzner_images`,
+`coolify_hetzner_locations`, `coolify_hetzner_server_types`,
+`coolify_hetzner_ssh_keys`, and `coolify_hetzner_firewalls`.
+
+**Cause:** `cloud_provider_token_uuid` does not match a Hetzner token
+that Coolify can use. Typical cases:
+
+- The UUID is a DigitalOcean or Vultr token, not a Hetzner token
+- The token was deleted in the Coolify UI
+- The token belongs to a different team than the API credential
+
+**Fix:**
+
+1. Read `data.coolify_cloud_tokens` and confirm `cloud_provider = "hetzner"`
+2. Recreate the token with `coolify_cloud_token` if it is gone
+3. Firewalls and networks also require Coolify >= v4.2.0; older instances
+   return 404 for those two routes even with a valid token
+
 ### "Application created but refresh failed"
 
 ```

--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -94,6 +94,8 @@ type. Additional read-only data sources include:
 - `coolify_hetzner_ssh_keys`: list SSH keys in Hetzner Cloud
 - `coolify_hetzner_firewalls`: list existing Hetzner Cloud firewalls (Coolify >= v4.2.0)
 - `coolify_hetzner_networks`: list existing Hetzner Cloud private networks (Coolify >= v4.2.0)
+- `coolify_digitalocean_images` / `coolify_digitalocean_regions` / `coolify_digitalocean_sizes` / `coolify_digitalocean_ssh_keys`: list DigitalOcean catalog items (Coolify >= v4.2.0)
+- `coolify_vultr_os` / `coolify_vultr_plans` / `coolify_vultr_regions` / `coolify_vultr_ssh_keys`: list Vultr catalog items (Coolify >= v4.2.0)
 
 ## Import
 

--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -92,6 +92,8 @@ type. Additional read-only data sources include:
 - `coolify_hetzner_locations`: list available Hetzner Cloud locations
 - `coolify_hetzner_server_types`: list available Hetzner Cloud server types
 - `coolify_hetzner_ssh_keys`: list SSH keys in Hetzner Cloud
+- `coolify_hetzner_firewalls`: list existing Hetzner Cloud firewalls (Coolify >= v4.2.0)
+- `coolify_hetzner_networks`: list existing Hetzner Cloud private networks (Coolify >= v4.2.0)
 
 ## Import
 

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -68,7 +68,7 @@ resource "coolify_server_hetzner" "example" {
 - `enable_ipv6` (Boolean) Whether to enable IPv6 on the server.
 - `hetzner_firewall_ids` (List of Number) Existing Hetzner firewall IDs to apply when Coolify creates the server. Use `data.coolify_hetzner_firewalls` to list available firewalls. Requires Coolify >= v4.2.0. Changing this forces a new resource.
 - `hetzner_network_ids` (List of Number) Existing Hetzner private network IDs to attach when Coolify creates the server. Use `data.coolify_hetzner_networks` to list available networks. Requires Coolify >= v4.2.0. Changing this forces a new resource.
-- `hetzner_ssh_key_ids` (String) Comma-separated list of Hetzner SSH key IDs to install on the server. Use `coolify_hetzner_ssh_keys` data source to list available keys. Changing this forces a new resource.
+- `hetzner_ssh_key_ids` (String) Comma-separated list of additional Hetzner SSH key IDs to install on the server (for example `12345,67890`). Coolify's API expects a JSON integer array; the provider parses this string and sends that array. Use `data.coolify_hetzner_ssh_keys` to list available keys. Changing this forces a new resource.
 - `instant_validate` (Boolean) Whether to validate server connectivity immediately after creation.
 - `is_build_server` (Boolean) Whether this server is used for building applications.
 - `port` (Number) The SSH port of the server.

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -31,6 +31,7 @@ resource "coolify_server_hetzner" "example" {
   # enable_ipv4       = true
   # enable_ipv6       = true
   # hetzner_ssh_key_ids = "12345,67890"
+  # Look up IDs with data.coolify_hetzner_firewalls / data.coolify_hetzner_networks.
   # hetzner_firewall_ids = [38, 39]   # Requires Coolify >= v4.2.0
   # hetzner_network_ids  = [456]      # Requires Coolify >= v4.2.0
   # instant_validate  = true

--- a/examples/data-sources/coolify_hetzner_firewalls/data-source.tf
+++ b/examples/data-sources/coolify_hetzner_firewalls/data-source.tf
@@ -2,6 +2,15 @@ data "coolify_hetzner_firewalls" "all" {
   cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
 }
 
+data "coolify_hetzner_firewalls" "web" {
+  cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
+
+  filter {
+    name   = "name"
+    values = ["web"]
+  }
+}
+
 output "hetzner_firewall_names" {
   value = [for fw in data.coolify_hetzner_firewalls.all.firewalls : fw.name]
 }

--- a/examples/data-sources/coolify_hetzner_networks/data-source.tf
+++ b/examples/data-sources/coolify_hetzner_networks/data-source.tf
@@ -2,6 +2,15 @@ data "coolify_hetzner_networks" "all" {
   cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
 }
 
+data "coolify_hetzner_networks" "private" {
+  cloud_provider_token_uuid = coolify_cloud_token.hetzner.uuid
+
+  filter {
+    name   = "name"
+    values = ["acme-private"]
+  }
+}
+
 output "hetzner_network_names" {
   value = [for n in data.coolify_hetzner_networks.all.networks : n.name]
 }

--- a/examples/resources/coolify_server_hetzner/resource.tf
+++ b/examples/resources/coolify_server_hetzner/resource.tf
@@ -10,6 +10,7 @@ resource "coolify_server_hetzner" "example" {
   # enable_ipv4       = true
   # enable_ipv6       = true
   # hetzner_ssh_key_ids = "12345,67890"
+  # Look up IDs with data.coolify_hetzner_firewalls / data.coolify_hetzner_networks.
   # hetzner_firewall_ids = [38, 39]   # Requires Coolify >= v4.2.0
   # hetzner_network_ids  = [456]      # Requires Coolify >= v4.2.0
   # instant_validate  = true

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5376,6 +5376,18 @@ func TestClient_ListHetznerImages(t *testing.T) {
 	assert.Equal(t, "ubuntu-22.04", images[0].Name)
 }
 
+func TestClient_ListHetznerImages_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Hetzner cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListHetznerImages(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
 func TestClient_ListHetznerLocations(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5394,6 +5406,18 @@ func TestClient_ListHetznerLocations(t *testing.T) {
 	require.Len(t, locations, 1)
 	assert.Equal(t, "fsn1", locations[0].Name)
 	assert.Equal(t, "DE", locations[0].Country)
+}
+
+func TestClient_ListHetznerLocations_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Hetzner cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListHetznerLocations(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
 }
 
 func TestClient_ListHetznerServerTypes(t *testing.T) {
@@ -5417,6 +5441,18 @@ func TestClient_ListHetznerServerTypes(t *testing.T) {
 	assert.Equal(t, int64(4), types[0].Memory)
 }
 
+func TestClient_ListHetznerServerTypes_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Hetzner cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListHetznerServerTypes(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
 func TestClient_ListHetznerSSHKeys(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5435,6 +5471,18 @@ func TestClient_ListHetznerSSHKeys(t *testing.T) {
 	require.Len(t, keys, 1)
 	assert.Equal(t, "deploy-key", keys[0].Name)
 	assert.Equal(t, "aa:bb:cc:dd", keys[0].Fingerprint)
+}
+
+func TestClient_ListHetznerSSHKeys_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Hetzner cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListHetznerSSHKeys(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
 }
 
 func TestClient_ListHetznerFirewalls(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3038,6 +3038,7 @@ func TestHetznerCreate_CloudProviderTokenUUID_JSONTag(t *testing.T) {
 func TestHetznerCreate_NetworkAndFirewallIDs_JSONTags(t *testing.T) {
 	t.Parallel()
 	input := CreateHetznerServerInput{
+		HetznerSSHKeyIDs:   []int64{12345, 67890},
 		HetznerFirewallIDs: []int64{38, 39},
 		HetznerNetworkIDs:  []int64{456},
 	}
@@ -3046,6 +3047,7 @@ func TestHetznerCreate_NetworkAndFirewallIDs_JSONTags(t *testing.T) {
 
 	var raw map[string]interface{}
 	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Equal(t, []interface{}{float64(12345), float64(67890)}, raw["hetzner_ssh_key_ids"])
 	assert.Equal(t, []interface{}{float64(38), float64(39)}, raw["hetzner_firewall_ids"])
 	assert.Equal(t, []interface{}{float64(456)}, raw["hetzner_network_ids"])
 
@@ -3054,6 +3056,8 @@ func TestHetznerCreate_NetworkAndFirewallIDs_JSONTags(t *testing.T) {
 	require.NoError(t, err)
 	var emptyRaw map[string]interface{}
 	require.NoError(t, json.Unmarshal(emptyData, &emptyRaw))
+	_, hasSSHKeys := emptyRaw["hetzner_ssh_key_ids"]
+	assert.False(t, hasSSHKeys, "empty slice must omit hetzner_ssh_key_ids")
 	_, hasFirewalls := emptyRaw["hetzner_firewall_ids"]
 	assert.False(t, hasFirewalls, "empty slice must omit hetzner_firewall_ids")
 	_, hasNetworks := emptyRaw["hetzner_network_ids"]

--- a/internal/client/servers.go
+++ b/internal/client/servers.go
@@ -219,7 +219,7 @@ type CreateHetznerServerInput struct {
 	PrivateKeyUUID         string  `json:"private_key_uuid"`
 	EnableIPv4             *bool   `json:"enable_ipv4,omitempty"`
 	EnableIPv6             *bool   `json:"enable_ipv6,omitempty"`
-	HetznerSSHKeyIDs       string  `json:"hetzner_ssh_key_ids,omitempty"`
+	HetznerSSHKeyIDs       []int64 `json:"hetzner_ssh_key_ids,omitempty"`
 	HetznerFirewallIDs     []int64 `json:"hetzner_firewall_ids,omitempty"`
 	HetznerNetworkIDs      []int64 `json:"hetzner_network_ids,omitempty"`
 	CloudInitScript        string  `json:"cloud_init_script,omitempty"`

--- a/internal/flex/token_list.go
+++ b/internal/flex/token_list.go
@@ -2,6 +2,7 @@ package flex
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -25,7 +26,10 @@ func ReadFilteredTokenList[T any](
 
 	items, err := listFn(ctx, tokenUUID)
 	if err != nil {
-		resp.Diagnostics.AddError(listErrorSummary, err.Error())
+		resp.Diagnostics.AddError(
+			listErrorSummary,
+			fmt.Sprintf("cloud_provider_token_uuid=%s: %s", tokenUUID, err),
+		)
 		return nil, false
 	}
 

--- a/internal/flex/token_list.go
+++ b/internal/flex/token_list.go
@@ -1,0 +1,33 @@
+package flex
+
+import (
+	"context"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// ReadFilteredTokenList lists cloud-token-scoped items and applies HCL filter
+// blocks. listFn is the client method; the unused Client pointer that used to
+// sit next to it is intentionally omitted.
+func ReadFilteredTokenList[T any](
+	ctx context.Context,
+	tokenUUID string,
+	filters []filter.Config,
+	dataSourceType string,
+	listErrorSummary string,
+	resp *datasource.ReadResponse,
+	listFn func(context.Context, string) ([]T, error),
+	accessor func(T, string) (string, bool),
+) ([]T, bool) {
+	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": dataSourceType})
+
+	items, err := listFn(ctx, tokenUUID)
+	if err != nil {
+		resp.Diagnostics.AddError(listErrorSummary, err.Error())
+		return nil, false
+	}
+
+	return filter.Apply(ctx, items, filters, accessor), true
+}

--- a/internal/flex/token_list_test.go
+++ b/internal/flex/token_list_test.go
@@ -83,7 +83,7 @@ func TestReadFilteredTokenList_ListError(t *testing.T) {
 	if got := errs[0].Summary(); got != "Error listing test items" {
 		t.Fatalf("summary = %q", got)
 	}
-	if got := errs[0].Detail(); got != "token not found" {
+	if got := errs[0].Detail(); got != "cloud_provider_token_uuid=missing: token not found" {
 		t.Fatalf("detail = %q", got)
 	}
 }

--- a/internal/flex/token_list_test.go
+++ b/internal/flex/token_list_test.go
@@ -1,0 +1,89 @@
+package flex_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type tokenListItem struct {
+	Name string
+}
+
+func TestReadFilteredTokenList_SuccessAndFilter(t *testing.T) {
+	t.Parallel()
+
+	resp := &datasource.ReadResponse{}
+	filters := []filter.Config{{
+		Name:   types.StringValue("name"),
+		Values: []types.String{types.StringValue("keep")},
+	}}
+	items, ok := flex.ReadFilteredTokenList(
+		context.Background(),
+		"tok",
+		filters,
+		"test_ds",
+		"Error listing test items",
+		resp,
+		func(_ context.Context, token string) ([]tokenListItem, error) {
+			if token != "tok" {
+				t.Fatalf("token = %q", token)
+			}
+			return []tokenListItem{{Name: "keep"}, {Name: "drop"}}, nil
+		},
+		func(item tokenListItem, field string) (string, bool) {
+			if field == "name" {
+				return item.Name, true
+			}
+			return "", false
+		},
+	)
+	if !ok {
+		t.Fatal("expected success")
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if len(items) != 1 || items[0].Name != "keep" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestReadFilteredTokenList_ListError(t *testing.T) {
+	t.Parallel()
+
+	resp := &datasource.ReadResponse{}
+	items, ok := flex.ReadFilteredTokenList(
+		context.Background(),
+		"missing",
+		nil,
+		"test_ds",
+		"Error listing test items",
+		resp,
+		func(context.Context, string) ([]tokenListItem, error) {
+			return nil, errors.New("token not found")
+		},
+		func(tokenListItem, string) (string, bool) { return "", false },
+	)
+	if ok || items != nil {
+		t.Fatalf("ok=%v items=%v", ok, items)
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected diagnostic")
+	}
+	errs := resp.Diagnostics.Errors()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+	if got := errs[0].Summary(); got != "Error listing test items" {
+		t.Fatalf("summary = %q", got)
+	}
+	if got := errs[0].Detail(); got != "token not found" {
+		t.Fatalf("detail = %q", got)
+	}
+}

--- a/internal/service/digitalocean/data_source_common.go
+++ b/internal/service/digitalocean/data_source_common.go
@@ -1,17 +1,14 @@
 package digitalocean
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribute {
@@ -24,26 +21,4 @@ func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribut
 
 func configureDigitalOceanDataSourceClient(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *client.Client {
 	return flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
-}
-
-func readFilteredTokenList[T any](
-	ctx context.Context,
-	tokenUUID string,
-	filters []filter.Config,
-	dataSourceType string,
-	listErrorSummary string,
-	resp *datasource.ReadResponse,
-	c *client.Client,
-	listFn func(context.Context, string) ([]T, error),
-	accessor func(T, string) (string, bool),
-) ([]T, bool) {
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": dataSourceType})
-
-	items, err := listFn(ctx, tokenUUID)
-	if err != nil {
-		resp.Diagnostics.AddError(listErrorSummary, err.Error())
-		return nil, false
-	}
-
-	return filter.Apply(ctx, items, filters, accessor), true
 }

--- a/internal/service/digitalocean/data_source_error_test.go
+++ b/internal/service/digitalocean/data_source_error_test.go
@@ -1,0 +1,51 @@
+package digitalocean_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestDigitalOceanListDataSources_APIError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		hclType string
+		errRe   string
+	}{
+		{"images", "coolify_digitalocean_images", `Error listing DigitalOcean images`},
+		{"regions", "coolify_digitalocean_regions", `Error listing DigitalOcean regions`},
+		{"sizes", "coolify_digitalocean_sizes", `Error listing DigitalOcean sizes`},
+		{"ssh_keys", "coolify_digitalocean_ssh_keys", `Error listing DigitalOcean SSH keys`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"message":"DigitalOcean cloud provider token not found."}`, http.StatusNotFound)
+			})))
+			t.Cleanup(srv.Close)
+
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+				Steps: []resource.TestStep{
+					{
+						Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "` + tc.hclType + `" "test" {
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+}
+`,
+						ExpectError: regexp.MustCompile(tc.errRe),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/service/digitalocean/data_source_images.go
+++ b/internal/service/digitalocean/data_source_images.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -72,9 +73,9 @@ func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	images, ok := readFilteredTokenList(
+	images, ok := flex.ReadFilteredTokenList(
 		ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_digitalocean_images", "Error listing DigitalOcean images", resp, d.client,
+		"coolify_digitalocean_images", "Error listing DigitalOcean images", resp,
 		d.client.ListDigitalOceanImages,
 		func(img client.DigitalOceanImage, field string) (string, bool) {
 			switch field {

--- a/internal/service/digitalocean/data_source_regions.go
+++ b/internal/service/digitalocean/data_source_regions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -66,9 +67,9 @@ func (d *regionsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	regions, ok := readFilteredTokenList(
+	regions, ok := flex.ReadFilteredTokenList(
 		ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_digitalocean_regions", "Error listing DigitalOcean regions", resp, d.client,
+		"coolify_digitalocean_regions", "Error listing DigitalOcean regions", resp,
 		d.client.ListDigitalOceanRegions,
 		func(r client.DigitalOceanRegion, field string) (string, bool) {
 			switch field {

--- a/internal/service/digitalocean/data_source_sizes.go
+++ b/internal/service/digitalocean/data_source_sizes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -72,9 +73,9 @@ func (d *sizesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	sizes, ok := readFilteredTokenList(
+	sizes, ok := flex.ReadFilteredTokenList(
 		ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_digitalocean_sizes", "Error listing DigitalOcean sizes", resp, d.client,
+		"coolify_digitalocean_sizes", "Error listing DigitalOcean sizes", resp,
 		d.client.ListDigitalOceanSizes,
 		func(s client.DigitalOceanSize, field string) (string, bool) {
 			switch field {

--- a/internal/service/digitalocean/data_source_ssh_keys.go
+++ b/internal/service/digitalocean/data_source_ssh_keys.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -66,9 +67,9 @@ func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	keys, ok := readFilteredTokenList(
+	keys, ok := flex.ReadFilteredTokenList(
 		ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_digitalocean_ssh_keys", "Error listing DigitalOcean SSH keys", resp, d.client,
+		"coolify_digitalocean_ssh_keys", "Error listing DigitalOcean SSH keys", resp,
 		d.client.ListDigitalOceanSSHKeys,
 		func(k client.DigitalOceanSSHKey, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_common.go
+++ b/internal/service/hetzner/data_source_common.go
@@ -1,17 +1,14 @@
 package hetzner
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribute {
@@ -24,26 +21,4 @@ func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribut
 
 func configureHetznerDataSourceClient(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *client.Client {
 	return flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
-}
-
-func readFilteredTokenList[T any](
-	ctx context.Context,
-	tokenUUID string,
-	filters []filter.Config,
-	dataSourceType string,
-	listErrorSummary string,
-	resp *datasource.ReadResponse,
-	c *client.Client,
-	listFn func(context.Context, string) ([]T, error),
-	accessor func(T, string) (string, bool),
-) ([]T, bool) {
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": dataSourceType})
-
-	items, err := listFn(ctx, tokenUUID)
-	if err != nil {
-		resp.Diagnostics.AddError(listErrorSummary, err.Error())
-		return nil, false
-	}
-
-	return filter.Apply(ctx, items, filters, accessor), true
 }

--- a/internal/service/hetzner/data_source_error_test.go
+++ b/internal/service/hetzner/data_source_error_test.go
@@ -1,0 +1,53 @@
+package hetzner_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestHetznerListDataSources_APIError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		hclType string
+		errRe   string
+	}{
+		{"images", "coolify_hetzner_images", `Error listing Hetzner images`},
+		{"locations", "coolify_hetzner_locations", `Error listing Hetzner locations`},
+		{"server_types", "coolify_hetzner_server_types", `Error listing Hetzner server types`},
+		{"ssh_keys", "coolify_hetzner_ssh_keys", `Error listing Hetzner SSH keys`},
+		{"firewalls", "coolify_hetzner_firewalls", `Error listing Hetzner firewalls`},
+		{"networks", "coolify_hetzner_networks", `Error listing Hetzner networks`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"message":"Hetzner cloud provider token not found."}`, http.StatusNotFound)
+			})))
+			t.Cleanup(srv.Close)
+
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+				Steps: []resource.TestStep{
+					{
+						Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "` + tc.hclType + `" "test" {
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+}
+`,
+						ExpectError: regexp.MustCompile(tc.errRe),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/service/hetzner/data_source_firewalls.go
+++ b/internal/service/hetzner/data_source_firewalls.go
@@ -1,4 +1,4 @@
-//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
+//nolint:dupl // schema and state mapping differ; list/filter logic is in flex.ReadFilteredTokenList
 package hetzner
 
 import (
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -71,14 +72,13 @@ func (d *firewallsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	firewalls, ok := readFilteredTokenList(
+	firewalls, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_firewalls",
 		"Error listing Hetzner firewalls",
 		resp,
-		d.client,
 		d.client.ListHetznerFirewalls,
 		func(fw client.HetznerFirewall, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_images.go
+++ b/internal/service/hetzner/data_source_images.go
@@ -1,4 +1,4 @@
-//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
+//nolint:dupl // schema and state mapping differ; list/filter logic is in flex.ReadFilteredTokenList
 package hetzner
 
 import (
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -73,14 +74,13 @@ func (d *imagesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	images, ok := readFilteredTokenList(
+	images, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_images",
 		"Error listing Hetzner images",
 		resp,
-		d.client,
 		d.client.ListHetznerImages,
 		func(img client.HetznerImage, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_locations.go
+++ b/internal/service/hetzner/data_source_locations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -76,14 +77,13 @@ func (d *locationsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	locations, ok := readFilteredTokenList(
+	locations, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_locations",
 		"Error listing Hetzner locations",
 		resp,
-		d.client,
 		d.client.ListHetznerLocations,
 		func(loc client.HetznerLocation, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_networks.go
+++ b/internal/service/hetzner/data_source_networks.go
@@ -1,4 +1,4 @@
-//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
+//nolint:dupl // schema and state mapping differ; list/filter logic is in flex.ReadFilteredTokenList
 package hetzner
 
 import (
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -73,14 +74,13 @@ func (d *networksDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	networks, ok := readFilteredTokenList(
+	networks, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_networks",
 		"Error listing Hetzner networks",
 		resp,
-		d.client,
 		d.client.ListHetznerNetworks,
 		func(n client.HetznerNetwork, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_server_types.go
+++ b/internal/service/hetzner/data_source_server_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -78,14 +79,13 @@ func (d *serverTypesDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	serverTypes, ok := readFilteredTokenList(
+	serverTypes, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_server_types",
 		"Error listing Hetzner server types",
 		resp,
-		d.client,
 		d.client.ListHetznerServerTypes,
 		func(st client.HetznerServerType, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/data_source_ssh_keys.go
+++ b/internal/service/hetzner/data_source_ssh_keys.go
@@ -1,4 +1,4 @@
-//nolint:dupl // schema and state mapping differ; list/filter logic is in data_source_common.go
+//nolint:dupl // schema and state mapping differ; list/filter logic is in flex.ReadFilteredTokenList
 package hetzner
 
 import (
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -73,14 +74,13 @@ func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	keys, ok := readFilteredTokenList(
+	keys, ok := flex.ReadFilteredTokenList(
 		ctx,
 		config.CloudProviderTokenUUID.ValueString(),
 		config.Filters,
 		"coolify_hetzner_ssh_keys",
 		"Error listing Hetzner SSH keys",
 		resp,
-		d.client,
 		d.client.ListHetznerSSHKeys,
 		func(k client.HetznerSSHKey, field string) (string, bool) {
 			switch field {

--- a/internal/service/hetzner/hasnondefault_test.go
+++ b/internal/service/hetzner/hasnondefault_test.go
@@ -22,6 +22,30 @@ func defaultHetznerPlan() hetznerServerResourceModel {
 	}
 }
 
+func TestInt64IDsFromCSV(t *testing.T) {
+	t.Parallel()
+
+	got, err := int64IDsFromCSV("12345, 67890")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0] != 12345 || got[1] != 67890 {
+		t.Fatalf("got %v, want [12345 67890]", got)
+	}
+
+	empty, err := int64IDsFromCSV("  ,  ")
+	if err != nil {
+		t.Fatalf("empty csv error: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty csv = %v, want empty", empty)
+	}
+
+	if _, err := int64IDsFromCSV("38,abc"); err == nil {
+		t.Fatal("expected error for non-integer token")
+	}
+}
+
 func TestHasNonDefaultCloudProviderSettings_ViaHetznerModel(t *testing.T) {
 	t.Parallel()
 	m := defaultHetznerPlan()

--- a/internal/service/hetzner/resource.go
+++ b/internal/service/hetzner/resource.go
@@ -3,6 +3,8 @@ package hetzner
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
@@ -155,9 +157,11 @@ func hetznerSchemaAttributes() map[string]schema.Attribute {
 			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"hetzner_ssh_key_ids": schema.StringAttribute{
-			MarkdownDescription: "Comma-separated list of Hetzner SSH key IDs to install on the server. Use `coolify_hetzner_ssh_keys` data source to list available keys. Changing this forces a new resource.",
-			Optional:            true,
-			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			MarkdownDescription: "Comma-separated list of additional Hetzner SSH key IDs to install on the server (for example `12345,67890`). " +
+				"Coolify's API expects a JSON integer array; the provider parses this string and sends that array. " +
+				"Use `data.coolify_hetzner_ssh_keys` to list available keys. Changing this forces a new resource.",
+			Optional:      true,
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"hetzner_firewall_ids": schema.ListAttribute{
 			ElementType: types.Int64Type,
@@ -232,7 +236,14 @@ func (r *hetznerServerResource) Create(ctx context.Context, req resource.CreateR
 		EnableIPv6:             flex.BoolValueOrNull(plan.EnableIPv6),
 		InstantValidate:        flex.BoolValueOrNull(plan.InstantValidate),
 	}
-	flex.SetIfKnown(&input.HetznerSSHKeyIDs, plan.HetznerSSHKeyIDs)
+	if !plan.HetznerSSHKeyIDs.IsNull() && !plan.HetznerSSHKeyIDs.IsUnknown() {
+		sshIDs, err := int64IDsFromCSV(plan.HetznerSSHKeyIDs.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid hetzner_ssh_key_ids", err.Error())
+			return
+		}
+		input.HetznerSSHKeyIDs = sshIDs
+	}
 	flex.SetIfKnown(&input.CloudInitScript, plan.CloudInitScript)
 	firewallIDs, fwDiags := int64IDsFromList(ctx, plan.HetznerFirewallIDs)
 	resp.Diagnostics.Append(fwDiags...)
@@ -412,4 +423,28 @@ func int64IDsFromList(ctx context.Context, list types.List) ([]int64, diag.Diagn
 	var ids []int64
 	diags := list.ElementsAs(ctx, &ids, false)
 	return ids, diags
+}
+
+// int64IDsFromCSV parses a comma-separated list of integers. Coolify's
+// Hetzner create endpoint validates hetzner_ssh_key_ids as nullable|array
+// of integers; the Terraform attribute stays a string for existing HCL.
+func int64IDsFromCSV(s string) ([]int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	ids := make([]int64, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not an integer", part)
+		}
+		ids = append(ids, n)
+	}
+	return ids, nil
 }

--- a/internal/service/hetzner/resource_test.go
+++ b/internal/service/hetzner/resource_test.go
@@ -441,10 +441,12 @@ resource "coolify_server_hetzner" "test" {
   location                  = "fsn1"
   image                     = "ubuntu-24.04"
   private_key_uuid          = "dddd0002-0002-4000-8000-000000000002"
+  hetzner_ssh_key_ids       = "12345, 67890"
   hetzner_firewall_ids      = [38, 39]
   hetzner_network_ids       = [456, 457]
 }`,
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_ssh_key_ids", "12345, 67890"),
 					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_firewall_ids.#", "2"),
 					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_firewall_ids.0", "38"),
 					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_firewall_ids.1", "39"),
@@ -452,6 +454,9 @@ resource "coolify_server_hetzner" "test" {
 					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_network_ids.0", "456"),
 					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "hetzner_network_ids.1", "457"),
 					func(_ *terraform.State) error {
+						if len(got.HetznerSSHKeyIDs) != 2 || got.HetznerSSHKeyIDs[0] != 12345 || got.HetznerSSHKeyIDs[1] != 67890 {
+							return fmt.Errorf("POST body hetzner_ssh_key_ids = %v, want [12345 67890]", got.HetznerSSHKeyIDs)
+						}
 						if len(got.HetznerFirewallIDs) != 2 || got.HetznerFirewallIDs[0] != 38 || got.HetznerFirewallIDs[1] != 39 {
 							return fmt.Errorf("POST body hetzner_firewall_ids = %v, want [38 39]", got.HetznerFirewallIDs)
 						}
@@ -471,6 +476,7 @@ resource "coolify_server_hetzner" "test" {
   location                  = "fsn1"
   image                     = "ubuntu-24.04"
   private_key_uuid          = "dddd0002-0002-4000-8000-000000000002"
+  hetzner_ssh_key_ids       = "12345, 67890"
   hetzner_firewall_ids      = [38, 39]
   hetzner_network_ids       = [456, 457]
 }`,
@@ -505,6 +511,31 @@ resource "coolify_server_hetzner" "test" {
 				ImportState:   true,
 				ImportStateId: "not-a-uuid",
 				ExpectError:   regexp.MustCompile(`Invalid Import ID`),
+			},
+		},
+	})
+}
+
+func TestHetznerServerResource_InvalidSSHKeyIDs(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.NotFoundHandler()))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_hetzner" "test" {
+  name                      = "bad-ssh-hetzner"
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+  server_type               = "cx22"
+  location                  = "fsn1"
+  image                     = "ubuntu-24.04"
+  private_key_uuid          = "dddd0002-0002-4000-8000-000000000002"
+  hetzner_ssh_key_ids       = "38,not-an-id"
+}`,
+				ExpectError: regexp.MustCompile(`Invalid hetzner_ssh_key_ids`),
 			},
 		},
 	})

--- a/internal/service/vultr/data_source_common.go
+++ b/internal/service/vultr/data_source_common.go
@@ -1,17 +1,14 @@
 package vultr
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribute {
@@ -24,24 +21,4 @@ func cloudProviderTokenUUIDAttribute(resourceLabel string) schema.StringAttribut
 
 func configureVultrDataSourceClient(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *client.Client {
 	return flex.ConfigureDataSourceClient(req, &resp.Diagnostics)
-}
-
-func readFilteredTokenList[T any](
-	ctx context.Context,
-	tokenUUID string,
-	filters []filter.Config,
-	dataSourceType string,
-	listErrorSummary string,
-	resp *datasource.ReadResponse,
-	c *client.Client,
-	listFn func(context.Context, string) ([]T, error),
-	accessor func(T, string) (string, bool),
-) ([]T, bool) {
-	tflog.Debug(ctx, "reading data source", map[string]interface{}{"data_source_type": dataSourceType})
-	items, err := listFn(ctx, tokenUUID)
-	if err != nil {
-		resp.Diagnostics.AddError(listErrorSummary, err.Error())
-		return nil, false
-	}
-	return filter.Apply(ctx, items, filters, accessor), true
 }

--- a/internal/service/vultr/data_source_error_test.go
+++ b/internal/service/vultr/data_source_error_test.go
@@ -1,0 +1,51 @@
+package vultr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestVultrListDataSources_APIError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		hclType string
+		errRe   string
+	}{
+		{"regions", "coolify_vultr_regions", `Error listing Vultr regions`},
+		{"plans", "coolify_vultr_plans", `Error listing Vultr plans`},
+		{"ssh_keys", "coolify_vultr_ssh_keys", `Error listing Vultr SSH keys`},
+		{"os", "coolify_vultr_os", `Error listing Vultr OS`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"message":"Vultr cloud provider token not found."}`, http.StatusNotFound)
+			})))
+			t.Cleanup(srv.Close)
+
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+				Steps: []resource.TestStep{
+					{
+						Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "` + tc.hclType + `" "test" {
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+}
+`,
+						ExpectError: regexp.MustCompile(tc.errRe),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/service/vultr/data_source_os.go
+++ b/internal/service/vultr/data_source_os.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,8 +56,8 @@ func (d *osDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	items, ok := readFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_vultr_os", "Error listing Vultr OS", resp, d.client, d.client.ListVultrOS,
+	items, ok := flex.ReadFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
+		"coolify_vultr_os", "Error listing Vultr OS", resp, d.client.ListVultrOS,
 		func(o client.VultrOS, field string) (string, bool) {
 			if field == "id" {
 				return filter.Int64ToString(o.ID), true

--- a/internal/service/vultr/data_source_plans.go
+++ b/internal/service/vultr/data_source_plans.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -59,8 +60,8 @@ func (d *plansDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	items, ok := readFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_vultr_plans", "Error listing Vultr plans", resp, d.client, d.client.ListVultrPlans,
+	items, ok := flex.ReadFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
+		"coolify_vultr_plans", "Error listing Vultr plans", resp, d.client.ListVultrPlans,
 		func(p client.VultrPlan, field string) (string, bool) {
 			if field == "id" {
 				return p.ID, true

--- a/internal/service/vultr/data_source_regions.go
+++ b/internal/service/vultr/data_source_regions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,8 +56,8 @@ func (d *regionsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	items, ok := readFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_vultr_regions", "Error listing Vultr regions", resp, d.client, d.client.ListVultrRegions,
+	items, ok := flex.ReadFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
+		"coolify_vultr_regions", "Error listing Vultr regions", resp, d.client.ListVultrRegions,
 		func(r client.VultrRegion, field string) (string, bool) {
 			switch field {
 			case "id":

--- a/internal/service/vultr/data_source_ssh_keys.go
+++ b/internal/service/vultr/data_source_ssh_keys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/filter"
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -53,8 +54,8 @@ func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	items, ok := readFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
-		"coolify_vultr_ssh_keys", "Error listing Vultr SSH keys", resp, d.client, d.client.ListVultrSSHKeys,
+	items, ok := flex.ReadFilteredTokenList(ctx, config.CloudProviderTokenUUID.ValueString(), config.Filters,
+		"coolify_vultr_ssh_keys", "Error listing Vultr SSH keys", resp, d.client.ListVultrSSHKeys,
 		func(k client.VultrSSHKey, field string) (string, bool) {
 			if field == "id" {
 				return k.ID, true

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -221,7 +221,7 @@ removed the resource from Terraform state.
 
 ```
 Error: Error listing Hetzner networks
-listing hetzner networks: unexpected status 404:
+cloud_provider_token_uuid=...: listing hetzner networks: unexpected status 404:
 {"message":"Hetzner cloud provider token not found."}
 ```
 

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -217,6 +217,32 @@ removed the resource from Terraform state.
 - If the resource was intentionally deleted, remove it from your `.tf`
   file and run `terraform apply`
 
+### Hetzner list data source: token not found
+
+```
+Error: Error listing Hetzner networks
+listing hetzner networks: unexpected status 404:
+{"message":"Hetzner cloud provider token not found."}
+```
+
+The same pattern appears for `coolify_hetzner_images`,
+`coolify_hetzner_locations`, `coolify_hetzner_server_types`,
+`coolify_hetzner_ssh_keys`, and `coolify_hetzner_firewalls`.
+
+**Cause:** `cloud_provider_token_uuid` does not match a Hetzner token
+that Coolify can use. Typical cases:
+
+- The UUID is a DigitalOcean or Vultr token, not a Hetzner token
+- The token was deleted in the Coolify UI
+- The token belongs to a different team than the API credential
+
+**Fix:**
+
+1. Read `data.coolify_cloud_tokens` and confirm `cloud_provider = "hetzner"`
+2. Recreate the token with `coolify_cloud_token` if it is gone
+3. Firewalls and networks also require Coolify >= v4.2.0; older instances
+   return 404 for those two routes even with a valid token
+
 ### "Application created but refresh failed"
 
 ```

--- a/templates/guides/concepts.md.tmpl
+++ b/templates/guides/concepts.md.tmpl
@@ -94,6 +94,8 @@ type. Additional read-only data sources include:
 - `coolify_hetzner_ssh_keys`: list SSH keys in Hetzner Cloud
 - `coolify_hetzner_firewalls`: list existing Hetzner Cloud firewalls (Coolify >= v4.2.0)
 - `coolify_hetzner_networks`: list existing Hetzner Cloud private networks (Coolify >= v4.2.0)
+- `coolify_digitalocean_images` / `coolify_digitalocean_regions` / `coolify_digitalocean_sizes` / `coolify_digitalocean_ssh_keys`: list DigitalOcean catalog items (Coolify >= v4.2.0)
+- `coolify_vultr_os` / `coolify_vultr_plans` / `coolify_vultr_regions` / `coolify_vultr_ssh_keys`: list Vultr catalog items (Coolify >= v4.2.0)
 
 ## Import
 

--- a/templates/guides/concepts.md.tmpl
+++ b/templates/guides/concepts.md.tmpl
@@ -92,6 +92,8 @@ type. Additional read-only data sources include:
 - `coolify_hetzner_locations`: list available Hetzner Cloud locations
 - `coolify_hetzner_server_types`: list available Hetzner Cloud server types
 - `coolify_hetzner_ssh_keys`: list SSH keys in Hetzner Cloud
+- `coolify_hetzner_firewalls`: list existing Hetzner Cloud firewalls (Coolify >= v4.2.0)
+- `coolify_hetzner_networks`: list existing Hetzner Cloud private networks (Coolify >= v4.2.0)
 
 ## Import
 


### PR DESCRIPTION
## Description

Coolify's Hetzner create endpoint validates `hetzner_ssh_key_ids` as a JSON integer array. The provider sent a comma-separated string, which 422s. This batch keeps the existing Terraform string attribute so current HCL still works, parses it, and sends the array Coolify expects.

It also tightens the cloud list data sources that landed with networks and firewalls: shared read helper, token UUID in errors, 404 tests, and user-facing docs.

## Problem

- Setting `hetzner_ssh_key_ids = "12345,67890"` sent a JSON string. Coolify's validator is `nullable|array` of integers and then `array_merge`s the value.
- Hetzner, DigitalOcean, and Vultr each copied the same list helper, including an unused client parameter. A missing token produced a generic 404 with no UUID.
- Concepts and common-errors lagged the new Hetzner firewall/network data sources.

## The change

- Parse the HCL CSV into `[]int64` before POST. Reject non-integers with a field diagnostic.
- Move token-scoped list reads to `flex.ReadFilteredTokenList` and include `cloud_provider_token_uuid` in the error detail.
- Add client and Terraform-layer 404 tests for Hetzner lists, plus DigitalOcean and Vultr data-source APIError tables.
- Document filter examples, token-not-found 404s, and the DigitalOcean/Vultr catalog data sources.
- Bump the documented test floor to 1410+.

## Validation

- `make ci` (exit 0). Counts: 56 resources, 69 data sources, 1417 tests (1410+ floor).
- Local reviewer on `origin/main...HEAD`: 0 issues.

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] `make ci` passes locally
- [x] `make fmt` ran (gofmt)
- [x] Documentation updated
- [x] `make docs` regenerated
- [x] Examples updated
- [x] CHANGELOG.md is release-please managed (no hand edit)
- [x] No breaking HCL schema changes (`hetzner_ssh_key_ids` stays a string)

## Issue reference

Ref #764
Ref #765