### PR TITLE
fix(deployment): deploy on first apply instead of restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-56 resources, 69 data sources, 1450+ tests (unit + acceptance), 10 CI jobs.
+56 resources, 69 data sources, 1460+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1450+ tests (unit + acceptance)
+- 1460+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 56 |
 | Data sources | 69 |
-| Tests | 1450+ unit and acceptance tests |
+| Tests | 1460+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -333,7 +333,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1450+ tests, race detector enabled)
+make test                                       # Run unit tests (1460+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/TESTING.md
+++ b/TESTING.md
@@ -463,7 +463,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 45/45 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 145
+- **Total acceptance test functions**: 146
 
 ### Testing strategies for edge cases
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -3,18 +3,21 @@
 page_title: "coolify_deployment Resource - coolify"
 subcategory: ""
 description: |-
-  Triggers a deployment for a Coolify application. Changing the triggers map forces a new deployment.
+  Triggers a Coolify application deployment (POST /api/v1/deploy?uuid=). Use this to bring up a newly created application in the same apply as the application resource. If Coolify already queued a deploy (instant_deploy = true), this resource adopts that deployment UUID instead of failing. Changing the triggers map forces a new deployment.
 ---
 
 # coolify_deployment (Resource)
 
-Triggers a deployment for a Coolify application. Changing the triggers map forces a new deployment.
+Triggers a Coolify application deployment (`POST /api/v1/deploy?uuid=`). Use this to bring up a newly created application in the same apply as the application resource. If Coolify already queued a deploy (`instant_deploy = true`), this resource adopts that deployment UUID instead of failing. Changing the triggers map forces a new deployment.
 
 ## Example Usage
 
 ```terraform
 resource "coolify_deployment" "web" {
   application_uuid = coolify_application.web.uuid
+
+  # Safe on first apply when the application sets instant_deploy = true;
+  # a deploy already queued for the same commit is adopted.
 
   triggers = {
     deploy_version = "v1.2.3"

--- a/examples/resources/coolify_deployment/resource.tf
+++ b/examples/resources/coolify_deployment/resource.tf
@@ -1,6 +1,9 @@
 resource "coolify_deployment" "web" {
   application_uuid = coolify_application.web.uuid
 
+  # Safe on first apply when the application sets instant_deploy = true;
+  # a deploy already queued for the same commit is adopted.
+
   triggers = {
     deploy_version = "v1.2.3"
   }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4700,6 +4700,158 @@ func TestClient_CancelDeployment(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClient_ListApplicationDeployments_WrappedObject(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/deployments/applications/app-wrap-1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"count": 2,
+			"deployments": []Deployment{
+				{UUID: "dep-wrap-1", Status: "finished"},
+				{UUID: "dep-wrap-2", Status: "in_progress"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	deps, err := c.ListApplicationDeployments(context.Background(), "app-wrap-1")
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+	assert.Equal(t, "dep-wrap-1", deps[0].UUID)
+	assert.Equal(t, "finished", deps[0].Status)
+	assert.Equal(t, "dep-wrap-2", deps[1].UUID)
+	assert.Equal(t, "in_progress", deps[1].Status)
+}
+
+func TestClient_DeployApplication(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/deploy", r.URL.Path)
+		assert.Equal(t, "app-deploy-1", r.URL.Query().Get("uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]string{{
+				"message":         "Application nginx deployment queued.",
+				"resource_uuid":   "app-deploy-1",
+				"deployment_uuid": "dep-from-deploy",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	got, err := c.DeployApplication(context.Background(), "app-deploy-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "dep-from-deploy", got.DeploymentUUID)
+	assert.Equal(t, "Application nginx deployment queued.", got.Message)
+}
+
+func TestClient_DeployApplication_SkipOmitsUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/deploy", r.URL.Path)
+		assert.Equal(t, "app-skip-1", r.URL.Query().Get("uuid"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]string{{
+				"message":       "Deployment already queued for this commit.",
+				"resource_uuid": "app-skip-1",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	got, err := c.DeployApplication(context.Background(), "app-skip-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.DeploymentUUID)
+	assert.Equal(t, "Deployment already queued for this commit.", got.Message)
+}
+
+func TestClient_LatestApplicationDeploymentUUID(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/deployments/applications/app-latest-1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"count": 2,
+			"deployments": []Deployment{
+				{UUID: "dep-finished", Status: "finished"},
+				{UUID: "dep-queued", Status: "queued"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	got, err := c.LatestApplicationDeploymentUUID(context.Background(), "app-latest-1")
+	require.NoError(t, err)
+	assert.Equal(t, "dep-queued", got)
+}
+
+func TestPickDeploymentUUID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		deps []Deployment
+		want string
+	}{
+		{name: "empty", want: ""},
+		{
+			name: "prefer queued over earlier finished",
+			deps: []Deployment{
+				{UUID: "fin", Status: "finished"},
+				{UUID: "q", Status: "queued"},
+			},
+			want: "q",
+		},
+		{
+			name: "prefer in_progress over finished",
+			deps: []Deployment{
+				{UUID: "fin", Status: "finished"},
+				{UUID: "ip", Status: "in_progress"},
+			},
+			want: "ip",
+		},
+		{
+			name: "status is case insensitive",
+			deps: []Deployment{{UUID: "q", Status: "QUEUED"}},
+			want: "q",
+		},
+		{
+			name: "fallback to first non-empty uuid",
+			deps: []Deployment{
+				{UUID: "", Status: "finished"},
+				{UUID: "first", Status: "finished"},
+				{UUID: "second", Status: "finished"},
+			},
+			want: "first",
+		},
+		{
+			name: "skip in-flight without uuid",
+			deps: []Deployment{
+				{UUID: "", Status: "queued"},
+				{UUID: "fin", Status: "finished"},
+			},
+			want: "fin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, pickDeploymentUUID(tt.deps))
+		})
+	}
+}
+
 func TestClient_Deploy(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -115,11 +115,24 @@ func (c *Client) GetDeployment(ctx context.Context, uuid string) (*Deployment, e
 	return &r, nil
 }
 func (c *Client) ListApplicationDeployments(ctx context.Context, appUUID string) ([]Deployment, error) {
-	var r []Deployment
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/deployments/applications/%s", url.PathEscape(appUUID)), nil, &r); err != nil {
+	// Coolify GET /deployments/applications/{uuid} returns
+	// {"count":N,"deployments":[...]}. Older mocks and some versions
+	// return a bare array. Accept both.
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/api/v1/deployments/applications/%s", url.PathEscape(appUUID)), nil, &raw); err != nil {
 		return nil, fmt.Errorf("listing deployments for application %s: %w", appUUID, err)
 	}
-	return r, nil
+	var r []Deployment
+	if err := json.Unmarshal(raw, &r); err == nil {
+		return r, nil
+	}
+	var wrap struct {
+		Deployments []Deployment `json:"deployments"`
+	}
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("listing deployments for application %s: decoding response: %w", appUUID, err)
+	}
+	return wrap.Deployments, nil
 }
 func (c *Client) CancelDeployment(ctx context.Context, uuid string) error {
 	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/api/v1/deployments/%s/cancel", url.PathEscape(uuid)), nil, nil); err != nil {
@@ -134,6 +147,69 @@ func (c *Client) Deploy(ctx context.Context) error {
 		return fmt.Errorf("triggering deploy: %w", err)
 	}
 	return nil
+}
+
+type deployByUUIDResponse struct {
+	Deployments []deployByUUIDItem `json:"deployments"`
+}
+
+type deployByUUIDItem struct {
+	Message        string `json:"message"`
+	ResourceUUID   string `json:"resource_uuid"`
+	DeploymentUUID string `json:"deployment_uuid"`
+}
+
+// DeployApplication POSTs /api/v1/deploy?uuid= to queue a real deploy
+// (not restart_only). When Coolify already has a queued or in-progress
+// deploy for the same commit it may omit deployment_uuid (skip). The
+// returned UUID may also be a never-persisted id; callers must GET it
+// and fall back to LatestApplicationDeploymentUUID on 404 or empty.
+func (c *Client) DeployApplication(ctx context.Context, appUUID string) (*RestartApplicationResponse, error) {
+	q := url.Values{}
+	q.Set("uuid", appUUID)
+	var wrap deployByUUIDResponse
+	if err := c.do(ctx, http.MethodPost, "/api/v1/deploy?"+q.Encode(), nil, &wrap); err != nil {
+		return nil, fmt.Errorf("deploying application %s: %w", appUUID, err)
+	}
+	out := &RestartApplicationResponse{}
+	for _, item := range wrap.Deployments {
+		if item.Message != "" {
+			out.Message = item.Message
+		}
+		if item.DeploymentUUID != "" {
+			out.DeploymentUUID = item.DeploymentUUID
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+// LatestApplicationDeploymentUUID returns the UUID of a queued or
+// in-progress deployment for the application, or the newest finished
+// one if nothing is in flight. Empty string when the app has none.
+func (c *Client) LatestApplicationDeploymentUUID(ctx context.Context, appUUID string) (string, error) {
+	deps, err := c.ListApplicationDeployments(ctx, appUUID)
+	if err != nil {
+		return "", err
+	}
+	return pickDeploymentUUID(deps), nil
+}
+
+func pickDeploymentUUID(deps []Deployment) string {
+	for _, d := range deps {
+		switch strings.ToLower(d.Status) {
+		case "queued", "in_progress":
+			if d.UUID != "" {
+				return d.UUID
+			}
+		}
+	}
+	for _, d := range deps {
+		if d.UUID != "" {
+			return d.UUID
+		}
+	}
+	return ""
 }
 
 func (c *Client) DeployByTag(ctx context.Context, tag string, input DeployByTagInput) error {

--- a/internal/service/deployment/resource.go
+++ b/internal/service/deployment/resource.go
@@ -58,7 +58,10 @@ func (r *deploymentResource) Metadata(_ context.Context, req resource.MetadataRe
 
 func (r *deploymentResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Triggers a deployment for a Coolify application. Changing the triggers map forces a new deployment.",
+		MarkdownDescription: "Triggers a Coolify application deployment (`POST /api/v1/deploy?uuid=`). " +
+			"Use this to bring up a newly created application in the same apply as the application resource. " +
+			"If Coolify already queued a deploy (`instant_deploy = true`), this resource adopts that deployment UUID instead of failing. " +
+			"Changing the triggers map forces a new deployment.",
 		Attributes: map[string]schema.Attribute{
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{Create: true}),
 			"application_uuid": schema.StringAttribute{
@@ -120,22 +123,28 @@ func (r *deploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	defer cancel()
 
 	appUUID := plan.ApplicationUUID.ValueString()
-	result, err := r.client.RestartApplication(ctx, appUUID)
+	result, err := r.client.DeployApplication(ctx, appUUID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error triggering deployment", fmt.Sprintf("Could not restart application %s: %s", appUUID, err))
+		resp.Diagnostics.AddError("Error triggering deployment", fmt.Sprintf("Could not deploy application %s: %s", appUUID, err))
 		return
 	}
 
-	if result.DeploymentUUID == "" {
+	depUUID, err := resolveDeploymentUUID(ctx, r.client, appUUID, result.DeploymentUUID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving deployment UUID",
+			fmt.Sprintf("Application %s: %s", appUUID, err))
+		return
+	}
+	if depUUID == "" {
 		resp.Diagnostics.AddError("Deployment triggered but no UUID returned",
-			fmt.Sprintf("Application %s restart was accepted but the API did not return a deployment UUID. Check the Coolify UI for the deployment status.", appUUID))
+			fmt.Sprintf("Application %s deploy was accepted but Coolify did not return a deployment UUID and no queued or recent deployment was found. Check the Coolify UI for the deployment status.", appUUID))
 		return
 	}
 
-	plan.UUID = types.StringValue(result.DeploymentUUID)
+	plan.UUID = types.StringValue(depUUID)
 
 	// Read back the deployment status.
-	dep, err := r.client.GetDeployment(ctx, result.DeploymentUUID)
+	dep, err := r.client.GetDeployment(ctx, depUUID)
 	if err != nil {
 		resp.Diagnostics.AddWarning("Could not read deployment status", fmt.Sprintf("Deployment was triggered but status could not be read: %s. Defaulting to 'queued'.", err))
 		plan.Status = types.StringValue("queued")
@@ -148,11 +157,35 @@ func (r *deploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Debug(ctx, "created resource", map[string]interface{}{"resource_type": "coolify_deployment", "uuid": result.DeploymentUUID})
+	tflog.Debug(ctx, "created resource", map[string]interface{}{"resource_type": "coolify_deployment", "uuid": depUUID})
 
 	if plan.WaitForCompletion.ValueBool() {
-		r.pollDeployment(ctx, result.DeploymentUUID, &plan, resp)
+		r.pollDeployment(ctx, depUUID, &plan, resp)
 	}
+}
+
+// resolveDeploymentUUID prefers the UUID from POST /deploy when GET
+// confirms it exists. Coolify skip can return a never-persisted id; on
+// GET 404 or any other GET failure, adopt a queued/in-progress (or
+// newest) app deployment when the list has one. Keep the POST UUID only
+// when the list is empty or the list call fails.
+func resolveDeploymentUUID(ctx context.Context, c *client.Client, appUUID, fromAPI string) (string, error) {
+	if fromAPI != "" {
+		if _, err := c.GetDeployment(ctx, fromAPI); err == nil {
+			return fromAPI, nil
+		}
+	}
+	latest, err := c.LatestApplicationDeploymentUUID(ctx, appUUID)
+	if err != nil {
+		if fromAPI != "" {
+			return fromAPI, nil
+		}
+		return "", err
+	}
+	if latest != "" {
+		return latest, nil
+	}
+	return fromAPI, nil
 }
 
 func (r *deploymentResource) pollDeployment(ctx context.Context, uuid string, plan *deploymentResourceModel, resp *resource.CreateResponse) {

--- a/internal/service/deployment/resource_acc_test.go
+++ b/internal/service/deployment/resource_acc_test.go
@@ -116,6 +116,60 @@ data "coolify_deployment" "test" {
 // Helpers
 // ---------------------------------------------------------------------------
 
+func TestAccDeploymentResource_InstantDeployAdoptsQueued(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	serverUUID := acctest.AccTestServerUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-deploy-id")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.AccCheckDestroy("coolify_project", "/api/v1/projects/"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeploymentInstantDeployConfig(name, serverUUID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coolify_deployment.test", "uuid"),
+					resource.TestCheckResourceAttrSet("coolify_deployment.test", "status"),
+				),
+			},
+			{
+				Config:             testAccDeploymentInstantDeployConfig(name, serverUUID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccDeploymentInstantDeployConfig(name, serverUUID string) string {
+	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
+resource "coolify_project" "test" {
+  name = %[1]q
+}
+
+resource "coolify_application_dockerfile" "test" {
+  project_uuid    = coolify_project.test.uuid
+  server_uuid     = %[2]q
+  instant_deploy  = true
+  dockerfile_location = base64encode(<<-DOCKERFILE
+    FROM nginx:alpine
+    EXPOSE 80
+  DOCKERFILE
+  )
+  ports_exposes = "80"
+}
+
+resource "coolify_deployment" "test" {
+  application_uuid = coolify_application_dockerfile.test.uuid
+  triggers = {
+    version = "1"
+  }
+}
+`, name, serverUUID)
+}
+
 func testAccDeploymentConfig(name, serverUUID string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {

--- a/internal/service/deployment/resource_test.go
+++ b/internal/service/deployment/resource_test.go
@@ -23,13 +23,24 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func requireRestartApplicationUUID(w http.ResponseWriter, r *http.Request, expectedAppUUID string) bool {
-	if r.PathValue("uuid") == expectedAppUUID {
+func requireDeployQueryUUID(w http.ResponseWriter, r *http.Request, expectedAppUUID string) bool {
+	if r.URL.Query().Get("uuid") == expectedAppUUID {
 		return true
 	}
 
-	http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	http.Error(w, `{"message":"No resources found."}`, http.StatusNotFound)
 	return false
+}
+
+func writeDeployQueued(w http.ResponseWriter, appUUID, deploymentUUID string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"deployments": []map[string]string{{
+			"message":         "Application deployment queued.",
+			"resource_uuid":   appUUID,
+			"deployment_uuid": deploymentUUID,
+		}},
+	})
 }
 
 func TestDeploymentResource_Create(t *testing.T) {
@@ -38,15 +49,11 @@ func TestDeploymentResource_Create(t *testing.T) {
 	appUUID := "cccc0002-0002-4000-8000-000000000002"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		uuid := r.PathValue("uuid")
@@ -112,19 +119,15 @@ func TestDeploymentResource_TriggersForceNew(t *testing.T) {
 	deploymentCount := 0
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
 		mu.Lock()
 		deploymentCount++
 		uuid := fmt.Sprintf("dep-uuid-%d", deploymentCount)
 		mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": uuid,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, uuid)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		uuid := r.PathValue("uuid")
@@ -189,15 +192,11 @@ func TestDeploymentResource_Import(t *testing.T) {
 	appUUID := "cccc0001-0001-4000-8000-000000000001"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		uuid := r.PathValue("uuid")
@@ -248,15 +247,11 @@ func TestDeploymentResource_Disappears(t *testing.T) {
 	deleted := false
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -312,22 +307,26 @@ func TestDeploymentResource_CreateReadBackFailureDefaultsQueued(t *testing.T) {
 	var readBackCalls atomic.Int32
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
+			return
+		}
+		writeDeployQueued(w, appUUID, deploymentUUID)
+	})
+	mux.HandleFunc("GET /api/v1/deployments/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"message":"Application not found"}`, http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		_ = json.NewEncoder(w).Encode(map[string]any{"count": 0, "deployments": []any{}})
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		count := readBackCalls.Add(1)
-		// Fail enough times to exhaust the client's 3 retries during
-		// Create's read-back, exercising the "default to queued" fallback.
+		// Fail resolve GET (4 attempts) plus Create status read-back
+		// (4 more) so the "default to queued" fallback still runs.
 		// Succeed afterward so the post-apply refresh Read works.
-		if count <= 4 {
+		if count <= 8 {
 			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
 			return
 		}
@@ -384,15 +383,11 @@ func TestDeploymentResource_WaitForCompletion(t *testing.T) {
 	getCount := 0
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -455,15 +450,11 @@ func TestDeploymentResource_WaitForCompletionFailed(t *testing.T) {
 			getCount := 0
 
 			mux := http.NewServeMux()
-			mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-				if !requireRestartApplicationUUID(w, r, appUUID) {
+			mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+				if !requireDeployQueryUUID(w, r, appUUID) {
 					return
 				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(map[string]string{
-					"deployment_uuid": deploymentUUID,
-					"message":         "Restart request queued.",
-				})
+				writeDeployQueued(w, appUUID, deploymentUUID)
 			})
 			mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 				mu.Lock()
@@ -527,15 +518,11 @@ func TestDeploymentResource_WaitForCompletionTimeout(t *testing.T) {
 	appUUID := "cccc0005-0005-4000-8000-000000000005"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -578,15 +565,11 @@ func TestDeploymentResource_ImportBadFormat(t *testing.T) {
 	appUUID := "cccc0002-0002-4000-8000-000000000002"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -630,15 +613,11 @@ func TestDeploymentResource_ImportBadUUID(t *testing.T) {
 	appUUID := "cccc0003-0003-4000-8000-000000000003"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -682,15 +661,11 @@ func TestDeploymentResource_ImportBadDeploymentUUID(t *testing.T) {
 	appUUID := "cccc0004-0004-4000-8000-000000000004"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -734,15 +709,11 @@ func TestDeploymentResource_UpdateWaitForCompletion(t *testing.T) {
 	appUUID := "cccc0006-0006-4000-8000-000000000006"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -821,14 +792,25 @@ func TestDeploymentResource_EmptyUUID(t *testing.T) {
 	appUUID := "cccc0007-0007-4000-8000-000000000007"
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": "",
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]string{{
+				"message":       "Deployment already queued for this commit.",
+				"resource_uuid": appUUID,
+			}},
 		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"message":"Application not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"count": 0, "deployments": []any{}})
 	})
 
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
@@ -890,16 +872,12 @@ func TestDeploymentResource_DestroyNoOp(t *testing.T) {
 	var restartCalls atomic.Int32
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, r *http.Request) {
-		if !requireRestartApplicationUUID(w, r, appUUID) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
 			return
 		}
 		restartCalls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
-			"deployment_uuid": deploymentUUID,
-			"message":         "Restart request queued.",
-		})
+		writeDeployQueued(w, appUUID, deploymentUUID)
 	})
 	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -931,14 +909,218 @@ resource "coolify_deployment" "test" {
 		},
 	})
 	if restartCalls.Load() != 1 {
-		t.Fatalf("expected restart only on create, got %d calls", restartCalls.Load())
+		t.Fatalf("expected deploy only on create, got %d calls", restartCalls.Load())
 	}
+}
+
+func TestDeploymentResource_AdoptsQueuedDeploy(t *testing.T) {
+	t.Parallel()
+	appUUID := "cccc0009-0009-4000-8000-000000000009"
+	existingUUID := "existing-queued-0001-4000-8000-000000000001"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]string{{
+				"message":       "Deployment already queued for this commit.",
+				"resource_uuid": appUUID,
+			}},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"message":"Application not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"count": 1,
+			"deployments": []map[string]any{{
+				"deployment_uuid": existingUUID,
+				"status":          "in_progress",
+			}},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != existingUUID {
+			http.Error(w, `{"message":"Deployment not found."}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployment_uuid": existingUUID,
+			"status":          "in_progress",
+		})
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+resource "coolify_deployment" "test" {
+  application_uuid = %q
+}
+`, srv.URL, appUUID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", existingUUID),
+					resource.TestCheckResourceAttr("coolify_deployment.test", "status", "in_progress"),
+				),
+			},
+		},
+	})
+}
+
+func TestDeploymentResource_PhantomDeployUUID(t *testing.T) {
+	t.Parallel()
+	appUUID := "cccc0010-0010-4000-8000-000000000010"
+	phantomUUID := "phantom-never-persisted-0001-4000-8000-0001"
+	existingUUID := "existing-queued-0002-4000-8000-000000000002"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
+			return
+		}
+		writeDeployQueued(w, appUUID, phantomUUID)
+	})
+	mux.HandleFunc("GET /api/v1/deployments/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"message":"Application not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"count": 1,
+			"deployments": []map[string]any{{
+				"deployment_uuid": existingUUID,
+				"status":          "queued",
+			}},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		uuid := r.PathValue("uuid")
+		if uuid != existingUUID {
+			http.Error(w, `{"message":"Deployment not found."}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"deployment_uuid": uuid,
+			"status":          "queued",
+		})
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+resource "coolify_deployment" "test" {
+  application_uuid = %q
+}
+`, srv.URL, appUUID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", existingUUID),
+				),
+			},
+		},
+	})
+}
+
+func TestDeploymentResource_TransientGetAdoptsQueued(t *testing.T) {
+	t.Parallel()
+	appUUID := "cccc0011-0011-4000-8000-000000000011"
+	phantomUUID := "phantom-never-persisted-0002-4000-8000-0002"
+	existingUUID := "existing-queued-0003-4000-8000-000000000003"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, r *http.Request) {
+		if !requireDeployQueryUUID(w, r, appUUID) {
+			return
+		}
+		writeDeployQueued(w, appUUID, phantomUUID)
+	})
+	mux.HandleFunc("GET /api/v1/deployments/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("uuid") != appUUID {
+			http.Error(w, `{"message":"Application not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"count": 1,
+			"deployments": []map[string]any{{
+				"deployment_uuid": existingUUID,
+				"status":          "queued",
+			}},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/deployments/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		uuid := r.PathValue("uuid")
+		if uuid == phantomUUID {
+			http.Error(w, `{"message":"temporary failure"}`, http.StatusUnprocessableEntity)
+			return
+		}
+		if uuid != existingUUID {
+			http.Error(w, `{"message":"Deployment not found."}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployment_uuid": uuid,
+			"status":          "queued",
+		})
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+resource "coolify_deployment" "test" {
+  application_uuid = %q
+}
+`, srv.URL, appUUID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_deployment.test", "uuid", existingUUID),
+				),
+			},
+		},
+	})
 }
 
 func TestDeploymentResource_CreateAPIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/applications/{uuid}/restart", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("POST /api/v1/deploy", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"message":"validation failed"}`, http.StatusUnprocessableEntity)
 	})
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))


