### PR TITLE
test: acc CRUD updates primary Coolify write fields

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -475,18 +475,15 @@ Known splits:
 | Resource | Create vs update | Acc coverage |
 |----------|------------------|--------------|
 | `coolify_application_docker_image` | `DockerImageFormat` on create vs `dockerImageNameRules()` on PATCH | `TestAccDockerImageApplicationResource_CRUD` must change `docker_image` (#786) |
-| All 8 `coolify_database_*` | Create POST accepts `limits_*`. Post-create PATCH sends remaining allow-list fields only. Coolify PATCH `$allowedFields` rejects `is_log_drain_enabled`, `is_include_timestamps`, `enable_ssl`, and other UI-only keys. | `TestAccPostgresqlDatabaseResource_CRUD` must set and update `limits_memory` (#789). Shared mock PATCH must 422 extra keys. |
+| All 8 `coolify_database_*` | Create POST accepts `limits_*`. Post-create PATCH sends remaining allow-list fields only. Coolify PATCH `$allowedFields` rejects `is_log_drain_enabled`, `is_include_timestamps`, `enable_ssl`, and other UI-only keys. | Every `TestAcc*DatabaseResource_CRUD` must set and update `limits_memory`. Shared mock PATCH must 422 extra keys. Guard: `TestDatabaseCRUDFiles_SetLimitsMemory`. |
+| `coolify_application` (public git), `coolify_application_private_git`, `coolify_application_github_app` | PATCH accepts `ports_exposes`; description-only Update never proves that write path | Acc CRUD must change `ports_exposes` (3000 to 8080). Guard: `TestApplicationCRUDFiles_UpdatePrimaryField`. |
+| `coolify_application_dockerfile` | Coolify may override `ports_exposes`; health check path is on PATCH `$allowedFields` | Acc CRUD must set and update `health_check_path`. Same guard as above. |
 
 Description-only Update steps that remain (no known create/update validator
 split on the primary field):
 
 | Acc test | Update field |
 |----------|----------------|
-| `TestAccApplicationResource_CRUD` | `description` |
-| `TestAccPrivateGitApplicationResource_CRUD` | `description` |
-| `TestAccGitHubAppApplicationResource_CRUD` | `description` |
-| `TestAccDockerfileApplicationResource_CRUD` | `description` |
-| `TestAccDatabase*Resource_CRUD` except postgresql | `description` (postgresql updates `limits_memory`; sibling engines share `SetUpdateExtended`) |
 | `TestAccProjectResource_basic` | `description` |
 | `TestAccEnvironmentResource_CRUD` | `description` |
 

--- a/internal/service/application/acc_primary_field_guard_test.go
+++ b/internal/service/application/acc_primary_field_guard_test.go
@@ -1,0 +1,55 @@
+package application
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestApplicationCRUDFiles_UpdatePrimaryField fails if an acc CRUD
+// file regresses to a description-only Update. That pattern missed #784
+// (docker_image) and would miss the next create/update validator split.
+func TestApplicationCRUDFiles_UpdatePrimaryField(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path    string
+		needles []string
+	}{
+		{
+			path:    "resource_docker_image_acc_test.go",
+			needles: []string{`nginx:1.27-alpine`},
+		},
+		{
+			path:    "resource_public_git_acc_test.go",
+			needles: []string{`"8080"`},
+		},
+		{
+			path:    "resource_private_git_acc_test.go",
+			needles: []string{`"8080"`},
+		},
+		{
+			path:    "resource_github_app_acc_test.go",
+			needles: []string{`"8080"`},
+		},
+		{
+			path:    "resource_dockerfile_acc_test.go",
+			needles: []string{`health_check_path = "/ready"`},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			b, err := os.ReadFile(tc.path) //nolint:gosec // test fixture path from the cases table
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.path, err)
+			}
+			body := string(b)
+			for _, needle := range tc.needles {
+				if !strings.Contains(body, needle) {
+					t.Errorf("%s acc CRUD must update a primary field; missing %q", tc.path, needle)
+				}
+			}
+		})
+	}
+}

