### PR TITLE
fix(database): omit Coolify-rejected fields from create PATCH

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -468,10 +468,14 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 ### Primary-field update coverage
 
 When Coolify uses different validators on create vs update, a description-only
-Update step will not catch a 422 on the primary field. `coolify_application_docker_image`
-is the known split (`DockerImageFormat` on create vs `dockerImageNameRules()` on
-PATCH). `TestAccDockerImageApplicationResource_CRUD` must change `docker_image`
-on update (#786).
+Update step will not catch a 422 on the primary field.
+
+Known splits:
+
+| Resource | Create vs update | Acc coverage |
+|----------|------------------|--------------|
+| `coolify_application_docker_image` | `DockerImageFormat` on create vs `dockerImageNameRules()` on PATCH | `TestAccDockerImageApplicationResource_CRUD` must change `docker_image` (#786) |
+| All 8 `coolify_database_*` | Create POST accepts `limits_*`. Post-create PATCH sends remaining allow-list fields only. Coolify PATCH `$allowedFields` rejects `is_log_drain_enabled`, `is_include_timestamps`, `enable_ssl`, and other UI-only keys. | `TestAccPostgresqlDatabaseResource_CRUD` must set and update `limits_memory` (#789). Shared mock PATCH must 422 extra keys. |
 
 Description-only Update steps that remain (no known create/update validator
 split on the primary field):
@@ -482,12 +486,13 @@ split on the primary field):
 | `TestAccPrivateGitApplicationResource_CRUD` | `description` |
 | `TestAccGitHubAppApplicationResource_CRUD` | `description` |
 | `TestAccDockerfileApplicationResource_CRUD` | `description` |
-| `TestAccDatabase*Resource_CRUD` (8 types) | `description` |
+| `TestAccDatabase*Resource_CRUD` except postgresql | `description` (postgresql updates `limits_memory`; sibling engines share `SetUpdateExtended`) |
 | `TestAccProjectResource_basic` | `description` |
 | `TestAccEnvironmentResource_CRUD` | `description` |
 
 Do not treat those as sufficient coverage if a new create/update validator
-split is found. Add a primary-field Update step instead.
+split is found. Add a primary-field Update step instead. Mocks must reject
+keys the real Coolify controller would 422.
 
 ### Testing strategies for edge cases
 

--- a/docs/resources/database_clickhouse.md
+++ b/docs/resources/database_clickhouse.md
@@ -33,8 +33,8 @@ resource "coolify_database_clickhouse" "example" {
 
 - `clickhouse_admin_password` (String, Sensitive) The ClickHouse admin password (maps to `CLICKHOUSE_PASSWORD`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `clickhouse_admin_user` (String) The ClickHouse admin user name (maps to `CLICKHOUSE_USER`). If omitted, Coolify auto-generates a value readable from state after creation.
-- `clickhouse_db` (String) The default ClickHouse database name. If omitted, Coolify uses `default`.
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `clickhouse_db` (String) The default ClickHouse database name. If omitted, Coolify uses `default`. The Coolify public API does not accept this field on create or update.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
@@ -45,8 +45,8 @@ resource "coolify_database_clickhouse" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -56,7 +56,7 @@ resource "coolify_database_clickhouse" "example" {
 - `limits_memory_swap` (String) Memory swap limit (e.g., `1g`).
 - `limits_memory_swappiness` (Number) Memory swappiness (0-100).
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/docs/resources/database_dragonfly.md
+++ b/docs/resources/database_dragonfly.md
@@ -31,11 +31,11 @@ resource "coolify_database_dragonfly" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
 - `dragonfly_password` (String, Sensitive) The Dragonfly password. If omitted, Coolify auto-generates a value readable from state after creation.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -44,8 +44,8 @@ resource "coolify_database_dragonfly" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -55,7 +55,7 @@ resource "coolify_database_dragonfly" "example" {
 - `limits_memory_swap` (String) Memory swap limit (e.g., `1g`).
 - `limits_memory_swappiness` (Number) Memory swappiness (0-100).
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/docs/resources/database_keydb.md
+++ b/docs/resources/database_keydb.md
@@ -31,10 +31,10 @@ resource "coolify_database_keydb" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -43,8 +43,8 @@ resource "coolify_database_keydb" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `keydb_conf` (String) Custom KeyDB configuration (base64-encoded `keydb.conf` content).
 - `keydb_password` (String, Sensitive) The KeyDB password. If omitted, Coolify auto-generates a value readable from state after creation.
@@ -56,7 +56,7 @@ resource "coolify_database_keydb" "example" {
 - `limits_memory_swap` (String) Memory swap limit (e.g., `1g`).
 - `limits_memory_swappiness` (Number) Memory swappiness (0-100).
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/docs/resources/database_mariadb.md
+++ b/docs/resources/database_mariadb.md
@@ -45,10 +45,10 @@ resource "coolify_database_mariadb" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -57,8 +57,8 @@ resource "coolify_database_mariadb" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -73,7 +73,7 @@ resource "coolify_database_mariadb" "example" {
 - `mariadb_root_password` (String, Sensitive) The MariaDB root password (maps to `MARIADB_ROOT_PASSWORD`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `mariadb_user` (String) The MariaDB user name (maps to `MARIADB_USER`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `ssl_mode` (String) The SSL connection mode. Only applies when `enable_ssl` is `true`. Valid values: `REQUIRED`, `DISABLED`, `PREFERRED`, `VERIFY_CA`, `VERIFY_IDENTITY`.

--- a/docs/resources/database_mongodb.md
+++ b/docs/resources/database_mongodb.md
@@ -39,10 +39,10 @@ resource "coolify_database_mongodb" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -51,8 +51,8 @@ resource "coolify_database_mongodb" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -66,7 +66,7 @@ resource "coolify_database_mongodb" "example" {
 - `mongo_initdb_root_password` (String, Sensitive) The MongoDB root password (maps to `MONGO_INITDB_ROOT_PASSWORD`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `mongo_initdb_root_username` (String) The MongoDB root username (maps to `MONGO_INITDB_ROOT_USERNAME`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `ssl_mode` (String) The SSL connection mode for MongoDB. Only applies when `enable_ssl` is `true`. Valid values: `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.

--- a/docs/resources/database_mysql.md
+++ b/docs/resources/database_mysql.md
@@ -45,10 +45,10 @@ resource "coolify_database_mysql" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -57,8 +57,8 @@ resource "coolify_database_mysql" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -73,7 +73,7 @@ resource "coolify_database_mysql" "example" {
 - `mysql_root_password` (String, Sensitive) The MySQL root password (maps to `MYSQL_ROOT_PASSWORD`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `mysql_user` (String) The MySQL user name (maps to `MYSQL_USER`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `ssl_mode` (String) The SSL connection mode. Only applies when `enable_ssl` is `true`. Valid values: `REQUIRED`, `DISABLED`, `PREFERRED`, `VERIFY_CA`, `VERIFY_IDENTITY`.

--- a/docs/resources/database_postgresql.md
+++ b/docs/resources/database_postgresql.md
@@ -41,10 +41,10 @@ resource "coolify_database_postgresql" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -52,10 +52,10 @@ resource "coolify_database_postgresql" "example" {
 - `health_check_start_period` (Number) Grace period in seconds before health checks start counting failures after container start. Minimum `0`. Defaults to `5`.
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
-- `init_scripts` (String) Initialization scripts as a JSON array.
+- `init_scripts` (String) Initialization scripts as a JSON array. The Coolify public API does not accept this field on create or update.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -65,7 +65,7 @@ resource "coolify_database_postgresql" "example" {
 - `limits_memory_swap` (String) Memory swap limit (e.g., `1g`).
 - `limits_memory_swappiness` (Number) Memory swappiness (0-100).
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `postgres_conf` (String) Custom PostgreSQL configuration (base64-encoded `postgresql.conf` content).
 - `postgres_db` (String) The default database name (maps to `POSTGRES_DB`). If omitted, Coolify auto-generates a value readable from state after creation.
 - `postgres_host_auth_method` (String) Host authentication method (maps to `POSTGRES_HOST_AUTH_METHOD`, e.g., `trust`, `scram-sha-256`).

--- a/docs/resources/database_redis.md
+++ b/docs/resources/database_redis.md
@@ -37,10 +37,10 @@ resource "coolify_database_redis" "example" {
 
 ### Optional
 
-- `custom_docker_run_options` (String) Custom Docker run options passed to the container.
+- `custom_docker_run_options` (String) Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `description` (String) A description of the database.
 - `destination_uuid` (String) UUID of the Coolify destination (Docker network) on the server. Create-only; changing forces a new resource. Coolify requires this when the server has multiple destinations and ignores a mismatched value when only one destination exists. Supported on database create for all Coolify versions this provider supports (v4.1.0+). When omitted on a multi-destination server, the client may auto-resolve after Coolify returns the multi-destination error (prefers network `coolify`). Manage destinations with `coolify_destination`. Import cannot recover this value (GET does not return destination UUID); re-adding it after import forces replacement unless you set it in state or omit the attribute.
-- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.
+- `enable_ssl` (Boolean) When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `environment_name` (String) The name of the environment within the project to deploy into. Coolify auto-creates a `production` environment per project; for other environments, create one first with `coolify_environment`. Defaults to `production`. Changing this forces a new resource.
 - `health_check_enabled` (Boolean) When `true`, enables the Docker health check probe for this database container. Defaults to `true`.
 - `health_check_interval` (Number) Health check interval in seconds. Minimum `1`. Defaults to `15`.
@@ -49,8 +49,8 @@ resource "coolify_database_redis" "example" {
 - `health_check_timeout` (Number) Health check timeout in seconds. Minimum `1`. Defaults to `5`.
 - `image` (String) The Docker image to use.
 - `instant_deploy` (Boolean) Whether to immediately deploy the database after creation. When `true`, Coolify starts the database container right away. When `false` (default), the database is created but not started.
-- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`.
-- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`.
+- `is_include_timestamps` (Boolean) When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
+- `is_log_drain_enabled` (Boolean) When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `is_public` (Boolean) When `true`, exposes the database on a port accessible via the server's IP address. When `false` (default), the database is only reachable from other containers on the same Docker network. Set `public_port` to choose a specific port.
 - `limits_cpu_shares` (Number) CPU shares (relative weight).
 - `limits_cpus` (String) CPU limit (e.g., `0.5`, `2`).
@@ -60,7 +60,7 @@ resource "coolify_database_redis" "example" {
 - `limits_memory_swap` (String) Memory swap limit (e.g., `1g`).
 - `limits_memory_swappiness` (Number) Memory swappiness (0-100).
 - `name` (String) The name of the database resource. Also used as the Docker container name and internal DNS hostname for inter-container communication.
-- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).
+- `ports_mappings` (String) Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.
 - `public_port` (Number) The host port to expose the database on when `is_public` is `true`. If omitted, Coolify auto-assigns an available port. Ignored when `is_public` is `false`.
 - `public_port_timeout` (Number) Timeout in seconds for public port allocation.
 - `redis_conf` (String) Custom Redis configuration (base64-encoded `redis.conf` content).

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -923,6 +923,35 @@ func TestClient_UpdateDatabase(t *testing.T) {
 	assert.Equal(t, "renamed-db", db.Name)
 }
 
+func TestClient_UpdateDatabase_StripsDisallowedKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var raw map[string]interface{}
+		require.NoError(t, json.Unmarshal(body, &raw))
+		for _, k := range DatabaseUpdateDisallowedJSONKeys {
+			_, ok := raw[k]
+			assert.False(t, ok, "PATCH body must not contain %s", k)
+		}
+		require.Contains(t, raw, "limits_memory")
+		assert.Equal(t, "512M", raw["limits_memory"])
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Database{UUID: "db-san", Name: "sanitized"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	mem := "512M"
+	en := true
+	_, err := c.UpdateDatabase(context.Background(), "db-san", UpdateDatabaseInput{
+		LimitsMemory:      &mem,
+		IsLogDrainEnabled: &en,
+		EnableSSL:         &en,
+	})
+	require.NoError(t, err)
+}
+
 func TestClient_DeleteDatabase(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/databases.go
+++ b/internal/client/databases.go
@@ -91,6 +91,14 @@ type CreateDatabaseBaseInput struct {
 	IsPublic        *bool  `json:"is_public,omitempty"`
 	PublicPort      *int64 `json:"public_port,omitempty"`
 	InstantDeploy   *bool  `json:"instant_deploy,omitempty"`
+	// Limits are accepted on create POST for every supported Coolify version.
+	LimitsMemory            string `json:"limits_memory,omitempty"`
+	LimitsMemorySwap        string `json:"limits_memory_swap,omitempty"`
+	LimitsMemorySwappiness  *int64 `json:"limits_memory_swappiness,omitempty"`
+	LimitsMemoryReservation string `json:"limits_memory_reservation,omitempty"`
+	LimitsCPUs              string `json:"limits_cpus,omitempty"`
+	LimitsCPUSet            string `json:"limits_cpuset,omitempty"`
+	LimitsCPUShares         *int64 `json:"limits_cpu_shares,omitempty"`
 }
 
 type CreatePostgresqlInput struct {
@@ -244,7 +252,38 @@ func (c *Client) CreateDatabase(ctx context.Context, dbType string, input any) (
 	}
 	return &d, nil
 }
+
+// DatabaseUpdateDisallowedJSONKeys are on standalone models (Livewire/UI)
+// but are not in DatabasesController create or update $allowedFields.
+// Sending any of them 422s with "This field is not allowed."
+var DatabaseUpdateDisallowedJSONKeys = []string{
+	"is_log_drain_enabled",
+	"is_include_timestamps",
+	"enable_ssl",
+	"ssl_mode",
+	"ports_mappings",
+	"custom_docker_run_options",
+	"init_scripts",
+	"clickhouse_db",
+}
+
+// SanitizeDatabaseUpdate clears fields Coolify PATCH/create reject.
+func SanitizeDatabaseUpdate(input *UpdateDatabaseInput) {
+	if input == nil {
+		return
+	}
+	input.IsLogDrainEnabled = nil
+	input.IsIncludeTimestamps = nil
+	input.EnableSSL = nil
+	input.SSLMode = nil
+	input.PortsMappings = nil
+	input.CustomDockerRunOptions = nil
+	input.InitScripts = nil
+	input.ClickhouseDB = nil
+}
+
 func (c *Client) UpdateDatabase(ctx context.Context, uuid string, input UpdateDatabaseInput) (*Database, error) {
+	SanitizeDatabaseUpdate(&input)
 	var d Database
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/databases/%s", url.PathEscape(uuid)), input, &d); err != nil {
 		return nil, fmt.Errorf("updating database %s: %w", uuid, err)

--- a/internal/service/database/clickhouse/resource.go
+++ b/internal/service/database/clickhouse/resource.go
@@ -39,7 +39,7 @@ func (r *res) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resour
 	resp.Schema = schema.Schema{MarkdownDescription: "Manages a ClickHouse database resource on Coolify.", Attributes: dbcommon.CommonDatabaseAttrs(ctx, map[string]schema.Attribute{
 		"clickhouse_admin_user":     schema.StringAttribute{MarkdownDescription: "The ClickHouse admin user name (maps to `CLICKHOUSE_USER`). If omitted, Coolify auto-generates a value readable from state after creation.", Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 		"clickhouse_admin_password": schema.StringAttribute{MarkdownDescription: "The ClickHouse admin password (maps to `CLICKHOUSE_PASSWORD`). If omitted, Coolify auto-generates a value readable from state after creation.", Optional: true, Computed: true, Sensitive: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-		"clickhouse_db":             schema.StringAttribute{MarkdownDescription: "The default ClickHouse database name. If omitted, Coolify uses `default`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+		"clickhouse_db":             schema.StringAttribute{MarkdownDescription: "The default ClickHouse database name. If omitted, Coolify uses `default`. The Coolify public API does not accept this field on create or update.", Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 	})}
 }
 func (r *res) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -83,12 +83,14 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 	}
 
 	ext := p.ExtFields()
-	if dbcommon.HasExtendedFields(ext) || flex.StringValueConfigured(p.ClickhouseDB) {
+	if dbcommon.HasExtendedFields(ext) {
 		update := client.UpdateDatabaseInput{}
 		dbcommon.SetUpdateExtended(&update, ext)
-		flex.SetStrPtr(&update.ClickhouseDB, p.ClickhouseDB)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting ClickHouse database extended fields", fmt.Sprintf("ClickHouse database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "ClickHouse database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}
@@ -136,7 +138,6 @@ func (r *res) Update(ctx context.Context, req resource.UpdateRequest, resp *reso
 		PublicPort:              flex.Int64IfChanged(p.PublicPort, s.PublicPort),
 		ClickhouseAdminUser:     flex.StringIfChanged(p.ClickhouseAdminUser, s.ClickhouseAdminUser),
 		ClickhouseAdminPassword: flex.StringIfChanged(p.ClickhouseAdminPassword, s.ClickhouseAdminPassword),
-		ClickhouseDB:            flex.StringIfChanged(p.ClickhouseDB, s.ClickhouseDB),
 	}
 	dbcommon.SetUpdateExtendedDiff(&u, p.ExtFields(), s.ExtFields())
 	db, err := dbcommon.UpdateDatabase(ctx, r.client, s.UUID.ValueString(), u)

--- a/internal/service/database/clickhouse/resource_test.go
+++ b/internal/service/database/clickhouse/resource_test.go
@@ -44,8 +44,6 @@ resource "coolify_database_clickhouse" "test" {
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "environment_name", "production"),
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "clickhouse_admin_user", "default"),
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_include_timestamps", "false"),
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "status", "running"),
 				),
 			},
@@ -75,21 +73,19 @@ resource "coolify_database_clickhouse" "test" {
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "description", "Updated ClickHouse"),
 				),
 			},
-			// Update logging fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_clickhouse" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  name                  = "updated-ch"
-  description           = "Updated ClickHouse"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  name          = "updated-ch"
+  description   = "Updated ClickHouse"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -100,8 +96,6 @@ resource "coolify_database_clickhouse" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-ch"
   description             = "Updated ClickHouse"
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -129,9 +123,9 @@ resource "coolify_database_clickhouse" "test" {
 	})
 }
 
-func TestClickhouseDatabaseResource_CreateWithTimestamps(t *testing.T) {
+func TestClickhouseDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("clickhouse", "ch-ts-db", "clickhouse/clickhouse-server:latest", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("clickhouse", "ch-ts-db", "clickhouse/clickhouse-server:latest", map[string]interface{}{
 		"clickhouse_admin_user":     "default",
 		"clickhouse_admin_password": "secret123",
 	})
@@ -143,15 +137,27 @@ func TestClickhouseDatabaseResource_CreateWithTimestamps(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_clickhouse" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/service/database/common.go
+++ b/internal/service/database/common.go
@@ -121,6 +121,29 @@ func PopulateBaseCreateInput(base *client.CreateDatabaseBaseInput, m *CommonMode
 	base.IsPublic = flex.BoolValueOrNull(m.IsPublic)
 	base.PublicPort = flex.Int64PtrFromFramework(m.PublicPort)
 	base.InstantDeploy = flex.BoolValueOrNull(m.InstantDeploy)
+	// Coolify create POST accepts limits_* on every supported version.
+	// Send only non-default values so a default create body stays small.
+	if flex.StringPtrNonDefault(&m.LimitsMemory, "0") {
+		flex.SetIfKnown(&base.LimitsMemory, m.LimitsMemory)
+	}
+	if flex.StringPtrNonDefault(&m.LimitsMemorySwap, "0") {
+		flex.SetIfKnown(&base.LimitsMemorySwap, m.LimitsMemorySwap)
+	}
+	if flex.Int64PtrNonDefault(&m.LimitsMemorySwappiness, 60) {
+		base.LimitsMemorySwappiness = flex.Int64PtrFromFramework(m.LimitsMemorySwappiness)
+	}
+	if flex.StringPtrNonDefault(&m.LimitsMemoryReservation, "0") {
+		flex.SetIfKnown(&base.LimitsMemoryReservation, m.LimitsMemoryReservation)
+	}
+	if flex.StringPtrNonDefault(&m.LimitsCPUs, "0") {
+		flex.SetIfKnown(&base.LimitsCPUs, m.LimitsCPUs)
+	}
+	if flex.StringPtrConfigured(&m.LimitsCPUSet) {
+		flex.SetIfKnown(&base.LimitsCPUSet, m.LimitsCPUSet)
+	}
+	if flex.Int64PtrNonDefault(&m.LimitsCPUShares, 1024) {
+		base.LimitsCPUShares = flex.Int64PtrFromFramework(m.LimitsCPUShares)
+	}
 }
 
 // CommonDatabaseAttrs returns the shared schema attributes for all database types.
@@ -161,15 +184,15 @@ func CommonDatabaseAttrs(ctx context.Context, extra map[string]schema.Attribute)
 		"limits_cpu_shares":         schema.Int64Attribute{MarkdownDescription: "CPU shares (relative weight).", Optional: true, Computed: true, Default: int64default.StaticInt64(1024)},
 		// Container/network settings
 		"ports_mappings": schema.StringAttribute{
-			MarkdownDescription: "Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`).",
+			MarkdownDescription: "Port mappings in `host:container` format, comma-separated (e.g., `8080:5432`). The Coolify public API does not accept this field on create or update; set it in the Coolify UI.",
 			Optional:            true,
 			Validators: []validator.String{
 				validate.PortMappings(),
 			},
 		},
-		"custom_docker_run_options": schema.StringAttribute{MarkdownDescription: "Custom Docker run options passed to the container.", Optional: true, Validators: []validator.String{validate.NoShellMetachars()}},
+		"custom_docker_run_options": schema.StringAttribute{MarkdownDescription: "Custom Docker run options passed to the container. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.", Optional: true, Validators: []validator.String{validate.NoShellMetachars()}},
 		"public_port_timeout":       schema.Int64Attribute{MarkdownDescription: "Timeout in seconds for public port allocation.", Optional: true},
-		"is_log_drain_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, sends container logs to the configured log drain. Defaults to `false`.", Optional: true, Computed: true, Default: booldefault.StaticBool(false)},
+		"is_log_drain_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, sends container logs to the configured log drain. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.", Optional: true, Computed: true, Default: booldefault.StaticBool(false)},
 		"is_include_timestamps":     IsIncludeTimestampsAttr(),
 		"health_check_enabled":      schema.BoolAttribute{MarkdownDescription: "When `true`, enables the Docker health check probe for this database container. Defaults to `true`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
 		"health_check_interval":     schema.Int64Attribute{MarkdownDescription: "Health check interval in seconds. Minimum `1`. Defaults to `15`.", Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(1)}},
@@ -190,7 +213,7 @@ func CommonDatabaseAttrs(ctx context.Context, extra map[string]schema.Attribute)
 // shared by all database types.
 func IsIncludeTimestampsAttr() schema.BoolAttribute {
 	return schema.BoolAttribute{
-		MarkdownDescription: "When `true`, includes timestamps in container log output. Defaults to `false`.",
+		MarkdownDescription: "When `true`, includes timestamps in container log output. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.",
 		Optional:            true,
 		Computed:            true,
 		Default:             booldefault.StaticBool(false),
@@ -201,7 +224,7 @@ func IsIncludeTimestampsAttr() schema.BoolAttribute {
 // database types except ClickHouse.
 func EnableSSLAttr() schema.BoolAttribute {
 	return schema.BoolAttribute{
-		MarkdownDescription: "When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`.",
+		MarkdownDescription: "When `true`, enables SSL/TLS encryption for database connections. Defaults to `false`. The Coolify public API does not accept this field on create or update; set it in the Coolify UI.",
 		Optional:            true,
 		Computed:            true,
 		Default:             booldefault.StaticBool(false),
@@ -350,6 +373,46 @@ func NormalizeCommonCreateState(m *CommonModel) {
 	flex.NormalizeUnknownBool(&m.IsPublic)
 	flex.NormalizeUnknownInt64(&m.PublicPort)
 	flex.NormalizeUnknownString(&m.Status)
+	NormalizeExtendedCreateUnknowns(m.ExtFields())
+}
+
+// NormalizeExtendedCreateUnknowns resolves computed extended fields that have
+// no prior state on create so a failed post-create PATCH does not taint.
+func NormalizeExtendedCreateUnknowns(f DatabaseExtendedPtrs) {
+	if f.LimitsCPUSet != nil {
+		flex.NormalizeUnknownString(f.LimitsCPUSet)
+	}
+	if f.HealthCheckEnabled != nil {
+		flex.NormalizeUnknownBool(f.HealthCheckEnabled)
+	}
+	if f.HealthCheckInterval != nil {
+		flex.NormalizeUnknownInt64(f.HealthCheckInterval)
+	}
+	if f.HealthCheckTimeout != nil {
+		flex.NormalizeUnknownInt64(f.HealthCheckTimeout)
+	}
+	if f.HealthCheckRetries != nil {
+		flex.NormalizeUnknownInt64(f.HealthCheckRetries)
+	}
+	if f.HealthCheckStartPeriod != nil {
+		flex.NormalizeUnknownInt64(f.HealthCheckStartPeriod)
+	}
+	if f.InternalDBUrl != nil {
+		flex.NormalizeUnknownString(f.InternalDBUrl)
+	}
+	if f.Status != nil {
+		flex.NormalizeUnknownString(f.Status)
+	}
+}
+
+// RecoverCreateAfterExtendedError GETs the database after a failed post-create
+// PATCH, writes flattened state, then records the PATCH error. That keeps a
+// valid state object so Terraform does not taint a database that already exists.
+func RecoverCreateAfterExtendedError(ctx context.Context, c *client.Client, uuid, label string, patchErr error, resp *resource.CreateResponse, flattenAndSet func(*client.Database)) {
+	if db, err := c.GetDatabase(ctx, uuid); err == nil {
+		flattenAndSet(db)
+	}
+	resp.Diagnostics.AddError("Error setting "+label+" extended fields", fmt.Sprintf("%s %s: %s", label, uuid, patchErr))
 }
 
 // AddCreateReadBackError is a thin wrapper around flex.AddCreateReadBackError
@@ -474,24 +537,18 @@ func SetUpdateExtended(input *client.UpdateDatabaseInput, f DatabaseExtendedPtrs
 	flex.SetStrPtr(&input.LimitsMemoryReservation, *f.LimitsMemoryReservation)
 	flex.SetStrPtr(&input.LimitsCPUs, *f.LimitsCPUs)
 	flex.SetStrPtr(&input.LimitsCPUSet, *f.LimitsCPUSet)
-	flex.SetStrPtr(&input.PortsMappings, *f.PortsMappings)
-	flex.SetStrPtr(&input.CustomDockerRunOptions, *f.CustomDockerRunOptions)
 	flex.SetInt64Ptr(&input.LimitsMemorySwappiness, *f.LimitsMemorySwappiness)
 	flex.SetInt64Ptr(&input.LimitsCPUShares, *f.LimitsCPUShares)
 	input.PublicPortTimeout = flex.Int64PtrFromFramework(*f.PublicPortTimeout)
-	flex.SetBoolPtr(&input.IsLogDrainEnabled, *f.IsLogDrainEnabled)
-	flex.SetBoolPtr(&input.IsIncludeTimestamps, *f.IsIncludeTimestamps)
+	// is_log_drain_enabled, is_include_timestamps, enable_ssl, ssl_mode,
+	// ports_mappings, and custom_docker_run_options are not on Coolify
+	// PATCH $allowedFields. Sending them 422s (see #789).
 	flex.SetBoolPtr(&input.HealthCheckEnabled, *f.HealthCheckEnabled)
 	flex.SetInt64Ptr(&input.HealthCheckInterval, *f.HealthCheckInterval)
 	flex.SetInt64Ptr(&input.HealthCheckTimeout, *f.HealthCheckTimeout)
 	flex.SetInt64Ptr(&input.HealthCheckRetries, *f.HealthCheckRetries)
 	flex.SetInt64Ptr(&input.HealthCheckStartPeriod, *f.HealthCheckStartPeriod)
-	if f.EnableSSL != nil {
-		flex.SetBoolPtr(&input.EnableSSL, *f.EnableSSL)
-	}
-	if f.SSLMode != nil {
-		flex.SetStrPtr(&input.SSLMode, *f.SSLMode)
-	}
+	client.SanitizeDatabaseUpdate(input)
 }
 
 // SetUpdateExtendedDiff populates the extended fields in an UpdateDatabaseInput,
@@ -502,24 +559,15 @@ func SetUpdateExtendedDiff(input *client.UpdateDatabaseInput, plan, state Databa
 	input.LimitsMemoryReservation = flex.StringIfChanged(*plan.LimitsMemoryReservation, *state.LimitsMemoryReservation)
 	input.LimitsCPUs = flex.StringIfChanged(*plan.LimitsCPUs, *state.LimitsCPUs)
 	input.LimitsCPUSet = flex.StringIfChanged(*plan.LimitsCPUSet, *state.LimitsCPUSet)
-	input.PortsMappings = flex.StringIfChanged(*plan.PortsMappings, *state.PortsMappings)
-	input.CustomDockerRunOptions = flex.StringIfChanged(*plan.CustomDockerRunOptions, *state.CustomDockerRunOptions)
 	input.LimitsMemorySwappiness = flex.Int64IfChanged(*plan.LimitsMemorySwappiness, *state.LimitsMemorySwappiness)
 	input.LimitsCPUShares = flex.Int64IfChanged(*plan.LimitsCPUShares, *state.LimitsCPUShares)
 	input.PublicPortTimeout = flex.Int64IfChanged(*plan.PublicPortTimeout, *state.PublicPortTimeout)
-	input.IsLogDrainEnabled = flex.BoolIfChanged(*plan.IsLogDrainEnabled, *state.IsLogDrainEnabled)
-	input.IsIncludeTimestamps = flex.BoolIfChanged(*plan.IsIncludeTimestamps, *state.IsIncludeTimestamps)
 	input.HealthCheckEnabled = flex.BoolIfChanged(*plan.HealthCheckEnabled, *state.HealthCheckEnabled)
 	input.HealthCheckInterval = flex.Int64IfChanged(*plan.HealthCheckInterval, *state.HealthCheckInterval)
 	input.HealthCheckTimeout = flex.Int64IfChanged(*plan.HealthCheckTimeout, *state.HealthCheckTimeout)
 	input.HealthCheckRetries = flex.Int64IfChanged(*plan.HealthCheckRetries, *state.HealthCheckRetries)
 	input.HealthCheckStartPeriod = flex.Int64IfChanged(*plan.HealthCheckStartPeriod, *state.HealthCheckStartPeriod)
-	if plan.EnableSSL != nil {
-		input.EnableSSL = flex.BoolIfChanged(*plan.EnableSSL, *state.EnableSSL)
-	}
-	if plan.SSLMode != nil {
-		input.SSLMode = flex.StringIfChanged(*plan.SSLMode, *state.SSLMode)
-	}
+	client.SanitizeDatabaseUpdate(input)
 }
 
 // HasExtendedFields returns true if any extended field is configured (not
@@ -529,17 +577,12 @@ func HasExtendedFields(f DatabaseExtendedPtrs) bool {
 		flex.StringPtrNonDefault(f.LimitsMemoryReservation, "0") || flex.StringPtrNonDefault(f.LimitsCPUs, "0") ||
 		flex.StringPtrConfigured(f.LimitsCPUSet) ||
 		flex.Int64PtrNonDefault(f.LimitsMemorySwappiness, 60) || flex.Int64PtrNonDefault(f.LimitsCPUShares, 1024) ||
-		flex.StringPtrConfigured(f.PortsMappings) || flex.StringPtrConfigured(f.CustomDockerRunOptions) ||
 		flex.Int64PtrConfigured(f.PublicPortTimeout) ||
-		flex.BoolPtrNonDefault(f.IsLogDrainEnabled, false) ||
-		flex.BoolPtrNonDefault(f.IsIncludeTimestamps, false) ||
 		flex.BoolPtrNonDefault(f.HealthCheckEnabled, true) ||
 		flex.Int64PtrNonDefault(f.HealthCheckInterval, 15) ||
 		flex.Int64PtrNonDefault(f.HealthCheckTimeout, 5) ||
 		flex.Int64PtrNonDefault(f.HealthCheckRetries, 5) ||
-		flex.Int64PtrNonDefault(f.HealthCheckStartPeriod, 5) ||
-		(f.EnableSSL != nil && flex.BoolPtrNonDefault(f.EnableSSL, false)) ||
-		(f.SSLMode != nil && flex.StringPtrConfigured(f.SSLMode))
+		flex.Int64PtrNonDefault(f.HealthCheckStartPeriod, 5)
 }
 
 // FlattenDatabaseCommon sets the fields shared by all database resource types.

--- a/internal/service/database/common_test.go
+++ b/internal/service/database/common_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,71 @@ func strPtr(v string) *types.String { s := types.StringValue(v); return &s }
 func int64Ptr(v int64) *types.Int64 { i := types.Int64Value(v); return &i }
 
 func boolPtr(v bool) *types.Bool { b := types.BoolValue(v); return &b }
+
+func TestSetUpdateExtended_OmitsDisallowedKeys(t *testing.T) {
+	t.Parallel()
+	input := client.UpdateDatabaseInput{}
+	f := DatabaseExtendedPtrs{
+		LimitsMemory:            strPtr("512M"),
+		LimitsMemorySwap:        strPtr("0"),
+		LimitsMemoryReservation: strPtr("0"),
+		LimitsCPUs:              strPtr("0"),
+		LimitsCPUSet:            strPtr(""),
+		LimitsMemorySwappiness:  int64Ptr(60),
+		LimitsCPUShares:         int64Ptr(1024),
+		PortsMappings:           strPtr("5432:5432"),
+		CustomDockerRunOptions:  strPtr("--shm-size=1g"),
+		PublicPortTimeout:       int64Ptr(30),
+		IsLogDrainEnabled:       boolPtr(false),
+		IsIncludeTimestamps:     boolPtr(false),
+		HealthCheckEnabled:      boolPtr(true),
+		HealthCheckInterval:     int64Ptr(15),
+		HealthCheckTimeout:      int64Ptr(5),
+		HealthCheckRetries:      int64Ptr(5),
+		HealthCheckStartPeriod:  int64Ptr(5),
+		EnableSSL:               boolPtr(false),
+		SSLMode:                 strPtr("require"),
+	}
+	SetUpdateExtended(&input, f)
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["limits_memory"] != "512M" {
+		t.Fatalf("limits_memory = %v, want 512M", body["limits_memory"])
+	}
+	for _, k := range client.DatabaseUpdateDisallowedJSONKeys {
+		if _, ok := body[k]; ok {
+			t.Errorf("PATCH body contains disallowed key %s", k)
+		}
+	}
+}
+
+func TestPopulateBaseCreateInput_LimitsMemory(t *testing.T) {
+	t.Parallel()
+	m := CommonModel{
+		ServerUUID:      types.StringValue("bbbb0001-0001-4000-8000-000000000001"),
+		ProjectUUID:     types.StringValue("aaaa0001-0001-4000-8000-000000000001"),
+		EnvironmentName: types.StringValue("production"),
+		LimitsMemory:    types.StringValue("512M"),
+	}
+	var base client.CreateDatabaseBaseInput
+	PopulateBaseCreateInput(&base, &m)
+	if base.LimitsMemory != "512M" {
+		t.Fatalf("LimitsMemory = %q, want 512M", base.LimitsMemory)
+	}
+
+	m.LimitsMemory = types.StringValue("0")
+	base = client.CreateDatabaseBaseInput{}
+	PopulateBaseCreateInput(&base, &m)
+	if base.LimitsMemory != "" {
+		t.Fatalf("default LimitsMemory = %q, want empty", base.LimitsMemory)
+	}
+}
 
 func TestHasExtendedFields_AllDefaults(t *testing.T) {
 	t.Parallel()
@@ -69,13 +135,7 @@ func TestHasExtendedFields_EachField(t *testing.T) {
 		{"LimitsCPUSet", func(f *DatabaseExtendedPtrs) { f.LimitsCPUSet = strPtr("0-3") }},
 		{"LimitsMemorySwappiness", func(f *DatabaseExtendedPtrs) { f.LimitsMemorySwappiness = int64Ptr(10) }},
 		{"LimitsCPUShares", func(f *DatabaseExtendedPtrs) { f.LimitsCPUShares = int64Ptr(512) }},
-		{"PortsMappings", func(f *DatabaseExtendedPtrs) { f.PortsMappings = strPtr("5432:5432") }},
-		{"CustomDockerRunOptions", func(f *DatabaseExtendedPtrs) { f.CustomDockerRunOptions = strPtr("--shm-size=1g") }},
 		{"PublicPortTimeout", func(f *DatabaseExtendedPtrs) { f.PublicPortTimeout = int64Ptr(30) }},
-		{"IsLogDrainEnabled", func(f *DatabaseExtendedPtrs) { f.IsLogDrainEnabled = boolPtr(true) }},
-		{"IsIncludeTimestamps", func(f *DatabaseExtendedPtrs) { f.IsIncludeTimestamps = boolPtr(true) }},
-		{"EnableSSL", func(f *DatabaseExtendedPtrs) { f.EnableSSL = boolPtr(true) }},
-		{"SSLMode", func(f *DatabaseExtendedPtrs) { f.SSLMode = strPtr("require") }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/service/database/dbtest/mock_server.go
+++ b/internal/service/database/dbtest/mock_server.go
@@ -21,6 +21,53 @@ type MockState struct {
 	Image       string
 	ExtraFields map[string]interface{}
 	Deleted     bool
+	LastCreate  map[string]interface{}
+	LastPatch   map[string]interface{}
+}
+
+// databaseUpdateAllowed is Coolify DatabasesController::update_by_uuid
+// $allowedFields plus health_check_* (merged on Coolify >= v4.1.2).
+var databaseUpdateAllowed = map[string]struct{}{
+	"name": {}, "description": {}, "image": {},
+	"public_port": {}, "public_port_timeout": {}, "is_public": {},
+	"instant_deploy": {},
+	"limits_memory":  {}, "limits_memory_swap": {}, "limits_memory_swappiness": {},
+	"limits_memory_reservation": {}, "limits_cpus": {}, "limits_cpuset": {},
+	"limits_cpu_shares": {},
+	"postgres_user":     {}, "postgres_password": {}, "postgres_db": {},
+	"postgres_initdb_args": {}, "postgres_host_auth_method": {}, "postgres_conf": {},
+	"clickhouse_admin_user": {}, "clickhouse_admin_password": {},
+	"dragonfly_password": {},
+	"redis_password":     {}, "redis_conf": {},
+	"keydb_password": {}, "keydb_conf": {},
+	"mariadb_conf": {}, "mariadb_root_password": {}, "mariadb_user": {},
+	"mariadb_password": {}, "mariadb_database": {},
+	"mongo_conf": {}, "mongo_initdb_root_username": {}, "mongo_initdb_root_password": {},
+	"mongo_initdb_database": {},
+	"mysql_root_password":   {}, "mysql_password": {}, "mysql_user": {},
+	"mysql_database": {}, "mysql_conf": {},
+	"health_check_enabled": {}, "health_check_interval": {},
+	"health_check_timeout": {}, "health_check_retries": {},
+	"health_check_start_period": {},
+}
+
+func rejectUnallowedUpdate(w http.ResponseWriter, body map[string]interface{}) bool {
+	errors := map[string]string{}
+	for k := range body {
+		if _, ok := databaseUpdateAllowed[k]; !ok {
+			errors[k] = "This field is not allowed."
+		}
+	}
+	if len(errors) == 0 {
+		return false
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Validation failed.",
+		"errors":  errors,
+	})
+	return true
 }
 
 // buildResponse returns the JSON-serializable map for a GET response.
@@ -62,8 +109,11 @@ func (s *MockState) applyPatch(body map[string]interface{}) {
 	if v, ok := body["image"].(string); ok {
 		s.Image = v
 	}
-	for k := range s.ExtraFields {
-		if v, ok := body[k]; ok {
+	for k, v := range body {
+		switch k {
+		case "name", "description", "image", "project_uuid", "server_uuid", "environment_name", "destination_uuid", "instant_deploy":
+			continue
+		default:
 			s.ExtraFields[k] = v
 		}
 	}
@@ -72,6 +122,20 @@ func (s *MockState) applyPatch(body map[string]interface{}) {
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (s *MockState) handlePatch(w http.ResponseWriter, r *http.Request) {
+	var body map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	s.LastPatch = body
+	if rejectUnallowedUpdate(w, body) {
+		return
+	}
+	s.applyPatch(body)
+	writeJSON(w, http.StatusOK, map[string]string{"message": "updated"})
 }
 
 // validateCreateBody decodes the POST body and checks that all required fields
@@ -132,6 +196,7 @@ func NewMockServer(dbType, name, image string, extraFields map[string]interface{
 			if !ok {
 				return
 			}
+			state.LastCreate = body
 			state.applyPatch(body)
 			writeJSON(w, http.StatusCreated, map[string]string{"uuid": state.UUID})
 
@@ -143,13 +208,7 @@ func NewMockServer(dbType, name, image string, extraFields map[string]interface{
 			writeJSON(w, http.StatusOK, state.buildResponse())
 
 		case r.Method == http.MethodPatch && r.URL.Path == dbPath:
-			var body map[string]interface{}
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
-				return
-			}
-			state.applyPatch(body)
-			writeJSON(w, http.StatusOK, map[string]string{"message": "updated"})
+			state.handlePatch(w, r)
 
 		case r.Method == http.MethodDelete && r.URL.Path == dbPath:
 			state.Deleted = true

--- a/internal/service/database/dragonfly/resource.go
+++ b/internal/service/database/dragonfly/resource.go
@@ -82,7 +82,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		dbcommon.SetUpdateExtended(&update, ext)
 		flex.SetStrPtr(&update.DragonflyPassword, p.DragonflyPassword)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting Dragonfly database extended fields", fmt.Sprintf("Dragonfly database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "Dragonfly database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/dragonfly/resource_test.go
+++ b/internal/service/database/dragonfly/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/dbtest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestDragonflyDatabaseResource_CreateUpdateImport(t *testing.T) {
@@ -39,9 +40,6 @@ resource "coolify_database_dragonfly" "test" {
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "image", "docker.dragonflydb.io/dragonflydb/dragonfly:latest"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "environment_name", "production"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "status", "running"),
 				),
 			},
@@ -71,7 +69,7 @@ resource "coolify_database_dragonfly" "test" {
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "description", "Updated Dragonfly"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_dragonfly" "test" {
@@ -79,15 +77,11 @@ resource "coolify_database_dragonfly" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-dragonfly"
   description           = "Updated Dragonfly"
-  enable_ssl            = true
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -98,9 +92,6 @@ resource "coolify_database_dragonfly" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-dragonfly"
   description             = "Updated Dragonfly"
-  enable_ssl              = true
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -150,9 +141,6 @@ resource "coolify_database_dragonfly" "test" {
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "image", "docker.dragonflydb.io/dragonflydb/dragonfly:latest"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "environment_name", "production"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "status", "running"),
 				),
 			},
@@ -203,7 +191,7 @@ resource "coolify_database_dragonfly" "test" {
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "description", "Updated Dragonfly"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_dragonfly" "test" {
@@ -211,24 +199,20 @@ resource "coolify_database_dragonfly" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-dragonfly"
   description           = "Updated Dragonfly"
-  enable_ssl            = true
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "limits_memory", "512M"),
 				),
 			},
 		},
 	})
 }
 
-func TestDragonflyDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestDragonflyDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("dragonfly", "dragonfly-ssl-db", "docker.dragonflydb.io/dragonflydb/dragonfly:latest", nil)
+	srv, state := dbtest.NewMockServer("dragonfly", "dragonfly-ssl-db", "docker.dragonflydb.io/dragonflydb/dragonfly:latest", nil)
 	defer srv.Close()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -237,15 +221,27 @@ func TestDragonflyDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_dragonfly" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/service/database/keydb/resource.go
+++ b/internal/service/database/keydb/resource.go
@@ -86,7 +86,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		flex.SetStrPtr(&update.KeydbPassword, p.KeydbPassword)
 		flex.SetStrPtr(&update.KeydbConf, p.KeydbConf)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting KeyDB database extended fields", fmt.Sprintf("KeyDB database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "KeyDB database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/keydb/resource_test.go
+++ b/internal/service/database/keydb/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/dbtest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestKeydbDatabaseResource_CreateUpdateImport(t *testing.T) {
@@ -39,9 +40,6 @@ resource "coolify_database_keydb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "image", "eqalpha/keydb:latest"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "environment_name", "production"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "status", "running"),
 				),
 			},
@@ -71,7 +69,7 @@ resource "coolify_database_keydb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "description", "Updated KeyDB"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_keydb" "test" {
@@ -79,15 +77,11 @@ resource "coolify_database_keydb" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-keydb"
   description           = "Updated KeyDB"
-  enable_ssl            = true
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -98,9 +92,6 @@ resource "coolify_database_keydb" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-keydb"
   description             = "Updated KeyDB"
-  enable_ssl              = true
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -150,9 +141,6 @@ resource "coolify_database_keydb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "image", "eqalpha/keydb:latest"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "environment_name", "production"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "status", "running"),
 				),
 			},
@@ -203,7 +191,7 @@ resource "coolify_database_keydb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "description", "Updated KeyDB"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_keydb" "test" {
@@ -211,24 +199,20 @@ resource "coolify_database_keydb" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-keydb"
   description           = "Updated KeyDB"
-  enable_ssl            = true
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "limits_memory", "512M"),
 				),
 			},
 		},
 	})
 }
 
-func TestKeydbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestKeydbDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("keydb", "keydb-ssl-db", "eqalpha/keydb:latest", nil)
+	srv, state := dbtest.NewMockServer("keydb", "keydb-ssl-db", "eqalpha/keydb:latest", nil)
 	defer srv.Close()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -237,15 +221,27 @@ func TestKeydbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_keydb" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_keydb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/service/database/mariadb/resource.go
+++ b/internal/service/database/mariadb/resource.go
@@ -100,7 +100,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		dbcommon.SetUpdateExtended(&update, ext)
 		flex.SetStrPtr(&update.MariadbConf, p.MariadbConf)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting MariaDB database extended fields", fmt.Sprintf("MariaDB database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "MariaDB database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/mariadb/resource_test.go
+++ b/internal/service/database/mariadb/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/dbtest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestMariadbDatabaseResource_CreateUpdateImport(t *testing.T) {
@@ -44,9 +45,6 @@ resource "coolify_database_mariadb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "mariadb_user", "mariauser"),
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "mariadb_database", "mariadb"),
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "image", "mariadb:11"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "status", "running"),
 				),
 			},
@@ -76,7 +74,7 @@ resource "coolify_database_mariadb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "description", "Updated MariaDB"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mariadb" "test" {
@@ -84,17 +82,11 @@ resource "coolify_database_mariadb" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-mariadb"
   description           = "Updated MariaDB"
-  enable_ssl            = true
-  ssl_mode              = "REQUIRED"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "ssl_mode", "REQUIRED"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -105,10 +97,6 @@ resource "coolify_database_mariadb" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-mariadb"
   description             = "Updated MariaDB"
-  enable_ssl              = true
-  ssl_mode                = "REQUIRED"
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -136,9 +124,9 @@ resource "coolify_database_mariadb" "test" {
 	})
 }
 
-func TestMariadbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestMariadbDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("mariadb", "mariadb-ssl-db", "mariadb:11", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("mariadb", "mariadb-ssl-db", "mariadb:11", map[string]interface{}{
 		"mariadb_user":          "mariadbuser",
 		"mariadb_password":      "mariadbpass",
 		"mariadb_database":      "mydb",
@@ -152,17 +140,27 @@ func TestMariadbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mariadb" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  ssl_mode              = "REQUIRED"
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "ssl_mode", "REQUIRED"),
-					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -366,7 +364,7 @@ func TestMariadbDatabaseResource_InvalidSSLMode(t *testing.T) {
 resource "coolify_database_mariadb" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  ssl_mode     = "bogus"
+  ssl_mode     = "not-a-mode"
 }
 `,
 				ExpectError: regexp.MustCompile(`(?s)ssl_mode value must be one of:`),

--- a/internal/service/database/mongodb/resource.go
+++ b/internal/service/database/mongodb/resource.go
@@ -96,7 +96,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		dbcommon.SetUpdateExtended(&update, ext)
 		flex.SetStrPtr(&update.MongoConf, p.MongoConf)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting MongoDB database extended fields", fmt.Sprintf("MongoDB database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "MongoDB database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/mongodb/resource_test.go
+++ b/internal/service/database/mongodb/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/dbtest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestMongodbDatabaseResource_CreateUpdateImport(t *testing.T) {
@@ -43,9 +44,6 @@ resource "coolify_database_mongodb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "mongo_initdb_root_username", "root"),
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "mongo_initdb_database", "admin"),
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "image", "mongo:7"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "status", "running"),
 				),
 			},
@@ -75,7 +73,7 @@ resource "coolify_database_mongodb" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "description", "Updated MongoDB"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mongodb" "test" {
@@ -83,17 +81,11 @@ resource "coolify_database_mongodb" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-mongo"
   description           = "Updated MongoDB"
-  enable_ssl            = true
-  ssl_mode              = "require"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "ssl_mode", "require"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -104,10 +96,6 @@ resource "coolify_database_mongodb" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-mongo"
   description             = "Updated MongoDB"
-  enable_ssl              = true
-  ssl_mode                = "require"
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -135,9 +123,9 @@ resource "coolify_database_mongodb" "test" {
 	})
 }
 
-func TestMongodbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestMongodbDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("mongodb", "mongo-ssl-db", "mongo:7", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("mongodb", "mongo-ssl-db", "mongo:7", map[string]interface{}{
 		"mongo_initdb_root_username": "admin",
 		"mongo_initdb_root_password": "secret",
 		"mongo_initdb_database":      "mydb",
@@ -150,17 +138,27 @@ func TestMongodbDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mongodb" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  ssl_mode              = "require"
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "ssl_mode", "require"),
-					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -362,7 +360,7 @@ func TestMongodbDatabaseResource_InvalidSSLMode(t *testing.T) {
 resource "coolify_database_mongodb" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  ssl_mode     = "bogus"
+  ssl_mode     = "not-a-mode"
 }
 `,
 				ExpectError: regexp.MustCompile(`value must be one of`),

--- a/internal/service/database/mysql/resource.go
+++ b/internal/service/database/mysql/resource.go
@@ -108,7 +108,10 @@ func (r *mysqlDatabaseResource) Create(ctx context.Context, req resource.CreateR
 		dbcommon.SetUpdateExtended(&update, ext)
 		flex.SetStrPtr(&update.MysqlConf, plan.MysqlConf)
 		if _, err := r.client.UpdateDatabase(ctx, created.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting MySQL database extended fields", fmt.Sprintf("MySQL database %s: %s", created.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, created.UUID, "MySQL database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &plan)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/mysql/resource_test.go
+++ b/internal/service/database/mysql/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/service/database/dbtest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestMysqlDatabaseResource_CreateUpdateImport(t *testing.T) {
@@ -45,9 +46,6 @@ resource "coolify_database_mysql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "mysql_database", "mydb"),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "image", "mysql:8"),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_public", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "status", "running"),
 				),
 			},
@@ -77,7 +75,7 @@ resource "coolify_database_mysql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "description", "Updated MySQL"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mysql" "test" {
@@ -85,17 +83,11 @@ resource "coolify_database_mysql" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-mysql-db"
   description           = "Updated MySQL"
-  enable_ssl            = true
-  ssl_mode              = "REQUIRED"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "ssl_mode", "REQUIRED"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -106,10 +98,6 @@ resource "coolify_database_mysql" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-mysql-db"
   description             = "Updated MySQL"
-  enable_ssl              = true
-  ssl_mode                = "REQUIRED"
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -137,9 +125,9 @@ resource "coolify_database_mysql" "test" {
 	})
 }
 
-func TestMysqlDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestMysqlDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("mysql", "mysql-ssl-db", "mysql:8", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("mysql", "mysql-ssl-db", "mysql:8", map[string]interface{}{
 		"mysql_user":          "mysqluser",
 		"mysql_password":      "mysqlpass",
 		"mysql_database":      "mydb",
@@ -153,17 +141,27 @@ func TestMysqlDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_mysql" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  ssl_mode              = "REQUIRED"
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "ssl_mode", "REQUIRED"),
-					resource.TestCheckResourceAttr("coolify_database_mysql.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -367,7 +365,7 @@ func TestMysqlDatabaseResource_InvalidSSLMode(t *testing.T) {
 resource "coolify_database_mysql" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  ssl_mode     = "bogus"
+  ssl_mode     = "not-a-mode"
 }
 `,
 				ExpectError: regexp.MustCompile(`value must be one of`),

--- a/internal/service/database/postgresql/resource.go
+++ b/internal/service/database/postgresql/resource.go
@@ -72,7 +72,7 @@ func (r *postgresqlDatabaseResource) Schema(ctx context.Context, _ resource.Sche
 				Optional:            true,
 			},
 			"init_scripts": schema.StringAttribute{
-				MarkdownDescription: "Initialization scripts as a JSON array.",
+				MarkdownDescription: "Initialization scripts as a JSON array. The Coolify public API does not accept this field on create or update.",
 				Optional:            true,
 			},
 			"enable_ssl": dbcommon.EnableSSLAttr(),
@@ -139,9 +139,11 @@ func (r *postgresqlDatabaseResource) Create(ctx context.Context, req resource.Cr
 		flex.SetStrPtr(&update.PostgresConf, plan.PostgresConf)
 		flex.SetStrPtr(&update.PostgresInitdbArgs, plan.PostgresInitdbArgs)
 		flex.SetStrPtr(&update.PostgresHostAuthMethod, plan.PostgresHostAuthMethod)
-		flex.SetStrPtr(&update.InitScripts, plan.InitScripts)
 		if _, err := r.client.UpdateDatabase(ctx, created.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting PostgreSQL database extended fields", fmt.Sprintf("PostgreSQL database %s: %s", created.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, created.UUID, "PostgreSQL database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &plan)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+			})
 			return
 		}
 	}
@@ -195,7 +197,6 @@ func (r *postgresqlDatabaseResource) Update(ctx context.Context, req resource.Up
 		PostgresConf:           flex.StringIfChanged(plan.PostgresConf, state.PostgresConf),
 		PostgresInitdbArgs:     flex.StringIfChanged(plan.PostgresInitdbArgs, state.PostgresInitdbArgs),
 		PostgresHostAuthMethod: flex.StringIfChanged(plan.PostgresHostAuthMethod, state.PostgresHostAuthMethod),
-		InitScripts:            flex.StringIfChanged(plan.InitScripts, state.InitScripts),
 	}
 	dbcommon.SetUpdateExtendedDiff(&input, plan.ExtFields().WithSSL(&plan.EnableSSL, &plan.SSLMode), state.ExtFields().WithSSL(&state.EnableSSL, &state.SSLMode))
 	db, err := dbcommon.UpdateDatabase(ctx, r.client, uuid, input)

--- a/internal/service/database/postgresql/resource_acc_test.go
+++ b/internal/service/database/postgresql/resource_acc_test.go
@@ -18,25 +18,32 @@ func TestAccPostgresqlDatabaseResource_CRUD(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_database_postgresql", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
-			// Create and verify
+			// Create and verify, including a PATCH-allow-list extended field.
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_postgresql.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_postgresql.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Update description
+			// Update description and the memory limit
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_postgresql.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_postgresql", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_memory", "512M"),
+				),
 			},
 			// Import
 			{

--- a/internal/service/database/postgresql/resource_test.go
+++ b/internal/service/database/postgresql/resource_test.go
@@ -46,9 +46,6 @@ resource "coolify_database_postgresql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "image", "postgres:16"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "environment_name", "production"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_public", "false"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "status", "running"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_cpu_shares", "1024"),
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "instant_deploy", "false"),
@@ -86,25 +83,19 @@ resource "coolify_database_postgresql" "test" {
 					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "description", "Updated description"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_postgresql" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  name                  = "updated-pg-db"
-  description           = "Updated description"
-  enable_ssl            = true
-  ssl_mode              = "require"
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  name          = "updated-pg-db"
+  description   = "Updated description"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "ssl_mode", "require"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -115,10 +106,6 @@ resource "coolify_database_postgresql" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-pg-db"
   description             = "Updated description"
-  enable_ssl              = true
-  ssl_mode                = "require"
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -286,32 +273,43 @@ resource "coolify_database_postgresql" "test" {
 	})
 }
 
-func TestPostgresqlDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestPostgresqlDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("postgresql", "pg-ssl-db", "postgres:16", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("postgresql", "pg-limits-db", "postgres:16", map[string]interface{}{
 		"postgres_user":     "postgres",
 		"postgres_password": "secret123",
-		"postgres_db":       "ssldb",
+		"postgres_db":       "limitsdb",
 	})
 	defer srv.Close()
 
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_database_postgresql", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_postgresql" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  ssl_mode              = "require"
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "ssl_mode", "require"),
-					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_postgresql.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -727,7 +725,7 @@ func TestPostgresqlDatabaseResource_InvalidSSLMode(t *testing.T) {
 resource "coolify_database_postgresql" "test" {
   project_uuid = "aaaa0001-0001-4000-8000-000000000001"
   server_uuid  = "bbbb0001-0001-4000-8000-000000000001"
-  ssl_mode     = "bogus"
+  ssl_mode     = "not-a-mode"
 }
 `,
 				ExpectError: regexp.MustCompile(`value must be one of`),

--- a/internal/service/database/redis/resource.go
+++ b/internal/service/database/redis/resource.go
@@ -85,7 +85,10 @@ func (r *res) Create(ctx context.Context, req resource.CreateRequest, resp *reso
 		dbcommon.SetUpdateExtended(&update, ext)
 		flex.SetStrPtr(&update.RedisConf, p.RedisConf)
 		if _, err := r.client.UpdateDatabase(ctx, c.UUID, update); err != nil {
-			resp.Diagnostics.AddError("Error setting Redis database extended fields", fmt.Sprintf("Redis database %s: %s", c.UUID, err))
+			dbcommon.RecoverCreateAfterExtendedError(ctx, r.client, c.UUID, "Redis database", err, resp, func(db *client.Database) {
+				flattenDatabase(db, &p)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &p)...)
+			})
 			return
 		}
 	}

--- a/internal/service/database/redis/resource_test.go
+++ b/internal/service/database/redis/resource_test.go
@@ -42,9 +42,6 @@ resource "coolify_database_redis" "test" {
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "image", "redis:7"),
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_public", "false"),
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "environment_name", "production"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_log_drain_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_include_timestamps", "false"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "enable_ssl", "false"),
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "status", "running"),
 				),
 			},
