### PR TITLE
test: cover instance email error paths and old Coolify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Terraform provider for [Coolify](https://coolify.io/), the open-source self-host
 Built with Go 1.26, Terraform Plugin Framework v1.19, and GoReleaser for releases.
 Builds use `GOFIPS140=latest` for FIPS 140-3 compliant cryptography (required for
 government/enterprise adoption; set in `.goreleaser.yml` and `release.yml` smoke test).
-57 resources, 69 data sources, 1490+ tests (unit + acceptance), 10 CI jobs.
+57 resources, 69 data sources, 1500+ tests (unit + acceptance), 10 CI jobs.
 18 ACME Corp scenario examples (all with `terraform test` integration tests; acme-private-repo uses plan-only).
 
 ## Source of Truth: Coolify Source Code (NOT OpenAPI spec)
@@ -220,7 +220,7 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 ## Testing
 
 - Framework: `hashicorp/terraform-plugin-testing` with `httptest` mock servers
-- 1490+ tests (unit + acceptance)
+- 1500+ tests (unit + acceptance)
 - Acceptance tests are skipped unless `TF_ACC=1` is set
 - Run `make ci && make testacc` before pushing (ci = build, lint, test, validate, actionlint-check, python-test, docs-check, api-coverage-check, counts-check, contract-compat, vulncheck, goreleaser-check, modverify; testacc = acceptance tests against real Coolify)
 - Before adding a test function, grep for its name to avoid duplicates

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Provision Coolify with Terraform. Manage applications, databases, servers, backu
 |---|---|
 | Managed resources | 57 |
 | Data sources | 69 |
-| Tests | 1490+ unit and acceptance tests |
+| Tests | 1500+ unit and acceptance tests |
 | Scenario examples | 18 ACME Corp setups |
 | Adoption path | New stacks and incremental import of existing Coolify resources |
 
@@ -334,7 +334,7 @@ targets from [GNUmakefile](GNUmakefile).
 
 ```bash
 make build                                      # Compile the provider
-make test                                       # Run unit tests (1490+ tests, race detector enabled)
+make test                                       # Run unit tests (1500+ tests, race detector enabled)
 make test-pkg PKG=./internal/service/project/   # Run one package with repo-standard unit-test flags
 make testacc-pkg PKG=./internal/service/project/ # Run one package with serialized repo-standard acceptance-test flags
 make testacc                                    # Run acceptance tests with serialized package and in-package execution

--- a/internal/client/instance_email_test.go
+++ b/internal/client/instance_email_test.go
@@ -89,6 +89,23 @@ func TestClient_GetInstanceEmailSettings_NotFound(t *testing.T) {
 	assert.True(t, client.IsNotFound(err))
 }
 
+func TestClient_GetInstanceEmailSettings_APIError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation failed."}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-token")
+	_, err := c.GetInstanceEmailSettings(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting instance email settings")
+	assert.False(t, client.IsNotFound(err))
+}
+
 func TestClient_UpdateInstanceEmailSettings_APIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/internal/service/instanceemail/resource_test.go
+++ b/internal/service/instanceemail/resource_test.go
@@ -234,6 +234,157 @@ func TestInstanceEmailSettingsResource_ReadNotFound(t *testing.T) {
 	})
 }
 
+func TestInstanceEmailSettingsResource_ReadAPIError(t *testing.T) {
+	t.Parallel()
+	var getCount int
+	var patchDone bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		getCount++
+		if patchDone && getCount >= 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		patchDone = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.10"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+				ExpectError: regexp.MustCompile(`Error reading instance email settings`),
+			},
+		},
+	})
+}
+
+func TestInstanceEmailSettingsResource_UpdateAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.10"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+			},
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.updated.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+				ExpectError: regexp.MustCompile(`Error updating instance email settings`),
+			},
+		},
+	})
+}
+
+func TestInstanceEmailSettingsResource_DestroyAPIError(t *testing.T) {
+	t.Parallel()
+	var patches int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		patches++
+		if patches == 2 {
+			http.Error(w, `{"message":"Validation failed."}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"smtp_enabled":true,"smtp_host":"smtp.example.com","smtp_port":587,"smtp_encryption":"starttls"}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.10"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled    = true
+  smtp_host       = "smtp.example.com"
+  smtp_port       = 587
+  smtp_encryption = "starttls"
+`),
+			},
+			{
+				Config:      acctest.ProviderBlockForURL(srv.URL),
+				ExpectError: regexp.MustCompile(`Error disabling instance email settings on destroy`),
+			},
+		},
+	})
+}
+
+func TestInstanceEmailSettingsResource_CreateUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.9"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled = true
+`),
+				ExpectError: regexp.MustCompile(`Coolify version cannot manage instance email settings`),
+			},
+		},
+	})
+}
+
 func TestInstanceEmailSettingsResource_DestroyNotFound(t *testing.T) {
 	t.Parallel()
 	var patches int


### PR DESCRIPTION
## Summary

Adds unit tests for `coolify_instance_email_settings` error paths that sibling notification resources already cover.

## Problem

PR #802 shipped the instance email resource with create/import/destroy-404 coverage. Update, read, and destroy API errors, plus create on Coolify older than v4.3.10, were untested.

## Change

- Resource tests: Read/Update/Destroy 422, and create rejected on a v4.3.9 mock
- Client test: GET `/settings/email` non-404 API error wrapping
- Documented test floor 1490+ to 1500+ (1507 tests)

## Validation

`go test -count=1 ./internal/client/ ./internal/service/instanceemail/`
`make counts-check`

## Issue reference

Follow-up to #802. Does not change #799 (channel pin still waits for nightly/tip/stable alignment).