### PR TITLE
fix(application): split docker image into name and tag on update

### DIFF
--- a/internal/service/application/resource_docker.go
+++ b/internal/service/application/resource_docker.go
@@ -180,7 +180,13 @@ func (r *dockerImageApplicationResource) Update(ctx context.Context, req resourc
 	planFields := plan.common()
 	stateFields := state.common()
 	input := buildUpdateInput(planFields, stateFields)
-	input.DockerRegistryImageName = flex.StringIfChanged(plan.DockerImage, state.DockerImage)
+	if changed := flex.StringIfChanged(plan.DockerImage, state.DockerImage); changed != nil {
+		name, tag := splitDockerImage(plan.DockerImage.ValueString())
+		input.DockerRegistryImageName = &name
+		if tag != "" {
+			input.DockerRegistryImageTag = &tag
+		}
+	}
 
 	dockerImageChanged := plan.DockerImage.ValueString() != state.DockerImage.ValueString()
 	updateAndReadBack(ctx, r.client, plan.UUID.ValueString(), input, resp, func(app *client.Application) {
@@ -207,6 +213,16 @@ func (r *dockerImageApplicationResource) ImportState(ctx context.Context, req re
 
 func (m *dockerImageApplicationResourceModel) common() commonAppFields {
 	return m.applicationCommonModel.common()
+}
+
+// splitDockerImage splits "repo/image:tag" into name and tag. Coolify stores
+// the tag in a separate docker_registry_image_tag field and rejects a tag
+// embedded in docker_registry_image_name when updating an application.
+func splitDockerImage(image string) (string, string) {
+	if i := strings.LastIndex(image, ":"); i >= 0 && !strings.Contains(image[i+1:], "/") {
+		return image[:i], image[i+1:]
+	}
+	return image, ""
 }
 
 // flattenDockerImageApplication copies API fields into the Terraform state model.

--- a/internal/service/application/resource_docker.go
+++ b/internal/service/application/resource_docker.go
@@ -182,10 +182,13 @@ func (r *dockerImageApplicationResource) Update(ctx context.Context, req resourc
 	input := buildUpdateInput(planFields, stateFields)
 	if changed := flex.StringIfChanged(plan.DockerImage, state.DockerImage); changed != nil {
 		name, tag := splitDockerImage(plan.DockerImage.ValueString())
-		input.DockerRegistryImageName = &name
-		if tag != "" {
-			input.DockerRegistryImageTag = &tag
+		// Coolify PATCH is partial. Create/deploy default a missing tag
+		// to latest; omitting the tag field would keep the previous tag.
+		if tag == "" {
+			tag = "latest"
 		}
+		input.DockerRegistryImageName = &name
+		input.DockerRegistryImageTag = &tag
 	}
 
 	dockerImageChanged := plan.DockerImage.ValueString() != state.DockerImage.ValueString()

--- a/internal/service/application/resource_docker_split_test.go
+++ b/internal/service/application/resource_docker_split_test.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"testing"
+)
+
+func TestSplitDockerImage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		image    string
+		wantName string
+		wantTag  string
+	}{
+		{
+			name:     "name and tag",
+			image:    "nginx:latest",
+			wantName: "nginx",
+			wantTag:  "latest",
+		},
+		{
+			name:     "namespaced image with tag",
+			image:    "ghcr.io/org/app:1.25",
+			wantName: "ghcr.io/org/app",
+			wantTag:  "1.25",
+		},
+		{
+			name:     "no tag",
+			image:    "nginx",
+			wantName: "nginx",
+			wantTag:  "",
+		},
+		{
+			name:     "registry with port is not split at the port colon",
+			image:    "localhost:5000/nginx",
+			wantName: "localhost:5000/nginx",
+			wantTag:  "",
+		},
+		{
+			name:     "empty image",
+			image:    "",
+			wantName: "",
+			wantTag:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, tag := splitDockerImage(tt.image)
+			if name != tt.wantName {
+				t.Errorf("splitDockerImage(%q) name = %q, want %q", tt.image, name, tt.wantName)
+			}
+			if tag != tt.wantTag {
+				t.Errorf("splitDockerImage(%q) tag = %q, want %q", tt.image, tag, tt.wantTag)
+			}
+		})
+	}
+}

--- a/internal/service/application/resource_docker_test.go
+++ b/internal/service/application/resource_docker_test.go
@@ -201,11 +201,12 @@ func TestDockerImageApplicationResource_Update(t *testing.T) {
 			currentApp.DockerRegistryImageName = name
 		}
 		tag, ok := requestBody["docker_registry_image_tag"].(string)
-		if !ok {
+		switch {
+		case !ok:
 			t.Errorf("PATCH missing docker_registry_image_tag")
-		} else if tag != wantTag {
+		case tag != wantTag:
 			t.Errorf("PATCH docker_registry_image_tag = %q, want %q", tag, wantTag)
-		} else {
+		default:
 			currentApp.DockerRegistryImageTag = tag
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/service/application/resource_docker_test.go
+++ b/internal/service/application/resource_docker_test.go
@@ -171,6 +171,7 @@ func TestDockerImageApplicationResource_Update(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(currentApp)
 	})
+	var patchCount atomic.Int32
 	mux.HandleFunc("PATCH /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		if r.PathValue("uuid") != currentApp.UUID {
 			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
@@ -182,16 +183,30 @@ func TestDockerImageApplicationResource_Update(t *testing.T) {
 		if !ok {
 			return
 		}
-		if v, ok := requestBody["docker_registry_image_name"].(string); ok {
-			// Coolify rejects a tag embedded in the image name on update; the
-			// provider must send the tag in docker_registry_image_tag instead.
-			if strings.Contains(v, ":") {
-				t.Errorf("PATCH docker_registry_image_name must not contain a tag, got %q", v)
-			}
-			currentApp.DockerRegistryImageName = v
+		n := patchCount.Add(1)
+		wantName, wantTag := "nginx", "1.25"
+		if n >= 2 {
+			wantTag = "latest"
 		}
-		if v, ok := requestBody["docker_registry_image_tag"].(string); ok {
-			currentApp.DockerRegistryImageTag = v
+		name, ok := requestBody["docker_registry_image_name"].(string)
+		if !ok {
+			t.Errorf("PATCH missing docker_registry_image_name")
+		} else {
+			if strings.Contains(name, ":") {
+				t.Errorf("PATCH docker_registry_image_name must not contain a tag, got %q", name)
+			}
+			if name != wantName {
+				t.Errorf("PATCH docker_registry_image_name = %q, want %q", name, wantName)
+			}
+			currentApp.DockerRegistryImageName = name
+		}
+		tag, ok := requestBody["docker_registry_image_tag"].(string)
+		if !ok {
+			t.Errorf("PATCH missing docker_registry_image_tag")
+		} else if tag != wantTag {
+			t.Errorf("PATCH docker_registry_image_tag = %q, want %q", tag, wantTag)
+		} else {
+			currentApp.DockerRegistryImageTag = tag
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(currentApp)
@@ -235,6 +250,18 @@ func TestDockerImageApplicationResource_Update(t *testing.T) {
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_application_docker_image.test", "docker_image", "nginx:1.25"),
+				),
+			},
+			{
+				Config: testDockerImageResourceConfig(srv.URL, `
+					name           = "nginx-proxy"
+					project_uuid   = "aaaa0002-0002-4000-8000-000000000002"
+					server_uuid    = "bbbb0002-0002-4000-8000-000000000002"
+					docker_image   = "nginx"
+					ports_exposes  = "80"
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application_docker_image.test", "docker_image", "nginx"),
 				),
 			},
 		},

--- a/internal/service/application/resource_docker_test.go
+++ b/internal/service/application/resource_docker_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -182,7 +183,15 @@ func TestDockerImageApplicationResource_Update(t *testing.T) {
 			return
 		}
 		if v, ok := requestBody["docker_registry_image_name"].(string); ok {
+			// Coolify rejects a tag embedded in the image name on update; the
+			// provider must send the tag in docker_registry_image_tag instead.
+			if strings.Contains(v, ":") {
+				t.Errorf("PATCH docker_registry_image_name must not contain a tag, got %q", v)
+			}
 			currentApp.DockerRegistryImageName = v
+		}
+		if v, ok := requestBody["docker_registry_image_tag"].(string); ok {
+			currentApp.DockerRegistryImageTag = v
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(currentApp)


### PR DESCRIPTION
Coolify's update endpoint rejects a tag embedded in docker_registry_image_name and requires it in the separate docker_registry_image_tag field. Split the configured image:tag on update so image bumps no longer fail with 422 validation errors.

## Description

What does this PR do?

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally
- [x] `make fmt` ran (gofmt + go mod tidy)
- [ ] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated
- [x] No breaking changes to existing resources
