### PR TITLE
fix: redact API keys in logs and cover server control-plane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     labels:
       - dependencies
     commit-message:
@@ -19,6 +20,7 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    rebase-strategy: auto
     labels:
       - dependencies
     commit-message:
@@ -29,6 +31,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     labels:
       - dependencies
     commit-message:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 69 data sources, 1430+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 69 data sources, 1450+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1430+ tests (unit + acceptance)
+- 1450+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 69 |
-| Tests | 1430+ unit and acceptance tests |
+| Tests | 1450+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -333,7 +333,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1430+ tests, race detector enabled)
+make test                                       # Run unit tests (1450+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -324,6 +324,21 @@ queues, sidecars). See the [Domains and HTTPS](domains-and-https)
 guide. Clearing an existing FQDN with `domains = ""` is blocked by a
 Coolify update-path bug (`$request->has('domains')`); tracked as #647.
 
+### Server proxy `false` flags stay `true`
+
+**Symptom:** `coolify_server_proxy` plan sets `redirect_enabled = false`
+or `generate_exact_labels = false`, apply succeeds, and the next plan
+shows the value still `true`.
+
+**Cause:** Coolify's proxy PATCH uses Laravel `$request->has()` for those
+bools. JSON `false` is treated as absent, so the stored default (`true`)
+stays. `redirect_url` uses `exists()` and does persist.
+
+**Fix:** leave `redirect_enabled` and `generate_exact_labels` unset or
+`true` until Coolify switches those gates to `exists()`. Prove the update
+path with `redirect_url` (use a resolvable host such as
+`https://example.com`; reserved names like `example.invalid` return 422).
+
 ### "forces replacement"
 
 ```

--- a/docs/resources/server_proxy.md
+++ b/docs/resources/server_proxy.md
@@ -31,10 +31,10 @@ resource "coolify_server_proxy" "example" {
 ### Optional
 
 - `configuration` (String) Raw proxy configuration written with PUT .../proxy/configuration.
-- `generate_exact_labels` (Boolean)
+- `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers). Setting `false` is ignored by Coolify today (`$request->has('generate_exact_labels')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.
 - `proxy_type` (String) Proxy type (for example traefik or caddy).
 - `redirect_enabled` (Boolean) Whether HTTP to HTTPS redirect is enabled. Coolify defaults this to `true`. Setting `false` is ignored by Coolify today (`$request->has('redirect_enabled')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.
-- `redirect_url` (String)
+- `redirect_url` (String) HTTPS redirect target URL. Coolify persists this field (`$request->exists('redirect_url')`). Use a resolvable host; reserved names such as `example.invalid` return 422.
 
 ## Import
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -447,7 +447,8 @@ func redactValue(v interface{}) {
 			lower := strings.ToLower(k)
 			if sensitiveKeys[lower] || strings.Contains(lower, "password") ||
 				strings.Contains(lower, "secret") || strings.Contains(lower, "private_key") ||
-				strings.Contains(lower, "token") {
+				strings.Contains(lower, "token") || strings.Contains(lower, "api_key") ||
+				strings.Contains(lower, "license_key") || strings.Contains(lower, "user_key") {
 				val[k] = "[REDACTED]"
 			} else {
 				redactValue(child)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5280,6 +5280,24 @@ func TestRedactJSON_Nested(t *testing.T) {
 	assert.Contains(t, got, `"name":"ok"`)
 }
 
+func TestRedactJSON_APIKeysAndLicenses(t *testing.T) {
+	t.Parallel()
+	input := `{
+		"name":"drain",
+		"logdrain_axiom_api_key":"axiom-secret",
+		"logdrain_newrelic_license_key":"nr-license",
+		"resend_api_key":"re_123",
+		"pushover_user_key":"po-user"
+	}`
+	got := redactJSON([]byte(input))
+	assert.Contains(t, got, `"name":"drain"`)
+	assert.NotContains(t, got, "axiom-secret")
+	assert.NotContains(t, got, "nr-license")
+	assert.NotContains(t, got, "re_123")
+	assert.NotContains(t, got, "po-user")
+	assert.Contains(t, got, `[REDACTED]`)
+}
+
 func TestRedactJSON_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	got := redactJSON([]byte("not json"))

--- a/internal/client/server_control_test.go
+++ b/internal/client/server_control_test.go
@@ -1,0 +1,333 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testServerUUID = "aaaa0001-0001-4000-8000-000000000001"
+
+func TestServerProxyUpdate_JSONTags(t *testing.T) {
+	t.Parallel()
+	enabled := false
+	url := "https://example.com"
+	labels := true
+	proxyType := "caddy"
+	input := ServerProxyUpdateInput{
+		RedirectEnabled:     &enabled,
+		RedirectURL:         &url,
+		GenerateExactLabels: &labels,
+		ProxyType:           &proxyType,
+	}
+	raw, err := json.Marshal(input)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, false, got["redirect_enabled"])
+	assert.Equal(t, "https://example.com", got["redirect_url"])
+	assert.Equal(t, true, got["generate_exact_labels"])
+	assert.Equal(t, "caddy", got["proxy_type"])
+
+	empty, err := json.Marshal(ServerProxyUpdateInput{})
+	require.NoError(t, err)
+	var emptyRaw map[string]any
+	require.NoError(t, json.Unmarshal(empty, &emptyRaw))
+	assert.Empty(t, emptyRaw)
+}
+
+func TestClient_GetUpdateServerProxy(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/proxy", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(ServerProxy{ProxyType: "traefik", RedirectURL: "https://example.com"})
+		case http.MethodPatch:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "caddy", body["proxy_type"])
+			assert.Equal(t, "https://example.com", body["redirect_url"])
+			_ = json.NewEncoder(w).Encode(ServerProxy{ProxyType: "caddy", RedirectURL: "https://example.com"})
+		default:
+			http.Error(w, r.URL.Path, http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	got, err := c.GetServerProxy(context.Background(), testServerUUID)
+	require.NoError(t, err)
+	assert.Equal(t, "traefik", got.ProxyType)
+	assert.Equal(t, "https://example.com", got.RedirectURL)
+
+	url := "https://example.com"
+	proxyType := "caddy"
+	updated, err := c.UpdateServerProxy(context.Background(), testServerUUID, ServerProxyUpdateInput{
+		RedirectURL: &url,
+		ProxyType:   &proxyType,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "caddy", updated.ProxyType)
+}
+
+func TestClient_PutServerProxyConfiguration(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/proxy/configuration", r.URL.Path)
+		var body ServerProxyConfigInput
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "http:\n  routers:\n    web: {}", body.Configuration)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	require.NoError(t, c.PutServerProxyConfiguration(context.Background(), testServerUUID, "http:\n  routers:\n    web: {}"))
+}
+
+func TestClient_GetUpdateServerLogDrains(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/log-drains", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		enabled := true
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(ServerLogDrains{IsAxiomEnabled: &enabled, AxiomDatasetName: "coolify"})
+		case http.MethodPatch:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, true, body["is_logdrain_axiom_enabled"])
+			assert.Equal(t, "coolify-prod", body["logdrain_axiom_dataset_name"])
+			_ = json.NewEncoder(w).Encode(ServerLogDrains{IsAxiomEnabled: &enabled, AxiomDatasetName: "coolify-prod"})
+		default:
+			http.Error(w, r.URL.Path, http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	got, err := c.GetServerLogDrains(context.Background(), testServerUUID)
+	require.NoError(t, err)
+	require.NotNil(t, got.IsAxiomEnabled)
+	assert.True(t, *got.IsAxiomEnabled)
+	assert.Equal(t, "coolify", got.AxiomDatasetName)
+
+	enabled := true
+	updated, err := c.UpdateServerLogDrains(context.Background(), testServerUUID, ServerLogDrains{
+		IsAxiomEnabled:   &enabled,
+		AxiomDatasetName: "coolify-prod",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "coolify-prod", updated.AxiomDatasetName)
+}
+
+func TestClient_GetUpdateServerCloudflareTunnel(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/cloudflare-tunnel", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(ServerCloudflareTunnel{IsCloudflareTunnel: false})
+		case http.MethodPatch:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, true, body["is_cloudflare_tunnel"])
+			_ = json.NewEncoder(w).Encode(ServerCloudflareTunnel{IsCloudflareTunnel: true})
+		default:
+			http.Error(w, r.URL.Path, http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	got, err := c.GetServerCloudflareTunnel(context.Background(), testServerUUID)
+	require.NoError(t, err)
+	assert.False(t, got.IsCloudflareTunnel)
+
+	updated, err := c.UpdateServerCloudflareTunnel(context.Background(), testServerUUID, true)
+	require.NoError(t, err)
+	assert.True(t, updated.IsCloudflareTunnel)
+}
+
+func TestClient_GetUpdateServerSentinel(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/sentinel", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		enabled := true
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(ServerSentinel{IsSentinelEnabled: &enabled, SentinelToken: "tok"})
+		case http.MethodPatch:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, true, body["is_sentinel_enabled"])
+			assert.Equal(t, true, body["is_metrics_enabled"])
+			_ = json.NewEncoder(w).Encode(ServerSentinel{IsSentinelEnabled: &enabled, IsMetricsEnabled: &enabled})
+		default:
+			http.Error(w, r.URL.Path, http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	got, err := c.GetServerSentinel(context.Background(), testServerUUID)
+	require.NoError(t, err)
+	require.NotNil(t, got.IsSentinelEnabled)
+	assert.True(t, *got.IsSentinelEnabled)
+	assert.Equal(t, "tok", got.SentinelToken)
+
+	enabled := true
+	updated, err := c.UpdateServerSentinel(context.Background(), testServerUUID, ServerSentinel{
+		IsSentinelEnabled: &enabled,
+		IsMetricsEnabled:  &enabled,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.IsMetricsEnabled)
+	assert.True(t, *updated.IsMetricsEnabled)
+}
+
+func TestClient_GetUpdateServerDockerCleanup(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/servers/"+testServerUUID+"/docker-cleanup", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		threshold := int64(70)
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(ServerDockerCleanup{DockerCleanupFrequency: "@daily", DockerCleanupThreshold: &threshold})
+		case http.MethodPatch:
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "daily", body["docker_cleanup_frequency"])
+			assert.Equal(t, float64(80), body["docker_cleanup_threshold"])
+			updated := int64(80)
+			_ = json.NewEncoder(w).Encode(ServerDockerCleanup{DockerCleanupFrequency: "daily", DockerCleanupThreshold: &updated})
+		default:
+			http.Error(w, r.URL.Path, http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	got, err := c.GetServerDockerCleanup(context.Background(), testServerUUID)
+	require.NoError(t, err)
+	assert.Equal(t, "@daily", got.DockerCleanupFrequency)
+	require.NotNil(t, got.DockerCleanupThreshold)
+	assert.Equal(t, int64(70), *got.DockerCleanupThreshold)
+
+	threshold := int64(80)
+	updated, err := c.UpdateServerDockerCleanup(context.Background(), testServerUUID, ServerDockerCleanup{
+		DockerCleanupFrequency: "daily",
+		DockerCleanupThreshold: &threshold,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "daily", updated.DockerCleanupFrequency)
+	require.NotNil(t, updated.DockerCleanupThreshold)
+	assert.Equal(t, int64(80), *updated.DockerCleanupThreshold)
+}
+
+func TestClient_ApplicationDestinations(t *testing.T) {
+	t.Parallel()
+	const destUUID = "dddd0001-0001-4000-8000-000000000001"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/applications/app-1/destinations":
+			_ = json.NewEncoder(w).Encode([]ApplicationDestination{{UUID: destUUID, IsPrimary: true}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/applications/app-1/destinations":
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, destUUID, body["destination_uuid"])
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/applications/app-1/destinations/"+destUUID:
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	list, err := c.ListApplicationDestinations(context.Background(), "app-1")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, destUUID, list[0].UUID)
+	assert.True(t, list[0].IsPrimary)
+
+	require.NoError(t, c.AttachApplicationDestination(context.Background(), "app-1", destUUID))
+	require.NoError(t, c.DetachApplicationDestination(context.Background(), "app-1", destUUID))
+}
+
+func TestClient_AttachApplicationDestination_WrongStatus(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+	err := c.AttachApplicationDestination(context.Background(), "app-1", "dest-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attaching destination dest-1 to application app-1")
+}
+
+func TestClient_ServerControl_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Not found."}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "test-token")
+
+	checks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"GetServerProxy", func() error { _, err := c.GetServerProxy(context.Background(), "missing"); return err }},
+		{"UpdateServerProxy", func() error {
+			_, err := c.UpdateServerProxy(context.Background(), "missing", ServerProxyUpdateInput{})
+			return err
+		}},
+		{"PutServerProxyConfiguration", func() error { return c.PutServerProxyConfiguration(context.Background(), "missing", "x") }},
+		{"GetServerLogDrains", func() error { _, err := c.GetServerLogDrains(context.Background(), "missing"); return err }},
+		{"UpdateServerLogDrains", func() error {
+			_, err := c.UpdateServerLogDrains(context.Background(), "missing", ServerLogDrains{})
+			return err
+		}},
+		{"GetServerCloudflareTunnel", func() error { _, err := c.GetServerCloudflareTunnel(context.Background(), "missing"); return err }},
+		{"UpdateServerCloudflareTunnel", func() error {
+			_, err := c.UpdateServerCloudflareTunnel(context.Background(), "missing", true)
+			return err
+		}},
+		{"GetServerSentinel", func() error { _, err := c.GetServerSentinel(context.Background(), "missing"); return err }},
+		{"UpdateServerSentinel", func() error {
+			_, err := c.UpdateServerSentinel(context.Background(), "missing", ServerSentinel{})
+			return err
+		}},
+		{"GetServerDockerCleanup", func() error { _, err := c.GetServerDockerCleanup(context.Background(), "missing"); return err }},
+		{"UpdateServerDockerCleanup", func() error {
+			_, err := c.UpdateServerDockerCleanup(context.Background(), "missing", ServerDockerCleanup{})
+			return err
+		}},
+		{"ListApplicationDestinations", func() error { _, err := c.ListApplicationDestinations(context.Background(), "missing"); return err }},
+		{"AttachApplicationDestination", func() error { return c.AttachApplicationDestination(context.Background(), "missing", "dest") }},
+		{"DetachApplicationDestination", func() error { return c.DetachApplicationDestination(context.Background(), "missing", "dest") }},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			require.Error(t, err)
+			assert.True(t, IsNotFound(err), "expected NotFound, got %v", err)
+		})
+	}
+}

--- a/internal/service/servercftunnel/resource_test.go
+++ b/internal/service/servercftunnel/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -127,6 +128,29 @@ resource "coolify_server_cloudflare_tunnel" "test" {
   is_cloudflare_tunnel = true
 }`,
 			Check: resource.TestCheckResourceAttr("coolify_server_cloudflare_tunnel.test", "is_cloudflare_tunnel", "true"),
+		}},
+	})
+}
+
+func TestServerCFTunnelResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/cloudflare-tunnel") && r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		http.Error(w, r.URL.Path, http.StatusNotFound)
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_cloudflare_tunnel" "test" {
+  server_uuid          = "aaaa0001-0001-4000-8000-000000000001"
+  is_cloudflare_tunnel = true
+}`,
+			ExpectError: regexp.MustCompile(`Error applying Cloudflare tunnel setting`),
 		}},
 	})
 }

