### PR TITLE
feat: enable Hetzner backups and cover DO/Vultr list clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 69 data sources, 1410+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 69 data sources, 1430+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1410+ tests (unit + acceptance)
+- 1430+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 69 |
-| Tests | 1410+ unit and acceptance tests |
+| Tests | 1430+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -333,7 +333,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1410+ tests, race detector enabled)
+make test                                       # Run unit tests (1430+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -182,7 +182,7 @@ must be set in your `.tf` configuration before running `terraform plan`:
 | `coolify_application_github_app` | `github_app_uuid` (Coolify stores the linked GitHub App as `source_id`/`source_type`, so import cannot recover the original UUID) |
 | `coolify_service` | `project_uuid`, `server_uuid`, `environment_name`, `type` |
 | `coolify_server` | `private_key_uuid` (Coolify stores only the linked `private_key_id`, so import cannot reconstruct the original UUID) |
-| `coolify_server_hetzner` | `cloud_provider_token_uuid`, `server_type`, `location`, `image`, `private_key_uuid`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_ipv4`, `enable_ipv6`, `instant_validate` (Hetzner-specific fields are only sent at creation time and not returned by the server GET endpoint) |
+| `coolify_server_hetzner` | `cloud_provider_token_uuid`, `server_type`, `location`, `image`, `private_key_uuid`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_ipv4`, `enable_ipv6`, `enable_backups`, `instant_validate` (Hetzner-specific fields are only sent at creation time and not returned by the server GET endpoint) |
 | `coolify_environment_variable` | `value` (sensitive value is not reliably returned on import; keep it in configuration before the first `terraform plan`) |
 | `coolify_deployment` | `triggers`, `wait_for_completion` (Terraform-only behavior controls, not persisted by the Coolify API) |
 | `coolify_environment` | `description` (stored in Terraform state only; not returned by the API) |

--- a/docs/resources/server_hetzner.md
+++ b/docs/resources/server_hetzner.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Provisions a Hetzner Cloud server and registers it with Coolify.
   ~> Warning: Deleting this resource will delete the server from Coolify and cascade-delete all applications, databases, and services deployed on it. The underlying Hetzner Cloud server is not destroyed; manage its lifecycle separately.
-  ~> Import note: Hetzner-specific fields (cloud_provider_token_uuid, server_type, location, image, hetzner_ssh_key_ids, hetzner_firewall_ids, hetzner_network_ids, cloud_init_script) are only sent at creation time and are not returned by the Coolify API. After terraform import, these fields will be empty in state. Set them in your configuration before running terraform plan to avoid a forced replacement.
+  ~> Import note: Hetzner-specific fields (cloud_provider_token_uuid, server_type, location, image, hetzner_ssh_key_ids, hetzner_firewall_ids, hetzner_network_ids, cloud_init_script, enable_backups) are only sent at creation time and are not returned by the Coolify API. After terraform import, these fields will be empty in state (enable_backups becomes false). Set them in your configuration before running terraform plan to avoid a forced replacement.
 ---
 
 # coolify_server_hetzner (Resource)
@@ -14,7 +14,7 @@ Provisions a Hetzner Cloud server and registers it with Coolify.
 
 ~> **Warning:** Deleting this resource will delete the server from Coolify and cascade-delete all applications, databases, and services deployed on it. The underlying Hetzner Cloud server is not destroyed; manage its lifecycle separately.
 
-~> **Import note:** Hetzner-specific fields (`cloud_provider_token_uuid`, `server_type`, `location`, `image`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`) are only sent at creation time and are not returned by the Coolify API. After `terraform import`, these fields will be empty in state. Set them in your configuration before running `terraform plan` to avoid a forced replacement.
+~> **Import note:** Hetzner-specific fields (`cloud_provider_token_uuid`, `server_type`, `location`, `image`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_backups`) are only sent at creation time and are not returned by the Coolify API. After `terraform import`, these fields will be empty in state (`enable_backups` becomes `false`). Set them in your configuration before running `terraform plan` to avoid a forced replacement.
 
 ## Example Usage
 
