### PR TITLE
test: cover scenario suites and instance email 404 paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
               - 'scripts/ci-unit-packages.sh'
               - 'scripts/ci-acc-packages.sh'
               - 'scripts/ci-coolify-boot.sh'
+              - 'scripts/ci-scenario-suite-need.sh'
               - '.codecov.yml'
               - '.goreleaser.yml'
               - 'GNUmakefile'
@@ -647,30 +648,7 @@ jobs:
         env:
           GITHUB_APP_ID: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
           HETZNER_TOKEN: ${{ secrets.COOLIFY_HETZNER_TOKEN }}
-        run: |
-          case "${{ matrix.suite }}" in
-            core)
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              ;;
-            github-cicd)
-              if [ -n "$GITHUB_APP_ID" ]; then
-                echo "run=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "run=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            hetzner)
-              if [ -n "$HETZNER_TOKEN" ]; then
-                echo "run=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "run=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            *)
-              echo "::error::unknown suite ${{ matrix.suite }}"
-              exit 1
-              ;;
-          esac
+        run: bash scripts/ci-scenario-suite-need.sh "${{ matrix.suite }}" >> "$GITHUB_OUTPUT"
       - name: Skip suite (secrets not configured)
         if: steps.need.outputs.run != 'true'
         run: |

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -271,30 +271,7 @@ jobs:
         env:
           GITHUB_APP_ID: ${{ secrets.COOLIFY_GITHUB_APP_APP_ID }}
           HETZNER_TOKEN: ${{ secrets.COOLIFY_HETZNER_TOKEN }}
-        run: |
-          case "${{ matrix.suite }}" in
-            core)
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              ;;
-            github-cicd)
-              if [ -n "$GITHUB_APP_ID" ]; then
-                echo "run=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "run=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            hetzner)
-              if [ -n "$HETZNER_TOKEN" ]; then
-                echo "run=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "run=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            *)
-              echo "::error::unknown suite ${{ matrix.suite }}"
-              exit 1
-              ;;
-          esac
+        run: bash scripts/ci-scenario-suite-need.sh "${{ matrix.suite }}" >> "$GITHUB_OUTPUT"
       - name: Skip suite (secrets not configured)
         if: steps.need.outputs.run != 'true'
         run: |