--- a/internal/service/serverdockercleanup/resource.go
+++ b/internal/service/serverdockercleanup/resource.go
@@ -64,21 +64,13 @@ func (r *res) Configure(_ context.Context, req resource.ConfigureRequest, resp *
 	r.client = flex.ConfigureClient(req, &resp.Diagnostics)
 }
 
-func boolPtrKnown(b types.Bool) *bool {
-	if b.IsNull() || b.IsUnknown() {
-		return nil
-	}
-	v := b.ValueBool()
-	return &v
-}
-
 func toInput(m model) client.ServerDockerCleanup {
 	in := client.ServerDockerCleanup{
 		DockerCleanupFrequency:           m.DockerCleanupFrequency.ValueString(),
-		ForceDockerCleanup:               boolPtrKnown(m.ForceDockerCleanup),
-		DeleteUnusedVolumes:              boolPtrKnown(m.DeleteUnusedVolumes),
-		DeleteUnusedNetworks:             boolPtrKnown(m.DeleteUnusedNetworks),
-		DisableApplicationImageRetention: boolPtrKnown(m.DisableApplicationImageRetention),
+		ForceDockerCleanup:               flex.BoolValueOrNull(m.ForceDockerCleanup),
+		DeleteUnusedVolumes:              flex.BoolValueOrNull(m.DeleteUnusedVolumes),
+		DeleteUnusedNetworks:             flex.BoolValueOrNull(m.DeleteUnusedNetworks),
+		DisableApplicationImageRetention: flex.BoolValueOrNull(m.DisableApplicationImageRetention),
 	}
 	if !m.DockerCleanupThreshold.IsNull() && !m.DockerCleanupThreshold.IsUnknown() {
 		v := m.DockerCleanupThreshold.ValueInt64()

--- a/internal/service/serverdockercleanup/resource_test.go
+++ b/internal/service/serverdockercleanup/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -142,6 +143,30 @@ resource "coolify_server_docker_cleanup" "test" {
   docker_cleanup_threshold = 70
 }`,
 			Check: resource.TestCheckResourceAttr("coolify_server_docker_cleanup.test", "docker_cleanup_threshold", "70"),
+		}},
+	})
+}
+
+func TestServerDockerCleanupResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/docker-cleanup") && r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		http.Error(w, r.URL.Path, http.StatusNotFound)
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_docker_cleanup" "test" {
+  server_uuid              = "aaaa0001-0001-4000-8000-000000000001"
+  docker_cleanup_frequency = "@daily"
+  docker_cleanup_threshold = 70
+}`,
+			ExpectError: regexp.MustCompile(`Error applying Docker cleanup schedule`),
 		}},
 	})
 }

