### PR TITLE
ci: split scenario tests into core, github-cicd, and hetzner suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,13 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/ci.yml'
             scenarios:
-              # Product + scenario HCL only. Do not include ci.yml alone: every
-              # workflow-only PR was running the full ~45m Coolify scenario
-              # suite (path filter true from the workflow path). Edit the
-              # scenario-tests job via workflow_dispatch or after an internal/
-              # scenarios change when you need that matrix.
+              # Product + scenario HCL + the runner script. Do not include
+              # ci.yml alone: every workflow-only PR was running Coolify
+              # scenario jobs. Edit the job via workflow_dispatch or after
+              # an internal/scenarios/runner change when you need that matrix.
               - 'internal/**'
               - 'examples/scenarios/**'
+              - 'scripts/run-scenario-tests.sh'
 
   dco:
     name: DCO
@@ -614,7 +614,8 @@ jobs:
   scenario-tests:
     name: Scenario Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # core is short; github-cicd waits up to 15m on deploy; hetzner creates VMs.
+    timeout-minutes: 25
     needs: [changes]
     if: >-
       always() &&
@@ -622,6 +623,10 @@ jobs:
         needs.changes.outputs.scenarios == 'true' ||
         github.event_name == 'workflow_dispatch'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [core, github-cicd, hetzner]
     permissions:
       contents: read
       # Playwright browser cache save in setup-coolify.
@@ -637,19 +642,56 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Decide whether this suite needs Coolify
+        id: need
+        env:
+          GITHUB_APP_ID: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
+          HETZNER_TOKEN: ${{ secrets.COOLIFY_HETZNER_TOKEN }}
+        run: |
+          case "${{ matrix.suite }}" in
+            core)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            github-cicd)
+              if [ -n "$GITHUB_APP_ID" ]; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "run=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            hetzner)
+              if [ -n "$HETZNER_TOKEN" ]; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "run=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "::error::unknown suite ${{ matrix.suite }}"
+              exit 1
+              ;;
+          esac
+      - name: Skip suite (secrets not configured)
+        if: steps.need.outputs.run != 'true'
+        run: |
+          echo "SKIP suite ${{ matrix.suite }} (matching secret empty, no Coolify boot)"
       - name: Start Coolify image pull
+        if: steps.need.outputs.run == 'true'
         env:
           COOLIFY_DATA_DIR: /home/runner/coolify-data
         run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: steps.need.outputs.run == 'true'
         with:
           go-version-file: go.mod
           cache: true
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        if: steps.need.outputs.run == 'true'
         with:
           terraform_wrapper: false
           terraform_version: "1.15.x"
       - name: Build and install provider locally
+        if: steps.need.outputs.run == 'true'
         run: |
           GOFIPS140=latest go build -o terraform-provider-coolify .
           PLUGIN_DIR="$HOME/.terraform.d/plugins/coolify-terraform/coolify/0.0.0-dev/$(go env GOOS)_$(go env GOARCH)"
@@ -665,9 +707,11 @@ jobs:
           EOF
 
       - name: Setup Coolify
+        if: steps.need.outputs.run == 'true'
         uses: ./.github/actions/setup-coolify
 
       - name: Generate deploy key for scenarios
+        if: steps.need.outputs.run == 'true'
         run: |
           rm -f /tmp/scenario-deploy-key /tmp/scenario-deploy-key.pub
           ssh-keygen -t rsa -b 2048 -f /tmp/scenario-deploy-key -N "" -q
@@ -681,7 +725,9 @@ jobs:
             echo "EOFKEY2"
           } >> "$GITHUB_ENV"
       - name: Run scenario tests
+        if: steps.need.outputs.run == 'true'
         env:
+          SCENARIO_SUITE: ${{ matrix.suite }}
           # GitHub App scenarios (acme-github-cicd)
           TF_VAR_github_app_private_key: ${{ secrets.COOLIFY_GITHUB_APP_PRIVATE_KEY }}
           TF_VAR_github_app_id: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
@@ -700,18 +746,18 @@ jobs:
           export TF_VAR_coolify_token="$COOLIFY_TOKEN"
           export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 
