### PR TITLE
ci: accept TF_VAR and Coolify secret names in suite-need

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -58,7 +58,7 @@ Coolify only when that suite will actually run):
 |-------|------|--------------------|
 | `core` | 16 `acme-*` except the two below | API and config applies; a few minutes after setup |
 | `github-cicd` | `acme-github-cicd` | Real deploy with `wait_for_completion` (up to 15m). Skips Coolify boot if GitHub App secrets are empty |
-| `hetzner` | `acme-hetzner-infra` | Two real Hetzner CX22 servers. Skips Coolify boot if `COOLIFY_HETZNER_TOKEN` is empty |
+| `hetzner` | `acme-hetzner-infra` | Two real Hetzner CX22 servers. Skips Coolify boot if Hetzner token is empty |
 
 Do not even-split the 18 dirs across many runners. Each extra suite is
 another Coolify image pull next to the two Acceptance Test boots.
@@ -70,6 +70,11 @@ Setup still fails at 180s for `compose up`, 180s for register, and
 bash scripts/run-scenario-tests.sh --suite core
 bash scripts/run-scenario-tests.sh --list --suite all
 ```
+
+CI uses `scripts/ci-scenario-suite-need.sh` to skip Coolify boot when the
+suite secret is empty. It accepts `GITHUB_APP_ID` /
+`COOLIFY_GITHUB_APP_APP_ID` / `TF_VAR_github_app_id` and `HETZNER_TOKEN` /
+`COOLIFY_HETZNER_TOKEN` / `TF_VAR_hetzner_api_token`.
 
 ## Acceptance Tests
 

--- a/internal/service/instanceemail/data_source_acc_test.go
+++ b/internal/service/instanceemail/data_source_acc_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccInstanceEmailSettingsDataSource(t *testing.T) {
@@ -33,7 +36,17 @@ data "coolify_instance_email_settings" "test" {}
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.coolify_instance_email_settings.test", "id", "current"),
-					resource.TestCheckResourceAttrSet("data.coolify_instance_email_settings.test", "smtp_enabled"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["data.coolify_instance_email_settings.test"]
+						if !ok {
+							return fmt.Errorf("data.coolify_instance_email_settings.test not in state")
+						}
+						v := rs.Primary.Attributes["smtp_enabled"]
+						if v != "true" && v != "false" {
+							return fmt.Errorf("smtp_enabled = %q, want true or false", v)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/service/instanceemail/data_source_test.go
+++ b/internal/service/instanceemail/data_source_test.go
@@ -57,7 +57,7 @@ func TestInstanceEmailSettingsDataSource_ReadAPIError(t *testing.T) {
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 data "coolify_instance_email_settings" "test" {}
 `,
-				ExpectError: regexp.MustCompile(`Error reading instance email settings`),
+				ExpectError: regexp.MustCompile(`(?is)Error reading instance email settings.*Validation failed`),
 			},
 		},
 	})
@@ -79,7 +79,7 @@ func TestInstanceEmailSettingsDataSource_ReadNotFound(t *testing.T) {
 				Config: acctest.ProviderBlockForURL(srv.URL) + `
 data "coolify_instance_email_settings" "test" {}
 `,
-				ExpectError: regexp.MustCompile(`Error reading instance email settings`),
+				ExpectError: regexp.MustCompile(`(?is)Error reading instance email settings.*not found`),
 			},
 		},
 	})

--- a/scripts/ci-scenario-suite-need.sh
+++ b/scripts/ci-scenario-suite-need.sh
@@ -2,7 +2,10 @@
 # Decide whether a Scenario Tests matrix suite should boot Coolify.
 # Writes a single GITHUB_OUTPUT line: run=true or run=false.
 # Usage: ci-scenario-suite-need.sh SUITE
-# Env: GITHUB_APP_ID (github-cicd), HETZNER_TOKEN (hetzner). core always runs.
+# Env (first non-empty wins):
+#   github-cicd: GITHUB_APP_ID, COOLIFY_GITHUB_APP_APP_ID, TF_VAR_github_app_id
+#   hetzner:     HETZNER_TOKEN, COOLIFY_HETZNER_TOKEN, TF_VAR_hetzner_api_token
+# core and all always run.
 set -eu
 
 suite="${1:-}"
@@ -11,19 +14,22 @@ if [ -z "$suite" ]; then
   exit 2
 fi
 
+github_id="${GITHUB_APP_ID:-${COOLIFY_GITHUB_APP_APP_ID:-${TF_VAR_github_app_id:-}}}"
+hetzner_token="${HETZNER_TOKEN:-${COOLIFY_HETZNER_TOKEN:-${TF_VAR_hetzner_api_token:-}}}"
+
 case "$suite" in
   all|core)
     echo "run=true"
     ;;
   github-cicd)