--- a/internal/service/serverlogdrain/resource.go
+++ b/internal/service/serverlogdrain/resource.go
@@ -65,23 +65,15 @@ func (r *res) Configure(_ context.Context, req resource.ConfigureRequest, resp *
 	r.client = flex.ConfigureClient(req, &resp.Diagnostics)
 }
 
-func boolPtrKnown(b types.Bool) *bool {
-	if b.IsNull() || b.IsUnknown() {
-		return nil
-	}
-	v := b.ValueBool()
-	return &v
-}
-
 func toInput(m model) client.ServerLogDrains {
 	return client.ServerLogDrains{
-		IsNewRelicEnabled:  boolPtrKnown(m.NewRelicEnabled),
+		IsNewRelicEnabled:  flex.BoolValueOrNull(m.NewRelicEnabled),
 		NewRelicLicenseKey: m.NewRelicLicenseKey.ValueString(),
 		NewRelicBaseURI:    m.NewRelicBaseURI.ValueString(),
-		IsAxiomEnabled:     boolPtrKnown(m.AxiomEnabled),
+		IsAxiomEnabled:     flex.BoolValueOrNull(m.AxiomEnabled),
 		AxiomDatasetName:   m.AxiomDatasetName.ValueString(),
 		AxiomAPIKey:        m.AxiomAPIKey.ValueString(),
-		IsCustomEnabled:    boolPtrKnown(m.CustomEnabled),
+		IsCustomEnabled:    flex.BoolValueOrNull(m.CustomEnabled),
 		CustomConfig:       m.CustomConfig.ValueString(),
 		CustomConfigParser: m.CustomConfigParser.ValueString(),
 	}

--- a/internal/service/serverlogdrain/resource_test.go
+++ b/internal/service/serverlogdrain/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -141,6 +142,31 @@ resource "coolify_server_log_drain" "test" {
   logdrain_axiom_api_key      = "axiom-key"
 }`,
 			Check: resource.TestCheckResourceAttr("coolify_server_log_drain.test", "is_logdrain_axiom_enabled", "true"),
+		}},
+	})
+}
+
+func TestServerLogDrainResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/log-drains") && r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		http.Error(w, r.URL.Path, http.StatusNotFound)
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_log_drain" "test" {
+  server_uuid                 = "aaaa0001-0001-4000-8000-000000000001"
+  is_logdrain_axiom_enabled   = true
+  logdrain_axiom_dataset_name = "coolify"
+  logdrain_axiom_api_key      = "axiom-key"
+}`,
+			ExpectError: regexp.MustCompile(`Error applying server log drains`),
 		}},
 	})
 }

