### PR TITLE
ci: cap Coolify setup so Scenario Tests cannot hang 45m

### DIFF
--- a/.github/actions/setup-coolify/action.yml
+++ b/.github/actions/setup-coolify/action.yml
@@ -84,7 +84,13 @@ runs:
         COOLIFY_ENV_FILE: ${{ inputs.coolify-env-file }}
       run: |
         set -euo pipefail
-        ./scripts/setup-coolify-test.sh
+        # Hard cap so a hung Playwright register cannot eat the 45m job
+        # timeout (seen on #795: Setup Coolify 44.6m, terraform test never ran).
+        if command -v timeout >/dev/null 2>&1; then
+          timeout --foreground 300 ./scripts/setup-coolify-test.sh
+        else
+          ./scripts/setup-coolify-test.sh
+        fi
 
     - name: Verify Coolify API health
       shell: bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -51,6 +51,14 @@ if Acceptance Tests on the same SHA are green; inspect the job artifact
 (`scenario-diag/` plus compose logs) and the `coolify_deployment`
 error, which now includes the last Coolify deployment log lines.
 
+The 18 scenarios themselves take about 3.5 minutes. A 16-45 minute
+Scenario Tests job is Setup Coolify (image pull plus Playwright
+register), not `terraform test`. Do not shard the Scenario job to
+speed that up: each shard would boot its own Coolify and make the
+three-way pull contention with Acceptance Tests worse. Setup now
+fails at 180s for `compose up`, 180s for register, and 300s for the
+bootstrap script instead of sitting until the 45 minute job timeout.
+
 ## Acceptance Tests
 
 Acceptance tests run against a real Coolify instance. They exercise the

--- a/scripts/ci-coolify-boot.sh
+++ b/scripts/ci-coolify-boot.sh
@@ -42,6 +42,17 @@ compose() {
     "$@"
 }
 
+# GNU timeout on Linux CI; no-op on macOS unless coreutils is installed.
+run_limited() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --foreground "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 step_prepare() {
   log "PLAN: write Coolify compose files under $SOURCE_DIR (tag=${COOLIFY_IMAGE_TAG})"
   log "DO: create data directories"