--- a/internal/service/application/resource_dockerfile_acc_test.go
+++ b/internal/service/application/resource_dockerfile_acc_test.go
@@ -24,24 +24,29 @@ func TestAccDockerfileApplicationResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: acctest.AccTestDockerfileAppConfig(name, serverUUID, ""),
+				Config: acctest.AccTestDockerfileAppConfig(name, serverUUID, `health_check_path = "/health"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_application_dockerfile.test", "uuid"),
 					resource.TestCheckResourceAttrSet("coolify_application_dockerfile.test", "dockerfile_location"),
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "ports_exposes", "80"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "health_check_path", "/health"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDockerfileAppConfig(name, serverUUID, ""),
+				Config:             acctest.AccTestDockerfileAppConfig(name, serverUUID, `health_check_path = "/health"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Update description
+			// Step 2: Update health check path (PATCH-allow-listed) and description
 			{
-				Config: acctest.AccTestDockerfileAppConfig(name, serverUUID, `description = "Updated via acc test"`),
+				Config: acctest.AccTestDockerfileAppConfig(name, serverUUID, `
+  description       = "Updated via acc test"
+  health_check_path = "/ready"
+`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "health_check_path", "/ready"),
 				),
 			},
 			// Step 3: Import

--- a/internal/service/application/resource_github_app_acc_test.go
+++ b/internal/service/application/resource_github_app_acc_test.go
@@ -20,12 +20,13 @@ func TestAccGitHubAppApplicationResource_CRUD(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-ghapp-app")
 	privateKeyName := acctest.RandomWithPrefix("tf-acc-ghapp-app-key")
 	updatedDescription := "Updated github app application"
-	createConfig := testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName, fixture, "")
+	createConfig := testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName, fixture, "3000", "")
 	updatedConfig := testAccGitHubAppApplicationConfig(
 		name,
 		serverUUID,
 		privateKeyName,
 		fixture,
+		"8080",
 		fmt.Sprintf(`description = %q`, updatedDescription),
 	)
 
@@ -48,10 +49,13 @@ func TestAccGitHubAppApplicationResource_CRUD(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 3: Update description
+			// Step 3: Update exposed ports (primary field) and description
 			{
 				Config: updatedConfig,
-				Check:  resource.TestCheckResourceAttr("coolify_application_github_app.test", "description", updatedDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application_github_app.test", "description", updatedDescription),
+					resource.TestCheckResourceAttr("coolify_application_github_app.test", "ports_exposes", "8080"),
+				),
 			},
 			// Step 4: Idempotency check
 			{
@@ -146,7 +150,7 @@ func accTestGitHubAppApplicationFixture(t *testing.T) gitHubAppApplicationFixtur
 	}
 }
 