--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -62,8 +62,8 @@ func (r *serverProxyResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Whether to generate exact Docker labels (removes extra labels from containers). " +
 					"Setting `false` is ignored by Coolify today (`$request->has('generate_exact_labels')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.",
 			},
-			"proxy_type":            schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},
-			"configuration":         schema.StringAttribute{Optional: true, MarkdownDescription: "Raw proxy configuration written with PUT .../proxy/configuration."},
+			"proxy_type":    schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},
+			"configuration": schema.StringAttribute{Optional: true, MarkdownDescription: "Raw proxy configuration written with PUT .../proxy/configuration."},
 		},
 	}
 }

--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -149,21 +149,7 @@ func (r *serverProxyResource) Read(ctx context.Context, req resource.ReadRequest
 		resp.Diagnostics.AddError("Error reading server proxy", fmt.Sprintf("%s: %s", state.ServerUUID.ValueString(), err))
 		return
 	}
-	if got.RedirectEnabled != nil {
-		state.RedirectEnabled = types.BoolValue(*got.RedirectEnabled)
-	}
-	if got.RedirectURL != "" {
-		state.RedirectURL = types.StringValue(got.RedirectURL)
-	}
-	if got.GenerateExactLabels != nil {
-		state.GenerateExactLabels = types.BoolValue(*got.GenerateExactLabels)
-	}
-	if got.ProxyType != "" {
-		state.ProxyType = types.StringValue(strings.ToLower(got.ProxyType))
-	}
-	if got.Configuration != "" && !state.Configuration.IsNull() {
-		state.Configuration = types.StringValue(got.Configuration)
-	}
+	flattenProxy(got, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -51,8 +51,17 @@ func (r *serverProxyResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Whether HTTP to HTTPS redirect is enabled. Coolify defaults this to `true`. " +
 					"Setting `false` is ignored by Coolify today (`$request->has('redirect_enabled')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.",
 			},
-			"redirect_url":          schema.StringAttribute{Optional: true, Computed: true},
-			"generate_exact_labels": schema.BoolAttribute{Optional: true, Computed: true},
+			"redirect_url": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "HTTPS redirect target URL. Coolify persists this field (`$request->exists('redirect_url')`). Use a resolvable host; reserved names such as `example.invalid` return 422.",
+			},
+			"generate_exact_labels": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "Whether to generate exact Docker labels (removes extra labels from containers). " +
+					"Setting `false` is ignored by Coolify today (`$request->has('generate_exact_labels')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.",
+			},
 			"proxy_type":            schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},
 			"configuration":         schema.StringAttribute{Optional: true, MarkdownDescription: "Raw proxy configuration written with PUT .../proxy/configuration."},
 		},

