### PR TITLE
ci: replace dependency-review deny-licenses with an allowlist

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,25 @@
+# License allowlist for actions/dependency-review-action.
+# Anything not listed fails the PR. Stricter than the old deny list
+# (AGPL-3.0, GPL-3.0 only). Compound SPDX expressions (A AND B) work
+# since DRA 4.7.1 if the constituents are listed.
+#
+# Do not add CC-BY-SA here to silence golang.org/x/text. That module is
+# BSD-3-Clause; GitHub/ClearlyDefined sometimes attach CLDR data licenses.
+# If DRA false-fails a known-good module, add a PURL exception below
+# instead of widening the allowlist.
+fail-on-severity: high
+allow-licenses:
+  - 0BSD
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - BlueOak-1.0.0
+  - CC0-1.0
+  - CC-BY-4.0
+  - ISC
+  - MIT
+  - MIT-0
+  - MPL-2.0
+  - Unlicense
+# allow-dependencies-licenses:
+#   - pkg:golang/golang.org/x/text@*

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
-          deny-licenses: AGPL-3.0, GPL-3.0
           comment-summary-in-pr: always
+          config-file: ./.github/dependency-review-config.yml


### PR DESCRIPTION
## Description

Replaces deprecated `deny-licenses` on Dependency Review with a Go/Terraform SPDX allowlist in `.github/dependency-review-config.yml`.

The old denylist only blocked AGPL-3.0 and GPL-3.0 and printed a deprecation warning on every PR, including those that did not touch `go.mod`. The allowlist is stricter and matches how this repo already licenses its own code and HashiCorp SDK (MPL-2.0) plus the usual MIT/Apache/BSD/ISC modules.

`fail-on-severity: high` is unchanged. The action pin stays v5.0.0 (`a1d282b`). FOSSA is unchanged and still covers the full tree on same-repo PRs.

If GitHub later reports a known Go metadata false positive (for example `golang.org/x/text` as CC-BY-SA), add a PURL under `allow-dependencies-licenses` rather than widening the allowlist to CC-BY-SA.

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [ ] Tests added or updated
- [x] `make test` passes locally (actionlint on the workflow; no Go change)
- [x] `make fmt` ran (gofmt + go mod tidy; no Go source in this PR)
- [ ] Documentation updated (if adding/changing resources or data sources)
- [ ] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

## Test plan

- [x] `deny-licenses` removed from `.github/workflows/dependency-review.yml`
- [x] Allowlist includes MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0
- [x] Action SHA still `a1d282b36b6f3519aa1f3fc636f609c47dddb294` (latest v5.0.0)
- [x] FOSSA workflow not modified
- [x] `actionlint .github/workflows/dependency-review.yml`
- [ ] This PR's Dependency Review comment has no `deny-licenses` deprecation warning
- [ ] If this PR does not change `go.mod`, the next Dependabot gomod PR is the live allowlist proof

Closes #791