@@ -182,8 +193,12 @@ step_wait_pull() {
 step_up() {
   log "PLAN: start Coolify stack from already-pulled images"
   cd "$SOURCE_DIR"
-  log "DO: docker compose up -d --remove-orphans"
-  compose up -d --remove-orphans
+  log "DO: docker compose up -d --remove-orphans (180s cap)"
+  # Unbounded compose up hung Setup Coolify for 45m on #795 while Acc
+  # on the same run finished in 2m. Fail instead of eating the job timeout.
+  run_limited 180 docker compose --env-file .env \
+    -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.override.yml \
+    up -d --remove-orphans
   log "OK: compose up returned"
 }
 

--- a/scripts/setup-coolify-test.sh
+++ b/scripts/setup-coolify-test.sh
@@ -112,7 +112,10 @@ with sync_playwright() as p:
     page.locator('input[name="password"]').fill(pwd)
     page.locator('input[name="password_confirmation"]').fill(pwd)
     page.locator('button:has-text("Create Account")').first.click()
-    page.wait_for_url(lambda url: "register" not in url, timeout=60000)
+    page.wait_for_function(
+        "() => !window.location.pathname.includes('register')",
+        timeout=60000,
+    )
 
     print("Registration successful")
     browser.close()

--- a/scripts/setup-coolify-test.sh
+++ b/scripts/setup-coolify-test.sh
@@ -63,55 +63,58 @@ USER_COUNT=$(psql_exec "SELECT count(*) FROM users;")
 if [[ "$USER_COUNT" == "0" ]]; then
   log "Registering admin user via Playwright (required for Laravel bootstrap)"
 
-  # Ensure playwright is available
-  PW_VENV="/tmp/pw-venv"
-  if [[ ! -f "$PW_VENV/bin/python3" ]]; then
-    if ! command -v python3 >/dev/null 2>&1; then
-      echo "ERROR: python3 is required the first time this script bootstraps a Coolify user. Install Python 3.9+ with venv support and re-run." >&2
-      exit 1
+  # Prefer Playwright already installed by setup-coolify (CI). A second
+  # silent Chromium install has no timeout and hid the 45m hang on #795.
+  PW_PYTHON=""
+  if python3 -c "from playwright.sync_api import sync_playwright" 2>/dev/null; then
+    PW_PYTHON="python3"
+  else
+    PW_VENV="/tmp/pw-venv"
+    if [[ ! -f "$PW_VENV/bin/python3" ]]; then
+      if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: python3 is required the first time this script bootstraps a Coolify user. Install Python 3.9+ with venv support and re-run." >&2
+        exit 1
+      fi
+      if ! python3 -c "import venv" >/dev/null 2>&1; then
+        echo "ERROR: python3 venv support is required the first time this script bootstraps a Coolify user. Install python3-venv and re-run." >&2
+        exit 1
+      fi
+      python3 -m venv "$PW_VENV"
     fi
-    if ! python3 -c "import venv" >/dev/null 2>&1; then
-      echo "ERROR: python3 venv support is required the first time this script bootstraps a Coolify user. Install python3-venv and re-run." >&2
-      exit 1
+    if ! "$PW_VENV/bin/python3" -c "from playwright.sync_api import sync_playwright" 2>/dev/null; then
+      "$PW_VENV/bin/pip" install -q playwright
+      if command -v timeout >/dev/null 2>&1; then
+        timeout --foreground 180 "$PW_VENV/bin/playwright" install chromium
+      else
+        "$PW_VENV/bin/playwright" install chromium
+      fi
     fi
-    python3 -m venv "$PW_VENV"
-  fi
-  if ! "$PW_VENV/bin/python3" -c "import playwright" 2>/dev/null; then
-    "$PW_VENV/bin/pip" install -q playwright
-    "$PW_VENV/bin/playwright" install chromium 2>/dev/null
+    PW_PYTHON="$PW_VENV/bin/python3"
   fi
 
-  "$PW_VENV/bin/python3" << 'PYEOF'
-import secrets, time, sys
+  "$PW_PYTHON" << 'PYEOF'
+import secrets, signal, sys
 from playwright.sync_api import sync_playwright
+
+signal.alarm(180)
 
 pwd = "Sc" + secrets.token_urlsafe(20) + "!1"
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
     page = browser.new_page()
+    page.set_default_timeout(30000)
     page.goto("http://localhost:8000/register", timeout=30000)
-    page.wait_for_load_state("networkidle")
-    time.sleep(2)
-
+    # Do not wait for networkidle: Coolify keeps websockets/polling open.
+    page.locator('input[name="name"]').wait_for(state="visible", timeout=30000)
     page.locator('input[name="name"]').fill("admin")
     page.locator('input[name="email"]').fill("admin@acme.test")
     page.locator('input[name="password"]').fill(pwd)
     page.locator('input[name="password_confirmation"]').fill(pwd)
-    time.sleep(1)
-
     page.locator('button:has-text("Create Account")').first.click()
-    time.sleep(8)
-    page.wait_for_load_state("networkidle")
+    page.wait_for_url(lambda url: "register" not in url, timeout=60000)
 
-    if "register" not in page.url:
-        print("Registration successful")
-    else:
-        errors = page.locator('.text-red-500').all()
-        for e in errors:
-            print(f"Error: {e.text_content().strip()}", file=sys.stderr)
-        sys.exit(1)
-
+    print("Registration successful")
     browser.close()
 PYEOF
 else

--- a/scripts/test_ci_coolify_boot.py
+++ b/scripts/test_ci_coolify_boot.py
@@ -51,6 +51,11 @@ class TestCICoolifyBoot(unittest.TestCase):
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("FAIL: Coolify not ready", proc.stdout)
 
+    def test_compose_up_has_a_timeout_cap(self) -> None:
+        src = SCRIPT.read_text()
+        self.assertIn("run_limited 180", src)
+        self.assertIn("timeout --foreground", src)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_setup_coolify_test.py
+++ b/scripts/test_setup_coolify_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Guards for scripts/setup-coolify-test.sh (no Coolify required)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "setup-coolify-test.sh"
+ACTION = ROOT / ".github" / "actions" / "setup-coolify" / "action.yml"
+
+
+class TestSetupCoolifyTestTimeouts(unittest.TestCase):
+    def test_register_has_alarm_and_no_networkidle(self) -> None:
+        src = SCRIPT.read_text()
+        self.assertIn("signal.alarm(180)", src)
+        self.assertIn("set_default_timeout(30000)", src)
+        self.assertNotIn('wait_for_load_state("networkidle")', src)
+        self.assertNotIn("install chromium 2>/dev/null", src)
+        self.assertIn("timeout --foreground 180", src)
+
+    def test_ci_bootstrap_step_has_hard_cap(self) -> None:
+        src = ACTION.read_text()
+        self.assertIn("timeout --foreground 300", src)
+        self.assertIn("setup-coolify-test.sh", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Stop Scenario Tests from sitting in Setup Coolify until the 45 minute job timeout.

## The problem

On #795 the Scenario job spent 44.6 minutes in Setup Coolify and never ran `terraform test`. Acceptance Tests on the same SHA finished Setup in about 2 minutes. The 18 scenarios themselves take about 3.5 minutes. A second Scenario job would boot another Coolify and make the three-way `edge` image pull worse.

The hang was Playwright register (`networkidle` plus a silent Chromium install) after a contended Coolify boot.

## The change

- `docker compose up` capped at 180s
- Register script: 180s `signal.alarm`, no `networkidle`, prefer CI Playwright
- Bootstrap script capped at 300s
- Guards in `scripts/test_setup_coolify_test.py` and `scripts/test_ci_coolify_boot.py`
- TESTING.md: do not shard Scenario Tests to chase a boot hang

## Validation

- `python3 -m unittest scripts.test_ci_coolify_boot scripts.test_setup_coolify_test`
- Reviewer: 0 must-fix

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes to existing resources