--- a/internal/service/serverproxy/resource_test.go
+++ b/internal/service/serverproxy/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -138,5 +139,133 @@ resource "coolify_server_proxy" "test" {
 }`,
 			Check: resource.TestCheckResourceAttr("coolify_server_proxy.test", "proxy_type", "caddy"),
 		}},
+	})
+}
+
+func TestServerProxyResource_ConfigurationPUT(t *testing.T) {
+	t.Parallel()
+	const serverUUID = "aaaa0001-0001-4000-8000-000000000001"
+	store := map[string]any{"proxy_type": "traefik", "configuration": ""}
+	var mu sync.Mutex
+	var putCount int
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/proxy/configuration") && r.Method == http.MethodPut:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode proxy config: %v", err)
+			}
+			cfg, _ := body["configuration"].(string)
+			if cfg == "" {
+				t.Errorf("expected non-empty configuration in PUT body, got %v", body)
+			}
+			store["configuration"] = cfg
+			putCount++
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodPatch:
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for k, v := range body {
+				store[k] = v
+			}
+			_ = json.NewEncoder(w).Encode(store)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(store)
+		default:
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid   = "` + serverUUID + `"
+  proxy_type    = "traefik"
+  configuration = "http:\n  routers:\n    web: {}"
+}`,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_server_proxy.test", "configuration", "http:\n  routers:\n    web: {}"),
+				func(_ *terraform.State) error {
+					mu.Lock()
+					defer mu.Unlock()
+					if putCount < 1 {
+						return fmt.Errorf("expected PUT /proxy/configuration, got %d calls", putCount)
+					}
+					return nil
+				},
+			),
+		}},
+	})
+}
+
+func TestServerProxyResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		http.Error(w, r.URL.Path, http.StatusNotFound)
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid = "aaaa0001-0001-4000-8000-000000000001"
+  proxy_type  = "caddy"
+}`,
+			ExpectError: regexp.MustCompile(`Error applying server proxy`),
+		}},
+	})
+}
+
+func TestServerProxyResource_ImportBadUUID(t *testing.T) {
+	t.Parallel()
+	const serverUUID = "aaaa0001-0001-4000-8000-000000000001"
+	store := map[string]any{"proxy_type": "traefik"}
+	var mu sync.Mutex
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodPatch:
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for k, v := range body {
+				store[k] = v
+			}
+			_ = json.NewEncoder(w).Encode(store)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(store)
+		default:
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid = "` + serverUUID + `"
+  proxy_type  = "traefik"
+}`,
+			},
+			{
+				ResourceName:  "coolify_server_proxy.test",
+				ImportState:   true,
+				ImportStateId: "not-a-uuid",
+				ExpectError:   regexp.MustCompile(`Invalid Import ID`),
+			},
+		},
 	})
 }