-func testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName string, fixture gitHubAppApplicationFixture, extra string) string {
+func testAccGitHubAppApplicationConfig(name, serverUUID, privateKeyName string, fixture gitHubAppApplicationFixture, ports, extra string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {
   name = %[1]q
@@ -174,8 +178,8 @@ resource "coolify_application_github_app" "test" {
   git_repository  = %[9]q
   git_branch      = %[10]q
   build_pack      = "nixpacks"
-  ports_exposes   = "3000"
+  ports_exposes   = %[12]q
   %[11]s
 }
-`, name, serverUUID, privateKeyName, fixture.PrivateKey, fixture.AppID, fixture.InstallationID, fixture.ClientID, fixture.ClientSecret, fixture.GitRepository, fixture.GitBranch, extra)
+`, name, serverUUID, privateKeyName, fixture.PrivateKey, fixture.AppID, fixture.InstallationID, fixture.ClientID, fixture.ClientSecret, fixture.GitRepository, fixture.GitBranch, extra, ports)
 }

--- a/internal/service/application/resource_private_git_acc_test.go
+++ b/internal/service/application/resource_private_git_acc_test.go
@@ -22,7 +22,7 @@ func TestAccPrivateGitApplicationResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: testAccPrivateGitAppConfig(name, serverUUID, privKey, ""),
+				Config: testAccPrivateGitAppConfig(name, serverUUID, privKey, "3000", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_application_private_git.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_application_private_git.test", "git_repository", "git@github.com:coollabsio/coolify-examples.git"),
@@ -32,14 +32,17 @@ func TestAccPrivateGitApplicationResource_CRUD(t *testing.T) {
 			},
 			// Idempotency check
 			{
-				Config:             testAccPrivateGitAppConfig(name, serverUUID, privKey, ""),
+				Config:             testAccPrivateGitAppConfig(name, serverUUID, privKey, "3000", ""),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Update description
+			// Step 2: Update exposed ports (primary field) and description
 			{
-				Config: testAccPrivateGitAppConfig(name, serverUUID, privKey, `description = "Updated private git app"`),
-				Check:  resource.TestCheckResourceAttr("coolify_application_private_git.test", "description", "Updated private git app"),
+				Config: testAccPrivateGitAppConfig(name, serverUUID, privKey, "8080", `description = "Updated private git app"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application_private_git.test", "description", "Updated private git app"),
+					resource.TestCheckResourceAttr("coolify_application_private_git.test", "ports_exposes", "8080"),
+				),
 			},
 			// Step 3: Import by UUID
 			{
@@ -54,7 +57,7 @@ func TestAccPrivateGitApplicationResource_CRUD(t *testing.T) {
 	})
 }
 
-func testAccPrivateGitAppConfig(name, serverUUID, privKey, extra string) string {
+func testAccPrivateGitAppConfig(name, serverUUID, privKey, ports, extra string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {
   name = %[1]q
@@ -71,8 +74,8 @@ resource "coolify_application_private_git" "test" {
   private_key_uuid = coolify_private_key.test.uuid
   git_repository   = "git@github.com:coollabsio/coolify-examples.git"
   build_pack       = "nixpacks"
-  ports_exposes    = "3000"
+  ports_exposes    = %[5]q
   %[4]s
 }
-`, name, serverUUID, privKey, extra)
+`, name, serverUUID, privKey, extra, ports)
 }

--- a/internal/service/application/resource_public_git_acc_test.go
+++ b/internal/service/application/resource_public_git_acc_test.go
@@ -20,7 +20,7 @@ func TestAccApplicationResource_CRUD(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_application", "/api/v1/applications/"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicGitAppConfig(name, serverUUID, ""),
+				Config: testAccPublicGitAppConfig(name, serverUUID, "3000", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_application.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_application.test", "build_pack", "nixpacks"),
@@ -29,13 +29,16 @@ func TestAccApplicationResource_CRUD(t *testing.T) {
 			},
 			// Idempotency check
 			{
-				Config:             testAccPublicGitAppConfig(name, serverUUID, ""),
+				Config:             testAccPublicGitAppConfig(name, serverUUID, "3000", ""),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				Config: testAccPublicGitAppConfig(name, serverUUID, `description = "Updated public git app"`),
-				Check:  resource.TestCheckResourceAttr("coolify_application.test", "description", "Updated public git app"),
+				Config: testAccPublicGitAppConfig(name, serverUUID, "8080", `description = "Updated public git app"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application.test", "description", "Updated public git app"),
+					resource.TestCheckResourceAttr("coolify_application.test", "ports_exposes", "8080"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_application.test",
@@ -61,7 +64,7 @@ func TestAccApplicationResource_Disappears(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_application", "/api/v1/applications/"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicGitAppConfig(name, serverUUID, ""),
+				Config: testAccPublicGitAppConfig(name, serverUUID, "3000", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_application.test", "uuid"),
 					acctest.AccCheckResourceDisappears("coolify_application.test", "/api/v1/applications/"),
@@ -84,7 +87,7 @@ func TestAccApplicationDataSource(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_application", "/api/v1/applications/"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicGitAppConfig(name, serverUUID, "") + `
+				Config: testAccPublicGitAppConfig(name, serverUUID, "3000", "") + `
 data "coolify_application" "test" {
   uuid = coolify_application.test.uuid
 }
@@ -99,7 +102,7 @@ data "coolify_application" "test" {
 	})
 }
 
-func testAccPublicGitAppConfig(name, serverUUID, extra string) string {
+func testAccPublicGitAppConfig(name, serverUUID, ports, extra string) string {
 	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
 resource "coolify_project" "test" {
   name = %[1]q
@@ -112,8 +115,8 @@ resource "coolify_application" "test" {
   git_repository = "https://github.com/coollabsio/coolify-examples"
   git_branch     = "main"
   build_pack     = "nixpacks"
-  ports_exposes  = "3000"
+  ports_exposes  = %[4]q
   %[3]s
 }
-`, name, serverUUID, extra)
+`, name, serverUUID, extra, ports)
 }

--- a/internal/service/database/acc_primary_field_guard_test.go
+++ b/internal/service/database/acc_primary_field_guard_test.go
@@ -1,0 +1,37 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDatabaseCRUDFiles_SetLimitsMemory fails if a sibling engine acc
+// CRUD file stops creating/updating limits_memory. Description-only Update
+// missed #789 on every engine that shares SetUpdateExtended.
+func TestDatabaseCRUDFiles_SetLimitsMemory(t *testing.T) {
+	t.Parallel()
+	engines := []string{
+		"postgresql", "mysql", "mariadb", "mongodb",
+		"redis", "keydb", "dragonfly", "clickhouse",
+	}
+	for _, engine := range engines {
+		engine := engine
+		t.Run(engine, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(engine, "resource_acc_test.go")
+			b, err := os.ReadFile(path) //nolint:gosec // test fixture path from the engines list
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			body := string(b)
+			if !strings.Contains(body, `limits_memory = "256M"`) {
+				t.Errorf("%s acc CRUD must create with limits_memory", path)
+			}
+			if !strings.Contains(body, `limits_memory = "512M"`) {
+				t.Errorf("%s acc CRUD must update limits_memory", path)
+			}
+		})
+	}
+}

--- a/internal/service/database/clickhouse/resource_acc_test.go
+++ b/internal/service/database/clickhouse/resource_acc_test.go
@@ -50,22 +50,29 @@ func TestAccClickhouseDatabaseResource_CRUD(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_database_clickhouse", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_clickhouse.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_clickhouse.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_clickhouse", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_clickhouse.test", "limits_memory", "512M"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_database_clickhouse.test",

--- a/internal/service/database/dragonfly/resource_acc_test.go
+++ b/internal/service/database/dragonfly/resource_acc_test.go
@@ -51,23 +51,30 @@ func TestAccDragonflyDatabaseResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_dragonfly.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_dragonfly.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Update description
+			// Step 2: Update description and the memory limit
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_dragonfly", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_dragonfly.test", "limits_memory", "512M"),
+				),
 			},
 			// Step 3: Import by UUID
 			{

--- a/internal/service/database/keydb/resource_acc_test.go
+++ b/internal/service/database/keydb/resource_acc_test.go
@@ -51,23 +51,30 @@ func TestAccKeydbDatabaseResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_keydb.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_keydb.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_keydb.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Update description
+			// Step 2: Update description and the memory limit
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_keydb.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_keydb", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_keydb.test", "limits_memory", "512M"),
+				),
 			},
 			// Step 3: Import by UUID
 			{

--- a/internal/service/database/mariadb/resource_acc_test.go
+++ b/internal/service/database/mariadb/resource_acc_test.go
@@ -50,22 +50,29 @@ func TestAccMariadbDatabaseResource_CRUD(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_database_mariadb", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_mariadb.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_mariadb.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_mariadb.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mariadb", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_mariadb.test", "limits_memory", "512M"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_database_mariadb.test",

--- a/internal/service/database/mongodb/resource_acc_test.go
+++ b/internal/service/database/mongodb/resource_acc_test.go
@@ -50,22 +50,29 @@ func TestAccMongodbDatabaseResource_CRUD(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_database_mongodb", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_mongodb.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_mongodb.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_mongodb.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mongodb", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_mongodb.test", "limits_memory", "512M"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_database_mongodb.test",

--- a/internal/service/database/mysql/resource_acc_test.go
+++ b/internal/service/database/mysql/resource_acc_test.go
@@ -51,25 +51,30 @@ func TestAccMysqlDatabaseResource_CRUD(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_mysql.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "name", name),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Update description
+			// Step 2: Update description and the memory limit
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, `description = "updated mysql"`),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_mysql", name, serverUUID, `
+  description   = "updated mysql"
+  limits_memory = "512M"
+`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_mysql.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "name", name),
 					resource.TestCheckResourceAttr("coolify_database_mysql.test", "description", "updated mysql"),
+					resource.TestCheckResourceAttr("coolify_database_mysql.test", "limits_memory", "512M"),
 				),
 			},
 			// Step 3: Import by UUID

--- a/internal/service/database/redis/resource_acc_test.go
+++ b/internal/service/database/redis/resource_acc_test.go
@@ -50,22 +50,29 @@ func TestAccRedisDatabaseResource_CRUD(t *testing.T) {
 		CheckDestroy:             acctest.AccCheckDestroy("coolify_database_redis", "/api/v1/databases/"),
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, ""),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, `limits_memory = "256M"`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("coolify_database_redis.test", "uuid"),
 					resource.TestCheckResourceAttr("coolify_database_redis.test", "name", name),
 					resource.TestCheckResourceAttrSet("coolify_database_redis.test", "image"),
+					resource.TestCheckResourceAttr("coolify_database_redis.test", "limits_memory", "256M"),
 				),
 			},
 			// Idempotency check
 			{
-				Config:             acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, ""),
+				Config:             acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, `limits_memory = "256M"`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 			{
-				Config: acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, `description = "Updated via acc test"`),
-				Check:  resource.TestCheckResourceAttr("coolify_database_redis.test", "description", "Updated via acc test"),
+				Config: acctest.AccTestDatabaseConfig("coolify_database_redis", name, serverUUID, `
+  description   = "Updated via acc test"
+  limits_memory = "512M"
+`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_redis.test", "description", "Updated via acc test"),
+					resource.TestCheckResourceAttr("coolify_database_redis.test", "limits_memory", "512M"),
+				),
 			},
 			{
 				ResourceName:                         "coolify_database_redis.test",


### PR DESCRIPTION
## Description

Acceptance CRUD Update steps only changed `description`, so they never hit Coolify create-vs-update validator splits. That is how users found #783, #784, and #789 while the suite stayed green.

This PR makes the known-split acc tests change a field Coolify actually validates on write:

- All 8 database acc CRUDs create with `limits_memory = "256M"` and update to `"512M"` (postgres already did this after #790).
- Public git, private git, and GitHub App acc update `ports_exposes` from 3000 to 8080.
- Dockerfile acc sets and updates `health_check_path` (Coolify may override `ports_exposes` on dockerfile apps).

Unit guards fail if those acc files regress to description-only Update. `TESTING.md` primary-field table is updated.

No provider logic change.

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [x] `make test` passes locally (guard unit tests + package compile)
- [x] `make fmt` ran (gofmt + go mod tidy)
- [x] Documentation updated (if adding/changing resources or data sources)
- [ ] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources

## Test plan

- [x] `go test -run TestDatabaseCRUDFiles_SetLimitsMemory ./internal/service/database/`
- [x] `go test -run TestApplicationCRUDFiles_UpdatePrimaryField ./internal/service/application/`
- [x] `go test -run '^$'` on the seven database packages and `./internal/service/application/`
- [x] `golangci-lint` on the changed packages (0 issues)
- [ ] CI Acceptance Tests run the updated CRUD steps against real Coolify

Ref #786
Ref #789