### PR DESCRIPTION
## Summary

`coolify_deployment` now queues a real Coolify deploy on create (`POST /api/v1/deploy?uuid=`) so a new application can come up in the same apply. If Coolify already queued a job (`instant_deploy = true`), the resource adopts that deployment UUID instead of failing.

## Problem

Create called `RestartApplication` (`POST /applications/{uuid}/restart` with `restart_only`). That path cannot start an app that has never run, and Coolify skips a second queue for the same commit. The skip response either omits `deployment_uuid` or returns a never-persisted id, so Terraform failed with "Deployment triggered but no UUID returned" on first apply. A second apply worked because a finished deploy already existed.

## Change

- Add `DeployApplication` and wrap-aware `ListApplicationDeployments` (`{count,deployments}` or a bare array).
- Resolve the UUID by confirming GET, then adopting a queued or in-progress (or newest) app deployment when GET 404s or fails.
- Update schema, example, and generated docs.
- Unit tests cover adopt-queued, phantom POST UUID, transient GET adopt, wrap list decode, and the existing create/import/error paths against `/deploy`.
- Acceptance: `TestAccDeploymentResource_InstantDeployAdoptsQueued` (dockerfile + `instant_deploy = true` + plan-only).

## Validation

- `go test -race -count=1 ./internal/client/` (full package)
- `go test -race -count=1 ./internal/service/deployment/` (full package)
- `golangci-lint run ./internal/client/ ./internal/service/deployment/` (0 issues)
- Local reviewer: 0 bugs; suggestions folded (prefer listed UUID on GET failure, restore default-queued test, acc PlanOnly, example comment, client path asserts)

Closes #783