--- a/internal/service/serversentinel/resource.go
+++ b/internal/service/serversentinel/resource.go
@@ -63,19 +63,11 @@ func (r *res) Configure(_ context.Context, req resource.ConfigureRequest, resp *
 	r.client = flex.ConfigureClient(req, &resp.Diagnostics)
 }
 
-func boolPtrKnown(b types.Bool) *bool {
-	if b.IsNull() || b.IsUnknown() {
-		return nil
-	}
-	v := b.ValueBool()
-	return &v
-}
-
 func toInput(m model) client.ServerSentinel {
 	in := client.ServerSentinel{
-		IsSentinelEnabled:      boolPtrKnown(m.IsSentinelEnabled),
-		IsMetricsEnabled:       boolPtrKnown(m.IsMetricsEnabled),
-		IsSentinelDebugEnabled: boolPtrKnown(m.IsSentinelDebugEnabled),
+		IsSentinelEnabled:      flex.BoolValueOrNull(m.IsSentinelEnabled),
+		IsMetricsEnabled:       flex.BoolValueOrNull(m.IsMetricsEnabled),
+		IsSentinelDebugEnabled: flex.BoolValueOrNull(m.IsSentinelDebugEnabled),
 		SentinelToken:          m.SentinelToken.ValueString(),
 		SentinelCustomURL:      m.SentinelCustomURL.ValueString(),
 	}

--- a/internal/service/serversentinel/resource_test.go
+++ b/internal/service/serversentinel/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -132,6 +133,29 @@ resource "coolify_server_sentinel" "test" {
   is_sentinel_enabled = true
 }`,
 			Check: resource.TestCheckResourceAttr("coolify_server_sentinel.test", "is_sentinel_enabled", "true"),
+		}},
+	})
+}
+
+func TestServerSentinelResource_CreateAPIError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/sentinel") && r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		http.Error(w, r.URL.Path, http.StatusNotFound)
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_sentinel" "test" {
+  server_uuid         = "aaaa0001-0001-4000-8000-000000000001"
+  is_sentinel_enabled = true
+}`,
+			ExpectError: regexp.MustCompile(`Error applying Sentinel settings`),
 		}},
 	})
 }

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -324,6 +324,21 @@ queues, sidecars). See the [Domains and HTTPS](domains-and-https)
 guide. Clearing an existing FQDN with `domains = ""` is blocked by a
 Coolify update-path bug (`$request->has('domains')`); tracked as #647.
 