@@ -30,6 +30,7 @@ resource "coolify_server_hetzner" "example" {
   # Optional Hetzner settings:
   # enable_ipv4       = true
   # enable_ipv6       = true
+  # enable_backups    = true   # Requires Coolify >= v4.2.0; adds ~20% to the Hetzner monthly fee
   # hetzner_ssh_key_ids = "12345,67890"
   # Look up IDs with data.coolify_hetzner_firewalls / data.coolify_hetzner_networks.
   # hetzner_firewall_ids = [38, 39]   # Requires Coolify >= v4.2.0
@@ -64,6 +65,7 @@ resource "coolify_server_hetzner" "example" {
 - `deployment_queue_limit` (Number) Maximum number of queued deployments (default 25).
 - `description` (String) A description of the server.
 - `dynamic_timeout` (Number) Timeout in seconds for Docker operations (pull, build, health check) during deployment.
+- `enable_backups` (Boolean) Whether to enable Hetzner Cloud server backups after creation. Adds about 20% to the monthly Hetzner server fee. Requires Coolify >= v4.2.0. Changing this forces a new resource. The Coolify API does not return this field; after import it is `false` in state.
 - `enable_ipv4` (Boolean) Whether to enable IPv4 on the server.
 - `enable_ipv6` (Boolean) Whether to enable IPv6 on the server.
 - `hetzner_firewall_ids` (List of Number) Existing Hetzner firewall IDs to apply when Coolify creates the server. Use `data.coolify_hetzner_firewalls` to list available firewalls. Requires Coolify >= v4.2.0. Changing this forces a new resource.

--- a/examples/resources/coolify_server_hetzner/resource.tf
+++ b/examples/resources/coolify_server_hetzner/resource.tf
@@ -9,6 +9,7 @@ resource "coolify_server_hetzner" "example" {
   # Optional Hetzner settings:
   # enable_ipv4       = true
   # enable_ipv6       = true
+  # enable_backups    = true   # Requires Coolify >= v4.2.0; adds ~20% to the Hetzner monthly fee
   # hetzner_ssh_key_ids = "12345,67890"
   # Look up IDs with data.coolify_hetzner_firewalls / data.coolify_hetzner_networks.
   # hetzner_firewall_ids = [38, 39]   # Requires Coolify >= v4.2.0

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -3064,6 +3064,26 @@ func TestHetznerCreate_NetworkAndFirewallIDs_JSONTags(t *testing.T) {
 	assert.False(t, hasNetworks, "empty slice must omit hetzner_network_ids")
 }
 
+func TestHetznerCreate_EnableBackups_JSONTag(t *testing.T) {
+	t.Parallel()
+	enabled := true
+	input := CreateHetznerServerInput{EnableBackups: &enabled}
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Equal(t, true, raw["enable_backups"])
+
+	empty := CreateHetznerServerInput{}
+	emptyData, err := json.Marshal(empty)
+	require.NoError(t, err)
+	var emptyRaw map[string]interface{}
+	require.NoError(t, json.Unmarshal(emptyData, &emptyRaw))
+	_, hasBackups := emptyRaw["enable_backups"]
+	assert.False(t, hasBackups, "nil pointer must omit enable_backups")
+}
+
 // --- Scheduled Tasks ---
 
 func TestClient_ListScheduledTasks(t *testing.T) {
@@ -5865,6 +5885,242 @@ func TestClient_ListDigitalOceanRegions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, regions, 1)
 	assert.Equal(t, "nyc1", regions[0].Slug)
+}
+
+func TestClient_ListDigitalOceanRegions_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"DigitalOcean cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListDigitalOceanRegions(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListDigitalOceanSizes(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/digitalocean/sizes", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]DigitalOceanSize{
+			{Slug: "s-1vcpu-1gb", Memory: 1024, VCPUs: 1, Disk: 25, Available: true},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	sizes, err := c.ListDigitalOceanSizes(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, sizes, 1)
+	assert.Equal(t, "s-1vcpu-1gb", sizes[0].Slug)
+	assert.Equal(t, int64(1), sizes[0].VCPUs)
+}
+
+func TestClient_ListDigitalOceanSizes_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"DigitalOcean cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListDigitalOceanSizes(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListDigitalOceanImages(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/digitalocean/images", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]DigitalOceanImage{
+			{ID: 12, Name: "24.04 x64", Distribution: "Ubuntu", Slug: "ubuntu-24-04-x64", Public: true, Type: "snapshot"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	images, err := c.ListDigitalOceanImages(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+	assert.Equal(t, int64(12), images[0].ID)
+	assert.Equal(t, "ubuntu-24-04-x64", images[0].Slug)
+}
+
+func TestClient_ListDigitalOceanImages_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"DigitalOcean cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListDigitalOceanImages(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListDigitalOceanSSHKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/digitalocean/ssh-keys", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]DigitalOceanSSHKey{
+			{ID: 7, Name: "deploy", Fingerprint: "aa:bb:cc"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	keys, err := c.ListDigitalOceanSSHKeys(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "deploy", keys[0].Name)
+	assert.Equal(t, "aa:bb:cc", keys[0].Fingerprint)
+}
+
+func TestClient_ListDigitalOceanSSHKeys_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"DigitalOcean cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListDigitalOceanSSHKeys(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListVultrRegions(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/vultr/regions", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]VultrRegion{
+			{ID: "ewr", City: "Newark", Country: "US", Continent: "North America"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	regions, err := c.ListVultrRegions(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, regions, 1)
+	assert.Equal(t, "ewr", regions[0].ID)
+	assert.Equal(t, "Newark", regions[0].City)
+}
+
+func TestClient_ListVultrRegions_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Vultr cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListVultrRegions(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListVultrPlans(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/vultr/plans", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]VultrPlan{
+			{ID: "vc2-1c-1gb", VCPUCount: 1, RAM: 1024, Disk: 25, Type: "vc2"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	plans, err := c.ListVultrPlans(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	assert.Equal(t, "vc2-1c-1gb", plans[0].ID)
+	assert.Equal(t, int64(1), plans[0].VCPUCount)
+}
+
+func TestClient_ListVultrPlans_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Vultr cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListVultrPlans(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListVultrOS(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/vultr/os", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]VultrOS{
+			{ID: 1743, Name: "Ubuntu 24.04 LTS x64", Arch: "x64", Family: "ubuntu"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	oses, err := c.ListVultrOS(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, oses, 1)
+	assert.Equal(t, int64(1743), oses[0].ID)
+	assert.Equal(t, "ubuntu", oses[0].Family)
+}
+
+func TestClient_ListVultrOS_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Vultr cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListVultrOS(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}
+
+func TestClient_ListVultrSSHKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/vultr/ssh-keys", r.URL.Path)
+		assert.Equal(t, "tok-uuid-1", r.URL.Query().Get("cloud_provider_token_uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]VultrSSHKey{
+			{ID: "abc", Name: "deploy", DateCreated: "2026-01-01"},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	keys, err := c.ListVultrSSHKeys(context.Background(), "tok-uuid-1")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "abc", keys[0].ID)
+	assert.Equal(t, "deploy", keys[0].Name)
+}
+
+func TestClient_ListVultrSSHKeys_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Vultr cloud provider token not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	_, err := c.ListVultrSSHKeys(context.Background(), "missing-tok")
+	require.Error(t, err)
+	assert.True(t, IsNotFound(err))
 }
 
 func TestClient_DestinationCRUD(t *testing.T) {

--- a/internal/client/servers.go
+++ b/internal/client/servers.go
@@ -219,6 +219,7 @@ type CreateHetznerServerInput struct {
 	PrivateKeyUUID         string  `json:"private_key_uuid"`
 	EnableIPv4             *bool   `json:"enable_ipv4,omitempty"`
 	EnableIPv6             *bool   `json:"enable_ipv6,omitempty"`
+	EnableBackups          *bool   `json:"enable_backups,omitempty"`
 	HetznerSSHKeyIDs       []int64 `json:"hetzner_ssh_key_ids,omitempty"`
 	HetznerFirewallIDs     []int64 `json:"hetzner_firewall_ids,omitempty"`
 	HetznerNetworkIDs      []int64 `json:"hetzner_network_ids,omitempty"`

--- a/internal/service/hetzner/resource.go
+++ b/internal/service/hetzner/resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -55,6 +56,7 @@ type hetznerServerResourceModel struct {
 	InstantValidate        types.Bool   `tfsdk:"instant_validate"`
 	EnableIPv4             types.Bool   `tfsdk:"enable_ipv4"`
 	EnableIPv6             types.Bool   `tfsdk:"enable_ipv6"`
+	EnableBackups          types.Bool   `tfsdk:"enable_backups"`
 
 	// Shared server fields (updatable).
 	Name                                 types.String `tfsdk:"name"`
@@ -122,7 +124,7 @@ func (r *hetznerServerResource) Metadata(_ context.Context, req resource.Metadat
 
 func (r *hetznerServerResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Provisions a Hetzner Cloud server and registers it with Coolify.\n\n~> **Warning:** Deleting this resource will delete the server from Coolify and cascade-delete all applications, databases, and services deployed on it. The underlying Hetzner Cloud server is not destroyed; manage its lifecycle separately.\n\n~> **Import note:** Hetzner-specific fields (`cloud_provider_token_uuid`, `server_type`, `location`, `image`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`) are only sent at creation time and are not returned by the Coolify API. After `terraform import`, these fields will be empty in state. Set them in your configuration before running `terraform plan` to avoid a forced replacement.",
+		MarkdownDescription: "Provisions a Hetzner Cloud server and registers it with Coolify.\n\n~> **Warning:** Deleting this resource will delete the server from Coolify and cascade-delete all applications, databases, and services deployed on it. The underlying Hetzner Cloud server is not destroyed; manage its lifecycle separately.\n\n~> **Import note:** Hetzner-specific fields (`cloud_provider_token_uuid`, `server_type`, `location`, `image`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_backups`) are only sent at creation time and are not returned by the Coolify API. After `terraform import`, these fields will be empty in state (`enable_backups` becomes `false`). Set them in your configuration before running `terraform plan` to avoid a forced replacement.",
 		Attributes:          server.CommonServerAttrs(ctx, hetznerSchemaAttributes()),
 	}
 }
@@ -201,6 +203,15 @@ func hetznerSchemaAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Default:             booldefault.StaticBool(true),
 		},
+		"enable_backups": schema.BoolAttribute{
+			MarkdownDescription: "Whether to enable Hetzner Cloud server backups after creation. Adds about 20% to the monthly Hetzner server fee. Requires Coolify >= v4.2.0. Changing this forces a new resource. The Coolify API does not return this field; after import it is `false` in state.",
+			Optional:            true,
+			Computed:            true,
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.RequiresReplace(),
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
 	}
 }
 
@@ -234,6 +245,7 @@ func (r *hetznerServerResource) Create(ctx context.Context, req resource.CreateR
 		PrivateKeyUUID:         plan.PrivateKeyUUID.ValueString(),
 		EnableIPv4:             flex.BoolValueOrNull(plan.EnableIPv4),
 		EnableIPv6:             flex.BoolValueOrNull(plan.EnableIPv6),
+		EnableBackups:          flex.BoolValueOrNull(plan.EnableBackups),
 		InstantValidate:        flex.BoolValueOrNull(plan.InstantValidate),
 	}
 	if !plan.HetznerSSHKeyIDs.IsNull() && !plan.HetznerSSHKeyIDs.IsUnknown() {
@@ -412,6 +424,10 @@ func (m *hetznerServerResourceModel) commonPtrs() server.ServerCommonPtrs {
 
 func flattenHetznerServer(srv *client.Server, model *hetznerServerResourceModel) {
 	server.FlattenServerCommon(srv, model.commonPtrs())
+	// enable_backups is create-only; GET never returns it.
+	if model.EnableBackups.IsNull() || model.EnableBackups.IsUnknown() {
+		model.EnableBackups = types.BoolValue(false)
+	}
 }
 
 // int64IDsFromList copies a Terraform list of integers into a Go slice.

--- a/internal/service/hetzner/resource_acc_test.go
+++ b/internal/service/hetzner/resource_acc_test.go
@@ -59,6 +59,7 @@ func TestAccHetznerServerResource_CRUD(t *testing.T) {
 					"instant_validate",
 					"enable_ipv4",
 					"enable_ipv6",
+					"enable_backups",
 					"private_key_uuid",
 				},
 			},

--- a/internal/service/hetzner/resource_test.go
+++ b/internal/service/hetzner/resource_test.go
@@ -358,6 +358,7 @@ resource "coolify_server_hetzner" "test" {
 					"instant_validate",
 					"enable_ipv4",
 					"enable_ipv6",
+					"enable_backups",
 					"private_key_uuid",
 				},
 			},
@@ -479,6 +480,112 @@ resource "coolify_server_hetzner" "test" {
   hetzner_ssh_key_ids       = "12345, 67890"
   hetzner_firewall_ids      = [38, 39]
   hetzner_network_ids       = [456, 457]
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestHetznerServerResource_CreateWithEnableBackups(t *testing.T) {
+	t.Parallel()
+
+	var got client.CreateHetznerServerInput
+	servers := make(map[string]*client.Server)
+	var mu sync.Mutex
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/servers/hetzner":
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+				return
+			}
+			created := &client.Server{
+				UUID:           "aaaa0001-0001-4000-8000-000000000001",
+				Name:           got.Name,
+				IP:             "203.0.113.42",
+				Port:           22,
+				User:           "root",
+				PrivateKeyUUID: got.PrivateKeyUUID,
+				IsReachable:    true,
+				IsUsable:       true,
+				Settings: &client.ServerSettings{
+					ConcurrentBuilds:                     2,
+					DynamicTimeout:                       3600,
+					DeploymentQueueLimit:                 25,
+					ConnectionTimeout:                    10,
+					ServerDiskUsageNotificationThreshold: 80,
+					ServerDiskUsageCheckFrequency:        "*/5 * * * *",
+				},
+			}
+			servers[created.UUID] = created
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(created)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/servers/"):
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
+			s, ok := servers[uuid]
+			if !ok {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			resp := *s
+			resp.PrivateKeyUUID = ""
+			json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/servers/"):
+			uuid := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
+			delete(servers, uuid)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_server_hetzner", "/api/v1/servers/"),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_hetzner" "test" {
+  name                      = "my-hetzner"
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+  server_type               = "cx22"
+  location                  = "fsn1"
+  image                     = "ubuntu-24.04"
+  private_key_uuid          = "dddd0002-0002-4000-8000-000000000002"
+  enable_backups            = true
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_server_hetzner.test", "enable_backups", "true"),
+					func(_ *terraform.State) error {
+						if got.EnableBackups == nil || !*got.EnableBackups {
+							return fmt.Errorf("POST body enable_backups = %v, want true", got.EnableBackups)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_hetzner" "test" {
+  name                      = "my-hetzner"
+  cloud_provider_token_uuid = "cccc0001-0001-4000-8000-000000000001"
+  server_type               = "cx22"
+  location                  = "fsn1"
+  image                     = "ubuntu-24.04"
+  private_key_uuid          = "dddd0002-0002-4000-8000-000000000002"
+  enable_backups            = true
 }`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,

--- a/templates/guides/import.md.tmpl
+++ b/templates/guides/import.md.tmpl
@@ -182,7 +182,7 @@ must be set in your `.tf` configuration before running `terraform plan`:
 | `coolify_application_github_app` | `github_app_uuid` (Coolify stores the linked GitHub App as `source_id`/`source_type`, so import cannot recover the original UUID) |
 | `coolify_service` | `project_uuid`, `server_uuid`, `environment_name`, `type` |
 | `coolify_server` | `private_key_uuid` (Coolify stores only the linked `private_key_id`, so import cannot reconstruct the original UUID) |
-| `coolify_server_hetzner` | `cloud_provider_token_uuid`, `server_type`, `location`, `image`, `private_key_uuid`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_ipv4`, `enable_ipv6`, `instant_validate` (Hetzner-specific fields are only sent at creation time and not returned by the server GET endpoint) |
+| `coolify_server_hetzner` | `cloud_provider_token_uuid`, `server_type`, `location`, `image`, `private_key_uuid`, `hetzner_ssh_key_ids`, `hetzner_firewall_ids`, `hetzner_network_ids`, `cloud_init_script`, `enable_ipv4`, `enable_ipv6`, `enable_backups`, `instant_validate` (Hetzner-specific fields are only sent at creation time and not returned by the server GET endpoint) |
 | `coolify_environment_variable` | `value` (sensitive value is not reliably returned on import; keep it in configuration before the first `terraform plan`) |
 | `coolify_deployment` | `triggers`, `wait_for_completion` (Terraform-only behavior controls, not persisted by the Coolify API) |
 | `coolify_environment` | `description` (stored in Terraform state only; not returned by the API) |


### PR DESCRIPTION
## Description

Lands the leftover inbox from the MPI cycle that shipped PR #766: Hetzner Cloud backups on `coolify_server_hetzner`, plus client-level happy-path and 404 tests for every DigitalOcean and Vultr list helper.

## Problem

`POST /api/v1/servers/hetzner` accepts `enable_backups`, but the provider only exposed sibling flags (`enable_ipv4`, `enable_ipv6`). Users who wanted Hetzner backups had to leave Terraform.

Hetzner list helpers already had happy-path plus NotFound client tests. DigitalOcean and Vultr list helpers did not. Terraform-layer 404 tests exist; a wrong client path or missing `IsNotFound` wrap would still slip through.

## Change

- Add create-only `enable_backups` (Coolify >= v4.2.0, no schema Default, `RequiresReplace`, flatten defaults to `false` on import).
- Send `enable_backups` on the Hetzner create POST when set; omit it when unset so 4.1.2 still works.
- Client tests: `ListDigitalOcean*` and `ListVultr*` method, path, token query, decode, and `IsNotFound`.
- Docs, import guide, and example comment note the ~20% Hetzner fee and the version floor.

## Validation

- `go test` for new client and Hetzner resource tests
- `make ci` locally (1434 tests, 1430+ documented)

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally
- [x] `make fmt` ran (gofmt + go mod tidy)
- [x] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [x] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

Closes #764
Closes #765
