### PR TITLE
fix: stop server proxy acc from setting redirect_enabled false

### DIFF
--- a/docs/resources/server_proxy.md
+++ b/docs/resources/server_proxy.md
@@ -33,7 +33,7 @@ resource "coolify_server_proxy" "example" {
 - `configuration` (String) Raw proxy configuration written with PUT .../proxy/configuration.
 - `generate_exact_labels` (Boolean)
 - `proxy_type` (String) Proxy type (for example traefik or caddy).
-- `redirect_enabled` (Boolean)
+- `redirect_enabled` (Boolean) Whether HTTP to HTTPS redirect is enabled. Coolify defaults this to `true`. Setting `false` is ignored by Coolify today (`$request->has('redirect_enabled')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.
 - `redirect_url` (String)
 
 ## Import

--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -44,8 +44,13 @@ func (r *serverProxyResource) Schema(_ context.Context, _ resource.SchemaRequest
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages Coolify proxy settings and optional raw configuration for a server. Requires Coolify >= v4.3.0. Destroy leaves the remote proxy configuration in place.",
 		Attributes: map[string]schema.Attribute{
-			"server_uuid":           schema.StringAttribute{Required: true, MarkdownDescription: "Server UUID.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}, Validators: []validator.String{validate.UUID()}},
-			"redirect_enabled":      schema.BoolAttribute{Optional: true, Computed: true},
+			"server_uuid": schema.StringAttribute{Required: true, MarkdownDescription: "Server UUID.", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}, Validators: []validator.String{validate.UUID()}},
+			"redirect_enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "Whether HTTP to HTTPS redirect is enabled. Coolify defaults this to `true`. " +
+					"Setting `false` is ignored by Coolify today (`$request->has('redirect_enabled')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.",
+			},
 			"redirect_url":          schema.StringAttribute{Optional: true, Computed: true},
 			"generate_exact_labels": schema.BoolAttribute{Optional: true, Computed: true},
 			"proxy_type":            schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},

--- a/internal/service/serverproxy/resource_acc_test.go
+++ b/internal/service/serverproxy/resource_acc_test.go
@@ -32,16 +32,18 @@ resource "coolify_server_proxy" "test" {
 				// $request->has('redirect_enabled'); Laravel has() is false
 				// for JSON false, so the write is ignored and GET stays true
 				// (default). Same class as empty domains (#647).
+				// redirect_url uses exists() and persists, but SafeExternalUrl
+				// requires a resolvable host (example.invalid 422s).
 				Config: acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_server_proxy" "test" {
   server_uuid  = %q
   proxy_type   = "traefik"
-  redirect_url = "https://example.invalid"
+  redirect_url = "https://example.com"
 }
 `, serverUUID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_server_proxy.test", "proxy_type", "traefik"),
-					resource.TestCheckResourceAttr("coolify_server_proxy.test", "redirect_url", "https://example.invalid"),
+					resource.TestCheckResourceAttr("coolify_server_proxy.test", "redirect_url", "https://example.com"),
 				),
 			},
 			{

--- a/internal/service/serverproxy/resource_acc_test.go
+++ b/internal/service/serverproxy/resource_acc_test.go
@@ -28,14 +28,21 @@ resource "coolify_server_proxy" "test" {
 				Check: resource.TestCheckResourceAttr("coolify_server_proxy.test", "server_uuid", serverUUID),
 			},
 			{
+				// Do not set redirect_enabled = false. Coolify's PATCH uses
+				// $request->has('redirect_enabled'); Laravel has() is false
+				// for JSON false, so the write is ignored and GET stays true
+				// (default). Same class as empty domains (#647).
 				Config: acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_server_proxy" "test" {
-  server_uuid      = %q
-  proxy_type       = "traefik"
-  redirect_enabled = false
+  server_uuid  = %q
+  proxy_type   = "traefik"
+  redirect_url = "https://example.invalid"
 }
 `, serverUUID),
-				Check: resource.TestCheckResourceAttr("coolify_server_proxy.test", "proxy_type", "traefik"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_server_proxy.test", "proxy_type", "traefik"),
+					resource.TestCheckResourceAttr("coolify_server_proxy.test", "redirect_url", "https://example.invalid"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_server_proxy.test",


### PR DESCRIPTION
## Description

Stop `TestAccServerProxyResource_CRUD` from setting `redirect_enabled = false`. That write is ignored by Coolify and made Acceptance Tests (0) fail on main after #767.

## Problem

Coolify `ServerProxyController` PATCH uses `$request->has('redirect_enabled')`. Laravel `has()` is false for JSON `false`, so GET still returns the default `true`. Terraform then reports an inconsistent result after apply.

Same class as empty `domains` (#647). `redirect_url` uses `$request->exists()` and does persist.

## Change

- Acc update step now sets `redirect_url` instead of `redirect_enabled = false`
- Schema description documents that `false` is ignored

## Validation

- `go test -race ./internal/service/serverproxy/`
- `make docs`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Documentation updated
- [x] `make docs` regenerated
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
