### PR TITLE
ci: auto-merge GitHub Actions major Dependabot groups

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,8 +30,14 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Approve and enable auto-merge (patch/minor only)
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      # Actions majors (cache v4->v6, setup-go v5->v6) are Node runtime
+      # bumps, not API breaks. fetch-metadata reports the highest type in
+      # a group, so one action major used to block the whole weekly group.
+      # Keep skipping gomod (and other) majors for human review.
+      - name: Approve and enable auto-merge
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-major' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -39,5 +45,7 @@ jobs:
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
       - name: Skip major updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-major' &&
+          steps.metadata.outputs.package-ecosystem != 'github_actions'
         run: echo "Skipping major version update -- requires manual review"


### PR DESCRIPTION
## Description

Auto-merge Dependabot GitHub Actions groups even when the group includes a semver-major bump.

## The problem

[#770](https://github.com/coolify-terraform/terraform-provider-coolify/pull/770) is approved, `CI` is green, and mergeable, but auto-merge never armed. `dependabot/fetch-metadata` reported `update-type: version-update:semver-major` because the weekly `actions` group includes `actions/cache` 4.3.0 to 6.1.0. The workflow then ran "Skipping major version update" and left the PR for a human.

That is the wrong bar for Actions. Those majors are almost always Node runtime bumps. The same weekly group also carries patch/minor action pins, so one major blocks the whole PR.

Go module majors stay skipped.

## The change

`.github/workflows/dependabot-auto-merge.yml` enables auto-merge when the update is not major, or when `package-ecosystem` is `github_actions`.

## Validation

- `actionlint` on the workflow file
- Condition matches fetch-metadata output from #770 (`package-ecosystem: github_actions`, `update-type: version-update:semver-major`)

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated (workflow policy; no Go tests)
- [x] `make fmt` not required (YAML only)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
