### PR TITLE
fix: persist server proxy redirect_url when type is unchanged

### DIFF
--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
@@ -120,17 +121,36 @@ func flattenProxy(got *client.ServerProxy, plan *serverProxyModel) {
 func (r *serverProxyResource) apply(ctx context.Context, plan *serverProxyModel) error {
 	uuid := plan.ServerUUID.ValueString()
 	input := proxyUpdateFromPlan(*plan)
-	// Coolify update() calls changeProxy() whenever proxy_type is present.
-	// That refresh can drop redirect_url written in the same request.
-	// Send type first, then the remaining settings.
+
+	current, err := r.client.GetServerProxy(ctx, uuid)
+	if err != nil && !client.IsNotFound(err) {
+		return err
+	}
+	if current != nil {
+		flattenProxy(current, plan)
+	}
+
+	wantType := ""
 	if input.ProxyType != nil {
-		typeOnly := client.ServerProxyUpdateInput{ProxyType: input.ProxyType}
-		got, err := r.client.UpdateServerProxy(ctx, uuid, typeOnly)
+		wantType = strings.ToLower(*input.ProxyType)
+	}
+	curType := ""
+	if current != nil {
+		curType = strings.ToLower(current.ProxyType)
+	}
+	// changeProxy() is async and resets redirect_url. Skip a type PATCH
+	// when the value is already current so a later redirect_url write
+	// is not wiped by a no-op type change.
+	typeChanged := input.ProxyType != nil && wantType != curType
+	input.ProxyType = nil
+
+	if typeChanged {
+		typeVal := wantType
+		got, err := r.client.UpdateServerProxy(ctx, uuid, client.ServerProxyUpdateInput{ProxyType: &typeVal})
 		if err != nil {
 			return err
 		}
 		flattenProxy(got, plan)
-		input.ProxyType = nil
 	}
 	if input.RedirectEnabled != nil || input.RedirectURL != nil || input.GenerateExactLabels != nil {
 		got, err := r.client.UpdateServerProxy(ctx, uuid, input)
@@ -139,10 +159,48 @@ func (r *serverProxyResource) apply(ctx context.Context, plan *serverProxyModel)
 		}
 		flattenProxy(got, plan)
 	}
+	if typeChanged && input.RedirectURL != nil && *input.RedirectURL != "" {
+		if err := r.ensureRedirectURL(ctx, uuid, *input.RedirectURL, plan); err != nil {
+			return err
+		}
+	}
 	if !plan.Configuration.IsNull() && !plan.Configuration.IsUnknown() && plan.Configuration.ValueString() != "" {
 		return r.client.PutServerProxyConfiguration(ctx, uuid, plan.Configuration.ValueString())
 	}
 	return nil
+}
+
+// ensureRedirectURL re-applies redirect_url if an async changeProxy()
+// refresh dropped it after a proxy_type PATCH.
+func (r *serverProxyResource) ensureRedirectURL(ctx context.Context, uuid, want string, plan *serverProxyModel) error {
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		got, err := r.client.GetServerProxy(ctx, uuid)
+		if err != nil {
+			return err
+		}
+		if got.RedirectURL == want {
+			flattenProxy(got, plan)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("redirect_url %q did not persist after proxy_type change (GET has %q)", want, got.RedirectURL)
+		}
+		url := want
+		got, err = r.client.UpdateServerProxy(ctx, uuid, client.ServerProxyUpdateInput{RedirectURL: &url})
+		if err != nil {
+			return err
+		}
+		flattenProxy(got, plan)
+		if got.RedirectURL == want {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
 }
 
 func (r *serverProxyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/serverproxy/resource_test.go
+++ b/internal/service/serverproxy/resource_test.go
@@ -303,6 +303,66 @@ resource "coolify_server_proxy" "test" {
 	})
 }
 
+func TestServerProxyResource_SameTypeSkipsTypePatch(t *testing.T) {
+	t.Parallel()
+	const serverUUID = "aaaa0001-0001-4000-8000-000000000001"
+	store := map[string]any{
+		"redirect_url": "",
+		"proxy_type":   "TRAEFIK",
+	}
+	var mu sync.Mutex
+	var sawTypePatch bool
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodPatch:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode proxy patch: %v", err)
+			}
+			if _, ok := body["proxy_type"]; ok {
+				sawTypePatch = true
+			}
+			for k, v := range body {
+				store[k] = v
+			}
+			_ = json.NewEncoder(w).Encode(store)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(store)
+		default:
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid  = "` + serverUUID + `"
+  proxy_type   = "traefik"
+  redirect_url = "https://example.com"
+}`,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_server_proxy.test", "redirect_url", "https://example.com"),
+				func(_ *terraform.State) error {
+					mu.Lock()
+					defer mu.Unlock()
+					if sawTypePatch {
+						return fmt.Errorf("PATCH sent proxy_type when GET already had traefik")
+					}
+					if store["redirect_url"] != "https://example.com" {
+						return fmt.Errorf("store redirect_url=%v", store["redirect_url"])
+					}
+					return nil
+				},
+			),
+		}},
+	})
+}
+
 func TestServerProxyResource_ImportBadUUID(t *testing.T) {
 	t.Parallel()
 	const serverUUID = "aaaa0001-0001-4000-8000-000000000001"


### PR DESCRIPTION
## Description

Coolify `changeProxy()` runs whenever `proxy_type` is present on PATCH, even when the type did not change. That job is async and clears `redirect_url`.

`TestAccServerProxyResource_CRUD` on Coolify `latest` (4.3.5) failed ImportStateVerify: apply kept `redirect_url` from plan, import GET was empty. Tip-edge and floor passed (floor skips the test; tip raced the async job).

Skip the type PATCH when GET already matches (case-insensitive). After a real type change, re-GET and re-PATCH `redirect_url` if it disappeared.

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] `go test ./internal/service/serverproxy/` passes
- [x] `make fmt` ran (gofmt)
- [ ] CHANGELOG.md updated (release-please)

## Test plan

- [x] `TestServerProxyResource_SameTypeSkipsTypePatch`
- [x] Existing serverproxy unit tests
- [ ] Nightly Acc stable-latest `TestAccServerProxyResource_CRUD`