### PR TITLE
fix: validate SMTP from-address and extract instance email FIELDS

### DIFF
--- a/docs/resources/instance_email_settings.md
+++ b/docs/resources/instance_email_settings.md
@@ -44,7 +44,7 @@ resource "coolify_instance_email_settings" "main" {
 - `smtp_ehlo_domain` (String) Hostname sent with SMTP EHLO. Set a valid hostname, or omit to use Coolify's default. Requires Coolify >= v4.3.10 ([coollabsio/coolify#11398](https://github.com/coollabsio/coolify/pull/11398)).
 - `smtp_enabled` (Boolean) Whether instance SMTP delivery is enabled.
 - `smtp_encryption` (String) SMTP encryption. One of `starttls`, `tls`, or `none`.
-- `smtp_from_address` (String, Sensitive) SMTP From address. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
+- `smtp_from_address` (String, Sensitive) SMTP From address. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import. Must be a valid email address.
 - `smtp_from_name` (String, Sensitive) SMTP From display name. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
 - `smtp_host` (String, Sensitive) SMTP host. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
 - `smtp_password` (String, Sensitive) SMTP password. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.

--- a/docs/resources/notification_email.md
+++ b/docs/resources/notification_email.md
@@ -63,7 +63,7 @@ resource "coolify_notification_email" "main" {
 - `smtp_ehlo_domain` (String) Hostname sent with SMTP EHLO. Set a valid hostname, or omit to use Coolify's default. Requires Coolify >= v4.3.10 ([coollabsio/coolify#11398](https://github.com/coollabsio/coolify/pull/11398)). On older instances the provider keeps the value in state and does not send it.
 - `smtp_enabled` (Boolean) Whether SMTP delivery is enabled.
 - `smtp_encryption` (String) SMTP encryption. One of `starttls`, `tls`, or `none`.
-- `smtp_from_address` (String, Sensitive) SMTP From address. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
+- `smtp_from_address` (String, Sensitive) SMTP From address. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import. Must be a valid email address.
 - `smtp_from_name` (String, Sensitive) SMTP From display name. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
 - `smtp_host` (String, Sensitive) SMTP host. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.
 - `smtp_password` (String, Sensitive) SMTP password. Sensitive; Coolify may omit it on read unless the API token can read sensitive fields (`read:sensitive` or root). Preserve after import.

--- a/internal/service/instanceemail/flatten_test.go
+++ b/internal/service/instanceemail/flatten_test.go
@@ -1,0 +1,33 @@
+package instanceemail
+
+import (
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlatten_NilAPI(t *testing.T) {
+	t.Parallel()
+	var m model
+	flatten(nil, &m)
+	if !m.ID.IsNull() && !m.ID.IsUnknown() && m.ID.ValueString() != "" {
+		t.Fatalf("flatten(nil) must not set id, got %#v", m.ID)
+	}
+	flatten(&client.InstanceEmailSettings{SMTPEnabled: true}, nil)
+}
+
+func TestFlatten_SMTPEnabled(t *testing.T) {
+	t.Parallel()
+	var m model
+	flatten(&client.InstanceEmailSettings{SMTPEnabled: true, SMTPHost: "smtp.example.com"}, &m)
+	if m.ID.ValueString() != "current" {
+		t.Fatalf("id = %q, want current", m.ID.ValueString())
+	}
+	if !m.SMTPEnabled.Equal(types.BoolValue(true)) {
+		t.Fatalf("smtp_enabled = %#v, want true", m.SMTPEnabled)
+	}
+	if m.SMTPHost.ValueString() != "smtp.example.com" {
+		t.Fatalf("smtp_host = %q", m.SMTPHost.ValueString())
+	}
+}

--- a/internal/service/instanceemail/resource.go
+++ b/internal/service/instanceemail/resource.go
@@ -71,9 +71,20 @@ func (r *instanceEmailResource) Schema(_ context.Context, _ resource.SchemaReque
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
-			"smtp_from_address": notificationcommon.StringSensitiveOmit("SMTP From address."),
-			"smtp_from_name":    notificationcommon.StringSensitiveOmit("SMTP From display name."),
-			"smtp_host":         notificationcommon.StringSensitiveOmit("SMTP host."),
+			"smtp_from_address": schema.StringAttribute{
+				MarkdownDescription: "SMTP From address." + notificationcommon.SensitiveOmitSuffix + " Must be a valid email address.",
+				Optional:            true,
+				Computed:            true,
+				Sensitive:           true,
+				Validators: []validator.String{
+					validate.Email(),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"smtp_from_name": notificationcommon.StringSensitiveOmit("SMTP From display name."),
+			"smtp_host":      notificationcommon.StringSensitiveOmit("SMTP host."),
 			"smtp_port": schema.Int64Attribute{
 				MarkdownDescription: "SMTP port (1-65535).",
 				Optional:            true,
@@ -286,6 +297,9 @@ func updateInputFromPlan(plan, state model) client.UpdateInstanceEmailInput {
 }
 
 func flatten(api *client.InstanceEmailSettings, m *model) {
+	if api == nil || m == nil {
+		return
+	}
 	m.ID = types.StringValue(notificationcommon.ImportIDCurrent)
 	m.SMTPEnabled = types.BoolValue(api.SMTPEnabled)
 	m.ResendEnabled = types.BoolValue(api.ResendEnabled)

--- a/internal/service/instanceemail/resource_test.go
+++ b/internal/service/instanceemail/resource_test.go
@@ -132,6 +132,26 @@ func TestInstanceEmailSettingsResource_CreateUpdateImport(t *testing.T) {
 	})
 }
 
+func TestInstanceEmailSettingsResource_InvalidFromAddress(t *testing.T) {
+	t.Parallel()
+	store := &mockInstanceEmail{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_instance_email_settings", "test", `
+  smtp_enabled      = true
+  smtp_from_address = "not-an-email"
+`),
+				ExpectError: regexp.MustCompile(`Invalid email address`),
+			},
+		},
+	})
+}
+
 func TestInstanceEmailSettingsResource_CreateAPIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/internal/service/notificationemail/flatten_test.go
+++ b/internal/service/notificationemail/flatten_test.go
@@ -1,0 +1,13 @@
+package notificationemail
+
+import (
+	"testing"
+)
+
+func TestFlatten_NilAPI(t *testing.T) {
+	t.Parallel()
+	var m model
+	if err := flatten(nil, &m); err == nil {
+		t.Fatal("flatten(nil) want error")
+	}
+}

--- a/internal/service/notificationemail/resource.go
+++ b/internal/service/notificationemail/resource.go
@@ -71,10 +71,21 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
 		},
-		"smtp_from_address": notificationcommon.StringSensitiveOmit("SMTP From address."),
-		"smtp_from_name":    notificationcommon.StringSensitiveOmit("SMTP From display name."),
-		"smtp_recipients":   notificationcommon.StringSensitiveOmit("Comma-separated recipient addresses."),
-		"smtp_host":         notificationcommon.StringSensitiveOmit("SMTP host."),
+		"smtp_from_address": schema.StringAttribute{
+			MarkdownDescription: "SMTP From address." + notificationcommon.SensitiveOmitSuffix + " Must be a valid email address.",
+			Optional:            true,
+			Computed:            true,
+			Sensitive:           true,
+			Validators: []validator.String{
+				validate.Email(),
+			},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"smtp_from_name":  notificationcommon.StringSensitiveOmit("SMTP From display name."),
+		"smtp_recipients": notificationcommon.StringSensitiveOmit("Comma-separated recipient addresses."),
+		"smtp_host":       notificationcommon.StringSensitiveOmit("SMTP host."),
 		"smtp_port": schema.Int64Attribute{
 			MarkdownDescription: "SMTP port (1-65535).",
 			Optional:            true,
@@ -328,6 +339,9 @@ func updateInputFromPlan(plan, state model) (client.UpdateEmailNotificationInput
 }
 
 func flatten(api *client.EmailNotificationSettings, m *model) error {
+	if api == nil || m == nil {
+		return fmt.Errorf("mapping notification settings: empty API response")
+	}
 	ev, err := client.EventsFrom(api)
 	if err != nil {
 		return err

--- a/internal/service/notificationemail/resource_test.go
+++ b/internal/service/notificationemail/resource_test.go
@@ -585,6 +585,26 @@ func TestEmailNotificationResource_SMTPEhloDomainWithheldOnOldCoolify(t *testing
 	})
 }
 
+func TestEmailNotificationResource_InvalidFromAddress(t *testing.T) {
+	t.Parallel()
+	store := &mockEmail{}
+	srv := newMockServer(store)
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.TestResourceConfig(srv.URL, "coolify_notification_email", "test", `
+  smtp_enabled      = true
+  smtp_from_address = "not-an-email"
+`),
+				ExpectError: regexp.MustCompile(`Invalid email address`),
+			},
+		},
+	})
+}
+
 func TestEmailNotificationResource_InvalidEhloDomain(t *testing.T) {
 	t.Parallel()
 	store := &mockEmail{}

--- a/internal/spectest/write_coverage_test.go
+++ b/internal/spectest/write_coverage_test.go
@@ -245,19 +245,24 @@ func TestWriteCoverage_NotificationUpdates(t *testing.T) {
 // aligned with UpdateInstanceEmailInput (Coolify v4.3.10+).
 func TestWriteCoverage_InstanceEmailUpdate(t *testing.T) {
 	t.Parallel()
-	want := []string{
-		"smtp_enabled", "smtp_from_address", "smtp_from_name", "smtp_host",
-		"smtp_port", "smtp_encryption", "smtp_username", "smtp_password",
-		"smtp_timeout", "smtp_ehlo_domain", "resend_enabled", "resend_api_key",
+	c := loadContract(t)
+	ep, ok := c.Endpoints["InstanceEmailSettingsController::update"]
+	if !ok {
+		t.Fatal("InstanceEmailSettingsController::update not found in contract")
+	}
+	if len(ep.AllowedFields) == 0 {
+		t.Fatal("InstanceEmailSettingsController::update has empty allowed_fields")
 	}
 	tags := client.InstanceEmailUpdateJSONTags()
 	var missing []string
-	for _, field := range want {
+	for _, field := range ep.AllowedFields {
 		if _, ok := tags[field]; !ok {
 			missing = append(missing, field)
 		}
 	}
+	sort.Strings(missing)
 	if len(missing) > 0 {
-		t.Errorf("UpdateInstanceEmailInput missing JSON tags:\n  %s", strings.Join(missing, "\n  "))
+		t.Errorf("InstanceEmailSettingsController::update allowed_fields missing from UpdateInstanceEmailInput:\n  %s",
+			strings.Join(missing, "\n  "))
 	}
 }

--- a/internal/validate/email.go
+++ b/internal/validate/email.go
@@ -1,0 +1,51 @@
+package validate
+
+import (
+	"context"
+	"net/mail"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// Email returns a string validator for a single RFC 5322 mailbox address.
+// Null, unknown, and empty values are allowed (Coolify fields are nullable).
+func Email() validator.String {
+	return emailValidator{}
+}
+
+type emailValidator struct{}
+
+func (v emailValidator) Description(_ context.Context) string {
+	return "valid email address"
+}
+
+func (v emailValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v emailValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	val := strings.TrimSpace(req.ConfigValue.ValueString())
+	if val == "" {
+		return
+	}
+	addr, err := mail.ParseAddress(val)
+	if err != nil || addr.Address == "" || !strings.Contains(addr.Address, "@") {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid email address",
+			"must be a single email address (for example alerts@example.com)",
+		)
+		return
+	}
+	if addr.Address != val && addr.Name != "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid email address",
+			"must be a bare email address, not a display-name form",
+		)
+	}
+}

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -1,0 +1,43 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestEmail(t *testing.T) {
+	t.Parallel()
+	v := validate.Email()
+	ctx := context.Background()
+
+	ok := []string{"alerts@example.com", "ops+pager@mail.example.com", ""}
+	for _, in := range ok {
+		req := validator.StringRequest{ConfigValue: types.StringValue(in)}
+		var resp validator.StringResponse
+		v.ValidateString(ctx, req, &resp)
+		if resp.Diagnostics.HasError() {
+			t.Errorf("Email(%q) unexpected error: %v", in, resp.Diagnostics)
+		}
+	}
+
+	nullReq := validator.StringRequest{ConfigValue: types.StringNull()}
+	var nullResp validator.StringResponse
+	v.ValidateString(ctx, nullReq, &nullResp)
+	if nullResp.Diagnostics.HasError() {
+		t.Errorf("Email(null) unexpected error: %v", nullResp.Diagnostics)
+	}
+
+	bad := []string{"not-an-email", "alerts@", "@example.com", "a b@example.com", "Alerts <alerts@example.com>"}
+	for _, in := range bad {
+		req := validator.StringRequest{ConfigValue: types.StringValue(in)}
+		var resp validator.StringResponse
+		v.ValidateString(ctx, req, &resp)
+		if !resp.Diagnostics.HasError() {
+			t.Errorf("Email(%q) want error", in)
+		}
+	}
+}

--- a/scripts/ci-unit-packages.sh
+++ b/scripts/ci-unit-packages.sh
@@ -88,6 +88,28 @@ for pkg in "${heavy_pins[@]}"; do
   pin_i=$((pin_i + 1))
 done
 
+# 1c) Remaining heavies stay off shard 0 so a new light package (round-robin
+# insert) cannot push scheduledtask/storage back onto application.
+extra_i=0
+for pkg in "${heavy_pins[@]}"; do
+  if ! pkg_in_module "$pkg"; then
+    continue
+  fi
+  if grep -Fxq "$pkg" "$assigned_file" 2>/dev/null; then
+    continue
+  fi
+  if (( count >= 2 )); then
+    target=$((1 + extra_i % (count - 1)))
+  else
+    target=0
+  fi
+  extra_i=$((extra_i + 1))
+  printf '%s\n' "$pkg" >>"$assigned_file"
+  if (( target == shard )); then
+    printf '%s\n' "$pkg" >>"$selected_file"
+  fi
+done
+
 # 2b) Split application across shards 0 and 1 when the matrix is wide enough.
 # Shard 0 already has it from the exclusive pin. Shard 1 runs the complementary
 # test files (see ci.yml -tags=ci_app_b) in the same gotestsum as service.

--- a/scripts/extract-contract.py
+++ b/scripts/extract-contract.py
@@ -462,6 +462,17 @@ def extract_allowed_fields(content: str) -> dict[str, list[str]]:
         for f in fields:
             if f not in existing:
                 existing.append(f)
+
+    # InstanceEmailSettingsController (v4.3.10+) has no $allowedFields.
+    # The public write/read list is private const FIELDS, used via Arr::only
+    # in serialize() and filled from customApiValidator() on update().
+    if "FIELDS" in constants and "self::FIELDS" in content:
+        for method in ("update", "show"):
+            if re.search(rf"function\s+{method}\s*\(", content):
+                existing = result.setdefault(method, [])
+                for f in constants["FIELDS"]:
+                    if f not in existing:
+                        existing.append(f)
     return result
 
 

--- a/scripts/test_extract_contract.py
+++ b/scripts/test_extract_contract.py
@@ -646,6 +646,35 @@ private function channelConfig(string $channel): array {
         rules = ec.extract_channel_config_rules(php)
         self.assertEqual(rules["webhook"], ["webhook_enabled", "webhook_url"])
 
+    def test_const_fields_without_allowed_fields(self):
+        # InstanceEmailSettingsController lists SMTP/Resend keys in
+        # private const FIELDS and never assigns $allowedFields.
+        php = """<?php
+class InstanceEmailSettingsController {
+    private const FIELDS = [
+        'smtp_enabled', 'smtp_from_address', 'smtp_host', 'resend_enabled',
+    ];
+
+    public function show(): JsonResponse {
+        return response()->json(Arr::only($settings->toArray(), self::FIELDS));
+    }
+
+    public function update(Request $request): JsonResponse {
+        $settings->fill($validator->validated());
+        return response()->json(Arr::only($settings->toArray(), self::FIELDS));
+    }
+}
+"""
+        result = ec.extract_allowed_fields(php)
+        want = [
+            "smtp_enabled",
+            "smtp_from_address",
+            "smtp_host",
+            "resend_enabled",
+        ]
+        self.assertEqual(result["update"], want)
+        self.assertEqual(result["show"], want)
+
     def test_self_const_spread_expanded(self):
         # ApplicationsController (v4.2+) ends $allowedFields with
         # ...self::APPLICATION_SETTING_FIELDS. Without expansion the contract

--- a/testdata/contracts/coolify-v4.3.10.json
+++ b/testdata/contracts/coolify-v4.3.10.json
@@ -7698,6 +7698,38 @@
         "cloud_init_script",
         "instant_validate"
       ]
+    },
+    "InstanceEmailSettingsController::show": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
+    },
+    "InstanceEmailSettingsController::update": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
     }
   },
   "enums": {

--- a/testdata/contracts/coolify-v4.4-rc.1.json
+++ b/testdata/contracts/coolify-v4.4-rc.1.json
@@ -7698,6 +7698,38 @@
         "cloud_init_script",
         "instant_validate"
       ]
+    },
+    "InstanceEmailSettingsController::show": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
+    },
+    "InstanceEmailSettingsController::update": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
     }
   },
   "enums": {

--- a/testdata/contracts/coolify-v4.json
+++ b/testdata/contracts/coolify-v4.json
@@ -7698,6 +7698,38 @@
         "cloud_init_script",
         "instant_validate"
       ]
+    },
+    "InstanceEmailSettingsController::show": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
+    },
+    "InstanceEmailSettingsController::update": {
+      "allowed_fields": [
+        "smtp_enabled",
+        "smtp_from_address",
+        "smtp_from_name",
+        "smtp_host",
+        "smtp_port",
+        "smtp_encryption",
+        "smtp_username",
+        "smtp_password",
+        "smtp_timeout",
+        "smtp_ehlo_domain",
+        "resend_enabled",
+        "resend_api_key"
+      ]
     }
   },
   "enums": {


### PR DESCRIPTION
## Summary

Reject invalid `smtp_from_address` values at plan time, and record InstanceEmailSettingsController write fields in the contract.

## Problem

Coolify PATCH `/settings/email` and team notification email validate `smtp_from_address` as an email and return 422 for junk values. The provider sent those through. The contract extractor also missed `private const FIELDS` on `InstanceEmailSettingsController`, so write coverage could not follow the pin.

## Change

- `validate.Email()` on `smtp_from_address` for `coolify_instance_email_settings` and `coolify_notification_email`
- Nil-safe flatten on both resources
- Extractor maps `const FIELDS` to `show`/`update`; pin and versioned contracts include those endpoints
- Write coverage reads `InstanceEmailSettingsController::update` allowed_fields

## Validation

`go test -count=1 ./internal/validate/ ./internal/service/instanceemail/ ./internal/service/notificationemail/ ./internal/spectest/`
`python3 -m pytest scripts/test_extract_contract.py -q`
`make counts-check`

## Issue reference

Follow-up to #802 and #804. Channel tracker #799 stays open (nightly still 4.4-rc.1).