-          bash scripts/run-scenario-tests.sh
+          bash scripts/run-scenario-tests.sh --suite "${{ matrix.suite }}"
 
       - name: Capture Coolify logs on failure
-        if: failure()
+        if: failure() && steps.need.outputs.run == 'true'
         run: |
           docker compose -f "$COOLIFY_DATA_DIR/source/docker-compose.yml" \
             logs --timestamps > /tmp/coolify-logs.txt 2>&1 || true
       - name: Upload Coolify logs
-        if: failure()
+        if: failure() && steps.need.outputs.run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: coolify-logs-scenario-tests
+          name: coolify-logs-scenario-tests-${{ matrix.suite }}
           path: |
             /tmp/coolify-logs.txt
             /tmp/scenario-diag/

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -250,7 +250,11 @@ jobs:
         needs.prepare.outputs.profile == 'custom'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [core, github-cicd, hetzner]
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:
@@ -262,21 +266,58 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Decide whether this suite needs Coolify
+        id: need
+        env:
+          GITHUB_APP_ID: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
+          HETZNER_TOKEN: ${{ secrets.COOLIFY_HETZNER_TOKEN }}
+        run: |
+          case "${{ matrix.suite }}" in
+            core)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            github-cicd)
+              if [ -n "$GITHUB_APP_ID" ]; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "run=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            hetzner)
+              if [ -n "$HETZNER_TOKEN" ]; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "run=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "::error::unknown suite ${{ matrix.suite }}"
+              exit 1
+              ;;
+          esac
+      - name: Skip suite (secrets not configured)
+        if: steps.need.outputs.run != 'true'
+        run: |
+          echo "SKIP suite ${{ matrix.suite }} (matching secret empty, no Coolify boot)"
       - name: Start Coolify image pull
+        if: steps.need.outputs.run == 'true'
         env:
           COOLIFY_DATA_DIR: /home/runner/coolify-data
           COOLIFY_IMAGE_TAG: edge
         run: bash scripts/ci-coolify-boot.sh prepare-pull-bg
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: steps.need.outputs.run == 'true'
         with:
           go-version-file: go.mod
           cache: true
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        if: steps.need.outputs.run == 'true'
         with:
           terraform_wrapper: false
           terraform_version: "1.15.x"
 
       - name: Build and install provider locally
+        if: steps.need.outputs.run == 'true'
         run: |
           GOFIPS140=latest go build -o terraform-provider-coolify .
           PLUGIN_DIR="$HOME/.terraform.d/plugins/coolify-terraform/coolify/0.0.0-dev/$(go env GOOS)_$(go env GOARCH)"
@@ -292,11 +333,13 @@ jobs:
           EOF
 
       - name: Setup Coolify (edge)
+        if: steps.need.outputs.run == 'true'
         uses: ./.github/actions/setup-coolify
         with:
           coolify-image-tag: edge
 
       - name: Generate deploy key for scenarios
+        if: steps.need.outputs.run == 'true'
         run: |
           rm -f /tmp/scenario-deploy-key /tmp/scenario-deploy-key.pub
           ssh-keygen -t rsa -b 2048 -f /tmp/scenario-deploy-key -N "" -q
@@ -311,7 +354,9 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Run scenario tests
+        if: steps.need.outputs.run == 'true'
         env:
+          SCENARIO_SUITE: ${{ matrix.suite }}
           TF_VAR_github_app_private_key: ${{ secrets.COOLIFY_GITHUB_APP_PRIVATE_KEY }}
           TF_VAR_github_app_id: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
           TF_VAR_github_app_installation_id: ${{ secrets.COOLIFY_GITHUB_APP_INSTALLATION_ID }}
@@ -327,18 +372,18 @@ jobs:
           export TF_VAR_coolify_token="$COOLIFY_TOKEN"
           export TF_VAR_server_uuid="$COOLIFY_SERVER_UUID"
 
-          bash scripts/run-scenario-tests.sh
+          bash scripts/run-scenario-tests.sh --suite "${{ matrix.suite }}"
 
       - name: Capture Coolify logs on failure