--- a/docs/data-sources/instance_email_settings.md
+++ b/docs/data-sources/instance_email_settings.md
@@ -13,6 +13,8 @@ Reads Coolify instance-wide SMTP and Resend settings (`GET /settings/email`). Th
 ## Example Usage
 
 ```terraform
+# Instance-wide SMTP / Resend settings (Coolify >= v4.3.10).
+# Requires a root-team API token (team 0).
 data "coolify_instance_email_settings" "current" {}
 
 output "instance_smtp_enabled" {

--- a/docs/resources/notification_email.md
+++ b/docs/resources/notification_email.md
@@ -22,6 +22,8 @@ On destroy, all three enable flags are set to `false`; credentials are left unch
 # Team email notification settings (Coolify >= v4.3.0).
 # Import: terraform import coolify_notification_email.main current
 resource "coolify_notification_email" "main" {
+  # To inherit instance-wide SMTP instead, set use_instance_email_settings = true
+  # (coolify_instance_email_settings) and omit the smtp_* credentials below.
   smtp_enabled      = true
   smtp_host         = "smtp.example.com"
   smtp_port         = 587

--- a/examples/data-sources/coolify_instance_email_settings/data-source.tf
+++ b/examples/data-sources/coolify_instance_email_settings/data-source.tf
@@ -1,3 +1,5 @@
+# Instance-wide SMTP / Resend settings (Coolify >= v4.3.10).
+# Requires a root-team API token (team 0).
 data "coolify_instance_email_settings" "current" {}
 
 output "instance_smtp_enabled" {

--- a/examples/resources/coolify_notification_email/resource.tf
+++ b/examples/resources/coolify_notification_email/resource.tf
@@ -1,6 +1,8 @@
 # Team email notification settings (Coolify >= v4.3.0).
 # Import: terraform import coolify_notification_email.main current
 resource "coolify_notification_email" "main" {
+  # To inherit instance-wide SMTP instead, set use_instance_email_settings = true
+  # (coolify_instance_email_settings) and omit the smtp_* credentials below.
   smtp_enabled      = true
   smtp_host         = "smtp.example.com"
   smtp_port         = 587

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/pb33f/libopenapi-validator v0.14.0
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.12.1
 )
 
 require (
@@ -23,7 +23,6 @@ require (
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/go-openapi/jsonpointer v0.23.2 // indirect
 	github.com/go-openapi/swag/jsonname v0.26.1 // indirect
@@ -57,12 +56,12 @@ require (
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
@@ -75,5 +74,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/pb33f/testify v0.1.0/go.mod h1:nq283P/jJ8hXMmdhAqfj7BJIz0y+6IOHj9q004
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
@@ -178,8 +176,8 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -206,6 +204,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
 go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -289,5 +289,4 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/client/instance_email_test.go
+++ b/internal/client/instance_email_test.go
@@ -106,6 +106,25 @@ func TestClient_GetInstanceEmailSettings_APIError(t *testing.T) {
 	assert.False(t, client.IsNotFound(err))
 }
 
+func TestClient_UpdateInstanceEmailSettings_NotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not found."}`))
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.10"))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-token")
+	c.CoolifyVersion = "4.3.10"
+	en := true
+	_, err := c.UpdateInstanceEmailSettings(context.Background(), client.UpdateInstanceEmailInput{SMTPEnabled: &en})
+	require.Error(t, err)
+	assert.True(t, client.IsNotFound(err))
+	assert.Contains(t, err.Error(), "updating instance email settings")
+}
+
 func TestClient_UpdateInstanceEmailSettings_APIError(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/internal/service/instanceemail/data_source_test.go
+++ b/internal/service/instanceemail/data_source_test.go
@@ -63,6 +63,28 @@ data "coolify_instance_email_settings" "test" {}
 	})
 }
 