+### Server proxy `false` flags stay `true`
+
+**Symptom:** `coolify_server_proxy` plan sets `redirect_enabled = false`
+or `generate_exact_labels = false`, apply succeeds, and the next plan
+shows the value still `true`.
+
+**Cause:** Coolify's proxy PATCH uses Laravel `$request->has()` for those
+bools. JSON `false` is treated as absent, so the stored default (`true`)
+stays. `redirect_url` uses `exists()` and does persist.
+
+**Fix:** leave `redirect_enabled` and `generate_exact_labels` unset or
+`true` until Coolify switches those gates to `exists()`. Prove the update
+path with `redirect_url` (use a resolvable host such as
+`https://example.com`; reserved names like `example.invalid` return 422).
+
 ### "forces replacement"
 
 ```


### PR DESCRIPTION
## Description

Hardens server control-plane coverage and closes a debug-log leak of API keys, license keys, and Pushover user keys.

## The problem

- `internal/client/server_control.go` had no direct client tests (proxy, log drains, Cloudflare tunnel, Sentinel, Docker cleanup, application destinations).
- `coolify_server_proxy` Read duplicated `flattenProxy` instead of sharing it.
- Three singletons copied `boolPtrKnown` instead of `flex.BoolValueOrNull`.
- `generate_exact_labels = false` has the same Coolify Laravel `has()` ignore as `redirect_enabled`, but the schema and common-errors guide did not say so.
- `redactJSON` missed `api_key`, `license_key`, and `user_key`, so log-drain, Resend, and Pushover secrets could appear in TF_LOG traces.
- Dependabot lacked `rebase-strategy: auto`, so grouped PRs can sit BEHIND after main moves.

## The change

- Client tests for the full server control-plane family (happy path, JSON tags, 404).
- Configuration PUT, CreateAPIError, and invalid-import tests on `coolify_server_proxy`, plus CreateAPIError on sibling singletons.
- Shared flatten and bool-pointer helpers.
- Schema and common-errors docs for ignored `false` proxy flags.
- Broader secret redaction with a regression test.
- Dependabot auto-rebase on every ecosystem.
- Documented test floor 1450+ (actual 1452).

## Validation

- `make ci` (build, lint, unit tests with race, validate, actionlint, python-test, docs-check, api-coverage-check, counts-check, contract-compat, govulncheck, goreleaser-check, modverify)

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally
- [x] `make fmt` ran (gofmt + go mod tidy)
- [x] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