-        if: failure()
+        if: failure() && steps.need.outputs.run == 'true'
         run: |
           docker compose -f "$COOLIFY_DATA_DIR/source/docker-compose.yml" \
             logs --timestamps > /tmp/coolify-logs.txt 2>&1 || true
       - name: Upload Coolify logs
-        if: failure()
+        if: failure() && steps.need.outputs.run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: coolify-logs-nightly-scenarios
+          name: coolify-logs-nightly-scenarios-${{ matrix.suite }}
           path: |
             /tmp/coolify-logs.txt
             /tmp/scenario-diag/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,11 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 Detect Changes, DCO (PR only), Test (4 package shards), Coverage (merge shards),
 Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
-Acceptance Tests (2 shards), Scenario Tests, Contract Freshness (weekly only), CI (gate).
+Acceptance Tests (2 shards), Scenario Tests (3 suites), Contract Freshness (weekly only), CI (gate).
 Acceptance Tests boot two Coolify instances and split TestAcc packages across them.
-Scenario Tests bootstrap Coolify and run `terraform test` against it.
+Scenario Tests run `core`, `github-cicd`, and `hetzner` in parallel. Each suite
+boots Coolify only when that suite will run (github/hetzner skip the boot when
+the matching secret is empty).
 A separate Dependabot Auto-Merge workflow auto-merges minor/patch PRs.
 An Issue Triage workflow auto-labels new issues (`needs-triage` or `ready`).
 Format check (gofmt) is included in the Lint job via golangci-lint.

--- a/README.md
+++ b/README.md
@@ -368,7 +368,8 @@ and project structure details, see [CONTRIBUTING.md](CONTRIBUTING.md) and
 ### CI Pipeline
 
 9 jobs in the CI workflow: Detect Changes, DCO (PR only), Test, Lint,
-Validate (includes examples, docs, Trivy, Gitleaks), Scenario Tests,
+Validate (includes examples, docs, Trivy, Gitleaks), Scenario Tests
+(core, github-cicd, and hetzner suites),
 Acceptance Tests, Contract Freshness (weekly), and a CI gate job.
 
 ## Troubleshooting

--- a/TESTING.md
+++ b/TESTING.md
@@ -51,13 +51,25 @@ if Acceptance Tests on the same SHA are green; inspect the job artifact
 (`scenario-diag/` plus compose logs) and the `coolify_deployment`
 error, which now includes the last Coolify deployment log lines.
 
-The 18 scenarios themselves take about 3.5 minutes. A 16-45 minute
-Scenario Tests job is Setup Coolify (image pull plus Playwright
-register), not `terraform test`. Do not shard the Scenario job to
-speed that up: each shard would boot its own Coolify and make the
-three-way pull contention with Acceptance Tests worse. Setup now
-fails at 180s for `compose up`, 180s for register, and 300s for the
-bootstrap script instead of sitting until the 45 minute job timeout.
+CI runs three Scenario Tests suites in parallel (each boots its own
+Coolify only when that suite will actually run):
+
+| Suite | Dirs | Why it is separate |
+|-------|------|--------------------|
+| `core` | 16 `acme-*` except the two below | API and config applies; a few minutes after setup |
+| `github-cicd` | `acme-github-cicd` | Real deploy with `wait_for_completion` (up to 15m). Skips Coolify boot if GitHub App secrets are empty |
+| `hetzner` | `acme-hetzner-infra` | Two real Hetzner CX22 servers. Skips Coolify boot if `COOLIFY_HETZNER_TOKEN` is empty |
+
+Do not even-split the 18 dirs across many runners. Each extra suite is
+another Coolify image pull next to the two Acceptance Test boots.
+Setup still fails at 180s for `compose up`, 180s for register, and
+300s for the bootstrap script. Local default is `SCENARIO_SUITE=all`
+(every dir, one process):
+
+```bash
+bash scripts/run-scenario-tests.sh --suite core
+bash scripts/run-scenario-tests.sh --list --suite all
+```
 
 ## Acceptance Tests
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 18 ACME Corp scenarios                │
+│  - 18 ACME Corp scenarios (3 CI suites)  │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐
@@ -149,6 +149,6 @@ The CI pipeline runs 9 jobs on every push and PR:
 | Lint | golangci-lint (20 linters) + Govulncheck + GoReleaser check |
 | Validate | HCL formatting + tfplugindocs + Trivy + Gitleaks |
 | Acceptance Tests | Full suite against a bootstrapped Coolify instance |