-    if [ -n "${GITHUB_APP_ID:-}" ]; then
+    if [ -n "$github_id" ]; then
       echo "run=true"
     else
       echo "run=false"
     fi
     ;;
   hetzner)
-    if [ -n "${HETZNER_TOKEN:-}" ]; then
+    if [ -n "$hetzner_token" ]; then
       echo "run=true"
     else
       echo "run=false"

--- a/scripts/test_ci_scenario_suite_need.py
+++ b/scripts/test_ci_scenario_suite_need.py
@@ -16,6 +16,10 @@ def run_need(suite: str, env_updates: dict[str, str] | None = None) -> subproces
     env = os.environ.copy()
     env.pop("GITHUB_APP_ID", None)
     env.pop("HETZNER_TOKEN", None)
+    env.pop("COOLIFY_GITHUB_APP_APP_ID", None)
+    env.pop("COOLIFY_HETZNER_TOKEN", None)
+    env.pop("TF_VAR_github_app_id", None)
+    env.pop("TF_VAR_hetzner_api_token", None)
     if env_updates:
         env.update(env_updates)
     return subprocess.run(
@@ -32,6 +36,10 @@ class TestCIScenarioSuiteNeed(unittest.TestCase):
         env = os.environ.copy()
         env.pop("GITHUB_APP_ID", None)
         env.pop("HETZNER_TOKEN", None)
+        env.pop("COOLIFY_GITHUB_APP_APP_ID", None)
+        env.pop("COOLIFY_HETZNER_TOKEN", None)
+        env.pop("TF_VAR_github_app_id", None)
+        env.pop("TF_VAR_hetzner_api_token", None)
         proc = subprocess.run(
             ["bash", str(SCRIPT)],
             cwd=ROOT,
@@ -74,6 +82,16 @@ class TestCIScenarioSuiteNeed(unittest.TestCase):
 
     def test_hetzner_runs_with_secret(self) -> None:
         proc = run_need("hetzner", {"HETZNER_TOKEN": "tok"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+    def test_github_cicd_accepts_coolify_env_name(self) -> None:
+        proc = run_need("github-cicd", {"COOLIFY_GITHUB_APP_APP_ID": "123"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "run=true")
+
+    def test_hetzner_accepts_tf_var_name(self) -> None:
+        proc = run_need("hetzner", {"TF_VAR_hetzner_api_token": "tok"})
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertEqual(proc.stdout.strip(), "run=true")
 

--- a/scripts/test_ci_scenario_suite_need.py
+++ b/scripts/test_ci_scenario_suite_need.py
@@ -29,7 +29,16 @@ def run_need(suite: str, env_updates: dict[str, str] | None = None) -> subproces
 
 class TestCIScenarioSuiteNeed(unittest.TestCase):
     def test_missing_suite_exits_2(self) -> None:
-        proc = run_need("")
+        env = os.environ.copy()
+        env.pop("GITHUB_APP_ID", None)
+        env.pop("HETZNER_TOKEN", None)
+        proc = subprocess.run(
+            ["bash", str(SCRIPT)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
         self.assertEqual(proc.returncode, 2)
         self.assertIn("usage", proc.stderr)
 

--- a/scripts/test_run_scenario_tests.py
+++ b/scripts/test_run_scenario_tests.py
@@ -85,7 +85,10 @@ class TestRunScenarioTests(unittest.TestCase):
     def test_list_default_is_all(self) -> None:
         proc = run_script("--list", env_updates={"SCENARIO_SUITE": ""})
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertEqual(len(names_from_list(proc)), 18)
+        names = names_from_list(proc)
+        self.assertEqual(len(names), 18)
+        self.assertIn("acme-github-cicd", names)
+        self.assertIn("acme-hetzner-infra", names)
 
     def test_list_suite_from_env(self) -> None:
         proc = run_script("--list", env_updates={"SCENARIO_SUITE": "core"})


### PR DESCRIPTION
## Description

Tighten last-cycle scenario-suite and instance-email tests, and make the Coolify-boot skip helper accept the same env names terraform test already uses.

## Problem

The new data-source 404 and 422 tests both matched only the Terraform error title, so a swapped mock still passed. `ci-scenario-suite-need.sh` only looked at `GITHUB_APP_ID` / `HETZNER_TOKEN`, while local shells export `COOLIFY_*` and `TF_VAR_*`.

## Change

- Require API detail in instance email data-source 404 vs 422 errors
- Acc read asserts `smtp_enabled` is `true` or `false`
- Suite-need accepts `COOLIFY_GITHUB_APP_APP_ID` / `TF_VAR_github_app_id` and `COOLIFY_HETZNER_TOKEN` / `TF_VAR_hetzner_api_token`

## Validation

- `python3 -m unittest discover -s scripts -p "*test*.py"`
- `go test ./internal/service/instanceemail/`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Documentation updated (TESTING.md)
- [ ] CHANGELOG.md updated (release-please)
- [x] No breaking changes to existing resources