@@ -74,7 +71,7 @@ resource "coolify_database_redis" "test" {
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "description", "Updated Redis"),
 				),
 			},
-			// Update SSL and log drain fields
+			// Update limits (Coolify PATCH allow-list field)
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_redis" "test" {
@@ -82,15 +79,11 @@ resource "coolify_database_redis" "test" {
   server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
   name                  = "updated-redis"
   description           = "Updated Redis"
-  enable_ssl            = true
-  is_log_drain_enabled  = true
-  is_include_timestamps = true
+  limits_memory         = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_log_drain_enabled", "true"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_redis.test", "limits_memory", "512M"),
 				),
 			},
 			// Update health check fields to non-default values
@@ -101,9 +94,6 @@ resource "coolify_database_redis" "test" {
   server_uuid             = "bbbb0001-0001-4000-8000-000000000001"
   name                    = "updated-redis"
   description             = "Updated Redis"
-  enable_ssl              = true
-  is_log_drain_enabled    = true
-  is_include_timestamps   = true
   health_check_enabled    = false
   health_check_interval   = 30
   health_check_timeout    = 10
@@ -131,9 +121,9 @@ resource "coolify_database_redis" "test" {
 	})
 }
 
-func TestRedisDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
+func TestRedisDatabaseResource_CreateWithLimitsMemory(t *testing.T) {
 	t.Parallel()
-	srv, _ := dbtest.NewMockServer("redis", "redis-ssl-db", "redis:7", map[string]interface{}{
+	srv, state := dbtest.NewMockServer("redis", "redis-ssl-db", "redis:7", map[string]interface{}{
 		"redis_password": "redis-ssl-pass",
 	})
 	defer srv.Close()
@@ -144,15 +134,27 @@ func TestRedisDatabaseResource_CreateWithSSLEnabled(t *testing.T) {
 			{
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 resource "coolify_database_redis" "test" {
-  project_uuid          = "aaaa0001-0001-4000-8000-000000000001"
-  server_uuid           = "bbbb0001-0001-4000-8000-000000000001"
-  enable_ssl            = true
-  is_include_timestamps = true
+  project_uuid  = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid   = "bbbb0001-0001-4000-8000-000000000001"
+  limits_memory = "512M"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "enable_ssl", "true"),
-					resource.TestCheckResourceAttr("coolify_database_redis.test", "is_include_timestamps", "true"),
+					resource.TestCheckResourceAttr("coolify_database_redis.test", "limits_memory", "512M"),
+					func(_ *terraform.State) error {
+						if v, ok := state.LastCreate["limits_memory"]; !ok || v != "512M" {
+							return fmt.Errorf("create POST limits_memory = %v, want 512M", state.LastCreate["limits_memory"])
+						}
+						for _, k := range []string{"is_log_drain_enabled", "is_include_timestamps", "enable_ssl", "ssl_mode"} {
+							if _, ok := state.LastCreate[k]; ok {
+								return fmt.Errorf("create POST sent unallowed key %s", k)
+							}
+							if _, ok := state.LastPatch[k]; ok {
+								return fmt.Errorf("create PATCH sent unallowed key %s", k)
+							}
+						}
+						return nil
+					},
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

Creating a `coolify_database_*` with any extended field (for example `limits_memory`) no longer 422s or taints the resource.

## Problem

Create POST succeeded, then a follow-up PATCH used `SetUpdateExtended`, which sent every known field. Schema defaults of `false` for `is_log_drain_enabled`, `is_include_timestamps`, and `enable_ssl` were always known, so they always went out. Coolify `PATCH /databases/{uuid}` rejects extra keys. Terraform then reported an invalid result object and marked the healthy database for replace.

The second apply worked because Update uses `SetUpdateExtendedDiff` and only sends what changed.

This happens on every Coolify version this provider supports (4.1.0 through current tip). Those three keys have never been on create or update `$allowedFields`.

## Change

- Strip keys Coolify create/update reject (`is_log_drain_enabled`, `is_include_timestamps`, `enable_ssl`, `ssl_mode`, `ports_mappings`, `custom_docker_run_options`, `init_scripts`, `clickhouse_db`) on every database PATCH.
- Send non-default `limits_*` on create POST (the API accepts them on every supported version).
- On a failed post-create PATCH, GET and flatten so state matches Coolify and Terraform does not taint.
- Document that the stripped fields are UI-only.

## Why we missed it

Acc CRUD only updated `description`, so `HasExtendedFields` stayed false and the post-create PATCH never ran. The shared mock accepted extra PATCH keys. Unit tests that set `enable_ssl = true` passed against that mock.

Same class as #783 / #784 / #786: tests exercised the wrong Coolify path.

## Validation

- Unit: `TestSetUpdateExtended_OmitsDisallowedKeys`, `TestPopulateBaseCreateInput_LimitsMemory`, `TestClient_UpdateDatabase_StripsDisallowedKeys`
- Unit (all 8 engines): create with `limits_memory = "512M"` asserts POST has the limit and PATCH/POST omit the rejected keys
- Shared mock PATCH now 422s extra keys
- Acc: `TestAccPostgresqlDatabaseResource_CRUD` creates and updates `limits_memory`
- `golangci-lint` clean on changed packages
- Local reviewer: 0 bugs; 4 suggestions and 1 nit applied before push

Closes #789