-| Scenario Tests | `terraform test` against a real Coolify instance |
+| Scenario Tests | `terraform test` in 3 suites (core, github-cicd, hetzner) |
 | Contract Freshness | Weekly check that the contract matches upstream |
 | CI | Gate job that requires all other jobs to pass |

--- a/docs/guides/scenario-testing.md
+++ b/docs/guides/scenario-testing.md
@@ -274,15 +274,19 @@ terraform test -verbose
 
 # Run all scenarios (retries acme-github-cicd once if Coolify deploy status is failed)
 bash scripts/run-scenario-tests.sh
+
+# Same suites as CI (core / github-cicd / hetzner)
+bash scripts/run-scenario-tests.sh --suite core
 ```
 
-CI uses the same script. A single Coolify deploy `failed` on
-`acme-github-cicd` is retried once; if it still fails, Coolify
-deployment JSON (including logs when the API token can read them)
-is written to `/tmp/scenario-diag/` and uploaded with the job
-artifact. Acceptance Tests remain the product-code gate; inspect
-those before treating a lone scenario deploy failure as a provider
-regression.
+CI uses the same script on three parallel runners so a 15-minute
+GitHub deploy wait does not block the other 16 scenarios. A single
+Coolify deploy `failed` on `acme-github-cicd` is retried once; if it
+still fails, Coolify deployment JSON (including logs when the API
+token can read them) is written to `/tmp/scenario-diag/` and uploaded
+with the job artifact. Acceptance Tests remain the product-code gate;
+inspect those before treating a lone scenario deploy failure as a
+provider regression.
 
 ## Coming Back Later
 

--- a/scripts/run-scenario-tests.sh
+++ b/scripts/run-scenario-tests.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Run terraform test for each examples/scenarios/acme-* directory.
+# Run terraform test for selected examples/scenarios/acme-* directories.
+# Suites (SCENARIO_SUITE or --suite):
+#   all          every acme-* dir (local default)
+#   core         all except acme-github-cicd and acme-hetzner-infra
+#   github-cicd  acme-github-cicd only
+#   hetzner      acme-hetzner-infra only
 # Retries acme-github-cicd once (Coolify deploy status "failed" flake, #728).
 # On any failure, dumps Coolify deployment JSON when endpoint/token are set.
 set -u
@@ -7,8 +12,90 @@ set -u
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIAG_DIR="${SCENARIO_DIAG_DIR:-/tmp/scenario-diag}"
 RETRY_SCENARIO="${SCENARIO_RETRY:-acme-github-cicd}"
+SUITE="${SCENARIO_SUITE:-all}"
+LIST_ONLY=0
 
-echo "PLAN: terraform test each examples/scenarios/acme-* (retry ${RETRY_SCENARIO} once on failure)"
+usage() {
+  echo "usage: $0 [--list] [--suite all|core|github-cicd|hetzner]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --list)
+      LIST_ONLY=1
+      shift
+      ;;
+    --suite)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      SUITE="$2"
+      shift 2
+      ;;
+    --suite=*)
+      SUITE="${1#--suite=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+list_scenario_dirs() {
+  suite="$1"
+  case "$suite" in
+    all|core|github-cicd|hetzner) ;;
+    *)
+      echo "FAIL: unknown suite '$suite' (want all, core, github-cicd, hetzner)" >&2
+      return 2
+      ;;
+  esac
+  for dir in "${ROOT}"/examples/scenarios/acme-*/; do
+    [ -d "$dir" ] || continue
+    scenario="$(basename "$dir")"
+    case "$suite" in
+      all) echo "$dir" ;;
+      core)
+        case "$scenario" in
+          acme-github-cicd|acme-hetzner-infra) ;;
+          *) echo "$dir" ;;
+        esac
+        ;;
+      github-cicd)
+        if [ "$scenario" = "acme-github-cicd" ]; then
+          echo "$dir"
+        fi
+        ;;
+      hetzner)
+        if [ "$scenario" = "acme-hetzner-infra" ]; then
+          echo "$dir"
+        fi
+        ;;
+    esac
+  done
+}
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  list_scenario_dirs "$SUITE" || exit $?
+  exit 0
+fi
+
+SCENARIO_LIST="$(list_scenario_dirs "$SUITE")" || exit $?
+if [ -z "$SCENARIO_LIST" ]; then
+  echo "FAIL: suite '$SUITE' selected zero scenario directories" >&2
+  exit 2
+fi
+SCENARIO_COUNT="$(printf '%s\n' "$SCENARIO_LIST" | grep -c .)"
+
+echo "PLAN: terraform test suite=${SUITE} (${SCENARIO_COUNT} dir(s); retry ${RETRY_SCENARIO} once on failure)"
 
 dump_diag() {
   endpoint="${COOLIFY_ENDPOINT:-${TF_VAR_coolify_endpoint:-}}"
@@ -38,7 +125,7 @@ run_one() {
 }
 
 failed=0
-for dir in "${ROOT}"/examples/scenarios/acme-*/; do
+while IFS= read -r dir; do
   [ -d "$dir" ] || continue
   scenario="$(basename "$dir")"
   echo "=== Testing ${scenario} ==="
@@ -79,13 +166,13 @@ for dir in "${ROOT}"/examples/scenarios/acme-*/; do
     fi
   fi
   echo ""
-done
+done <<< "$SCENARIO_LIST"
 
 if [ "$failed" -eq 0 ]; then
-  echo "DONE: all scenario tests passed"
+  echo "DONE: all scenario tests passed (suite=${SUITE})"
   echo "NEXT: none"
   exit 0
 fi
-echo "DONE: one or more scenario tests failed (diag: ${DIAG_DIR})"
+echo "DONE: one or more scenario tests failed (suite=${SUITE}; diag: ${DIAG_DIR})"
 echo "NEXT: inspect terraform test output and ${DIAG_DIR}"
 exit 1

--- a/scripts/test_run_scenario_tests.py
+++ b/scripts/test_run_scenario_tests.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/run-scenario-tests.sh suite selection."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run-scenario-tests.sh"
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+
+
+def names_from_list(proc: subprocess.CompletedProcess[str]) -> list[str]:
+    return [Path(ln.strip()).name for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+class TestRunScenarioTests(unittest.TestCase):
+    def test_script_is_executable(self) -> None:
+        mode = SCRIPT.stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR, "run-scenario-tests.sh must be executable")
+
+    def test_unknown_suite_exits_2(self) -> None:
+        proc = run_script("--list", "--suite", "nope")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("unknown suite", proc.stderr)
+
+    def test_unknown_flag_exits_2(self) -> None:
+        proc = run_script("--wat")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("unknown argument", proc.stderr)
+
+    def test_list_all_is_eighteen_acme_dirs(self) -> None:
+        proc = run_script("--list", "--suite", "all")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        names = names_from_list(proc)
+        self.assertEqual(len(names), 18)
+        self.assertIn("acme-github-cicd", names)
+        self.assertIn("acme-hetzner-infra", names)
+        self.assertIn("acme-website", names)
+
+    def test_list_core_excludes_slow_suites(self) -> None:
+        proc = run_script("--list", "--suite=core")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        names = names_from_list(proc)
+        self.assertEqual(len(names), 16)
+        self.assertNotIn("acme-github-cicd", names)
+        self.assertNotIn("acme-hetzner-infra", names)
+        self.assertIn("acme-website", names)
+
+    def test_list_github_cicd_is_one_dir(self) -> None:
+        proc = run_script("--list", "--suite", "github-cicd")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(names_from_list(proc), ["acme-github-cicd"])
+
+    def test_list_hetzner_is_one_dir(self) -> None:
+        proc = run_script("--list", "--suite", "hetzner")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(names_from_list(proc), ["acme-hetzner-infra"])
+
+    def test_core_plus_slow_covers_all(self) -> None:
+        all_names = set(names_from_list(run_script("--list", "--suite", "all")))
+        core = set(names_from_list(run_script("--list", "--suite", "core")))
+        gh = set(names_from_list(run_script("--list", "--suite", "github-cicd")))
+        hz = set(names_from_list(run_script("--list", "--suite", "hetzner")))
+        self.assertEqual(core | gh | hz, all_names)
+        self.assertEqual(len(core & gh), 0)
+        self.assertEqual(len(core & hz), 0)

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -111,7 +111,7 @@ preserves the value from Terraform state rather than overwriting it.
 │  - .tftest.hcl files in examples/scen.   │
 │  - Multi-resource integration tests      │
 │  - Real Coolify instance                 │
-│  - 18 ACME Corp scenarios                │
+│  - 18 ACME Corp scenarios (3 CI suites)  │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐
@@ -149,6 +149,6 @@ The CI pipeline runs 9 jobs on every push and PR:
 | Lint | golangci-lint (20 linters) + Govulncheck + GoReleaser check |
 | Validate | HCL formatting + tfplugindocs + Trivy + Gitleaks |
 | Acceptance Tests | Full suite against a bootstrapped Coolify instance |
-| Scenario Tests | `terraform test` against a real Coolify instance |
+| Scenario Tests | `terraform test` in 3 suites (core, github-cicd, hetzner) |
 | Contract Freshness | Weekly check that the contract matches upstream |
 | CI | Gate job that requires all other jobs to pass |

--- a/templates/guides/scenario-testing.md.tmpl
+++ b/templates/guides/scenario-testing.md.tmpl
@@ -274,15 +274,19 @@ terraform test -verbose
 
 # Run all scenarios (retries acme-github-cicd once if Coolify deploy status is failed)
 bash scripts/run-scenario-tests.sh
+
+# Same suites as CI (core / github-cicd / hetzner)
+bash scripts/run-scenario-tests.sh --suite core
 ```
 