+func TestInstanceEmailSettingsDataSource_ReadNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/settings/email", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Not found."}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.10"))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+data "coolify_instance_email_settings" "test" {}
+`,
+				ExpectError: regexp.MustCompile(`Error reading instance email settings`),
+			},
+		},
+	})
+}
+
 func TestInstanceEmailSettingsDataSource_ReadUnsupportedVersion(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()

--- a/scripts/ci-scenario-suite-need.sh
+++ b/scripts/ci-scenario-suite-need.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Decide whether a Scenario Tests matrix suite should boot Coolify.
+# Writes a single GITHUB_OUTPUT line: run=true or run=false.
+# Usage: ci-scenario-suite-need.sh SUITE
+# Env: GITHUB_APP_ID (github-cicd), HETZNER_TOKEN (hetzner). core always runs.
+set -eu
+
+suite="${1:-}"
+if [ -z "$suite" ]; then
+  echo "FAIL: usage: $0 all|core|github-cicd|hetzner" >&2
+  exit 2
+fi
+
+case "$suite" in
+  all|core)
+    echo "run=true"
+    ;;
+  github-cicd)
+    if [ -n "${GITHUB_APP_ID:-}" ]; then
+      echo "run=true"
+    else
+      echo "run=false"
+    fi
+    ;;
+  hetzner)
+    if [ -n "${HETZNER_TOKEN:-}" ]; then
+      echo "run=true"
+    else
+      echo "run=false"
+    fi
+    ;;
+  *)
+    echo "FAIL: unknown suite ${suite}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/test_ci_scenario_suite_need.py
+++ b/scripts/test_ci_scenario_suite_need.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ci-scenario-suite-need.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci-scenario-suite-need.sh"
+
+
+def run_need(suite: str, env_updates: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("GITHUB_APP_ID", None)
+    env.pop("HETZNER_TOKEN", None)
+    if env_updates:
+        env.update(env_updates)
+    return subprocess.run(
+        ["bash", str(SCRIPT), suite],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestCIScenarioSuiteNeed(unittest.TestCase):
+    def test_missing_suite_exits_2(self) -> None:
+        proc = run_need("")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("usage", proc.stderr)
+
+    def test_unknown_suite_exits_1(self) -> None:
+        proc = run_need("nope")
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("unknown suite", proc.stderr)
+
+    def test_core_always_runs(self) -> None:
+        proc = run_need("core")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+    def test_all_always_runs(self) -> None:
+        proc = run_need("all")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+    def test_github_cicd_skips_without_secret(self) -> None:
+        proc = run_need("github-cicd")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=false")
+
+    def test_github_cicd_runs_with_secret(self) -> None:
+        proc = run_need("github-cicd", {"GITHUB_APP_ID": "123"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+    def test_hetzner_skips_without_secret(self) -> None:
+        proc = run_need("hetzner")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=false")
+
+    def test_hetzner_runs_with_secret(self) -> None:
+        proc = run_need("hetzner", {"HETZNER_TOKEN": "tok"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_scenario_tests.py
+++ b/scripts/test_run_scenario_tests.py
@@ -13,13 +13,16 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "run-scenario-tests.sh"
 
 
-def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+def run_script(*args: str, env_updates: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if env_updates:
+        env.update(env_updates)
     return subprocess.run(
         ["bash", str(SCRIPT), *args],
         cwd=ROOT,
         capture_output=True,
         text=True,
-        env=os.environ.copy(),
+        env=env,
     )
 
 
@@ -78,3 +81,26 @@ class TestRunScenarioTests(unittest.TestCase):
         self.assertEqual(core | gh | hz, all_names)
         self.assertEqual(len(core & gh), 0)
         self.assertEqual(len(core & hz), 0)
+
+    def test_list_default_is_all(self) -> None:
+        proc = run_script("--list", env_updates={"SCENARIO_SUITE": ""})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(len(names_from_list(proc)), 18)
+
+    def test_list_suite_from_env(self) -> None:
+        proc = run_script("--list", env_updates={"SCENARIO_SUITE": "core"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        names = names_from_list(proc)
+        self.assertEqual(len(names), 16)
+        self.assertNotIn("acme-github-cicd", names)
+        self.assertNotIn("acme-hetzner-infra", names)
+
+    def test_flag_overrides_env_suite(self) -> None:
+        proc = run_script(
+            "--list",
+            "--suite",
+            "hetzner",
+            env_updates={"SCENARIO_SUITE": "core"},
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(names_from_list(proc), ["acme-hetzner-infra"])


### PR DESCRIPTION
## Description

Follow-up after the scenario suite split: cover the CI env path, stop duplicating the Coolify-boot decision, and close test/docs gaps on instance email.

## Problem

`SCENARIO_SUITE` and the github-cicd/hetzner skip logic were only exercised by flags and two copied YAML `case` blocks. A 404 on `GET /settings/email` for a supported Coolify version had no data-source test. Examples did not mention the 4.3.10 / root-team floor or `use_instance_email_settings`.

## Change

- List scenarios via `SCENARIO_SUITE`, default `all`, and `--suite` override
- Data source 404 on Coolify 4.3.10 is a read error, not "unsupported version"
- Client `UpdateInstanceEmailSettings` 404 maps to `IsNotFound`
- Shared `scripts/ci-scenario-suite-need.sh` used by `ci.yml` and nightly
- Example comments for instance email floors and team-email inherit
- Bump `github.com/stretchr/testify` to v1.12.1 (only outdated direct module)

## Validation

- `python3 -m unittest scripts.test_run_scenario_tests scripts.test_ci_scenario_suite_need`
- `go test` for `./internal/client/` and `./internal/service/instanceemail/`
- `PATH="$(pwd)/bin:$PATH" make ci` (exit 0)

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] `make ci` passes locally
- [x] Documentation updated
- [x] `make docs` regenerated
- [x] Examples updated
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