-CI uses the same script. A single Coolify deploy `failed` on
-`acme-github-cicd` is retried once; if it still fails, Coolify
-deployment JSON (including logs when the API token can read them)
-is written to `/tmp/scenario-diag/` and uploaded with the job
-artifact. Acceptance Tests remain the product-code gate; inspect
-those before treating a lone scenario deploy failure as a provider
-regression.
+CI uses the same script on three parallel runners so a 15-minute
+GitHub deploy wait does not block the other 16 scenarios. A single
+Coolify deploy `failed` on `acme-github-cicd` is retried once; if it
+still fails, Coolify deployment JSON (including logs when the API
+token can read them) is written to `/tmp/scenario-diag/` and uploaded
+with the job artifact. Acceptance Tests remain the product-code gate;
+inspect those before treating a lone scenario deploy failure as a
+provider regression.
 
 ## Coming Back Later
 


### PR DESCRIPTION
## Summary

Run ACME scenario tests on three GitHub-hosted runners so a 15-minute GitHub deploy wait does not block the other 16 scenarios.

## Problem

A single Scenario Tests job serializes all 18 `terraform test` applies. On main, Setup Coolify can be ~75s while `Run scenario tests` stays on the runner for 30+ minutes. `acme-github-cicd` waits for a real Coolify deploy (create timeout 15m). `acme-hetzner-infra` can provision two Hetzner CX22 servers when the token secret is set.

Even-splitting all 18 dirs would boot many Coolify instances next to the two Acceptance Test boots.

## Change

- Suites: `core` (16 dirs), `github-cicd`, `hetzner`
- `scripts/run-scenario-tests.sh --suite` / `SCENARIO_SUITE` (default `all` locally)
- Skip Coolify image pull and setup when github/hetzner secrets are empty
- Same matrix on Coolify Nightly tip scenarios
- `fail-fast: false` so a core failure does not cancel an in-flight Hetzner apply

## Validation

`python3 -m pytest scripts/test_run_scenario_tests.py -q`
`bash -n scripts/run-scenario-tests.sh`
`actionlint` on the two workflows (only the known `permissions.code-quality` warning from #445)

## Issue reference

No issue auto-close. Release PR #801 is unchanged.