### PR TITLE
fix: extra-key probe smtp_ehlo_domain on CI edge

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -827,6 +827,89 @@ func AccTestSkipIfNoNotificationAPI(t *testing.T) {
 	}
 }
 
+// smtpEhloDomainProbeValue is not a valid hostname, so Coolify
+// ValidHostname 422s when smtp_ehlo_domain is on the allow list.
+// Extra-key 422 ("This field is not allowed.") means the field is
+// absent. Using an invalid value avoids mutating the team singleton.
+const smtpEhloDomainProbeValue = "not a hostname"
+
+// isExtraKeyNotAllowed reports whether a 422 body is Coolify rejecting
+// an unknown JSON key (not a field-level validation error).
+func isExtraKeyNotAllowed(msgLower string) bool {
+	return strings.Contains(msgLower, "this field is not allowed") ||
+		strings.Contains(msgLower, "field is not allowed")
+}
+
+// coolifyAcceptsSMTPEhloDomain extra-key PATCHes smtp_ehlo_domain on
+// /notifications/email. ok is true when Coolify treated the key as
+// allowed (validation 422 or 2xx). Do not use AccTestSkipIfCoolifyBelow
+// for this field: CI edge reports 4.3.0 while already shipping #11398.
+func coolifyAcceptsSMTPEhloDomain(t *testing.T) (ok bool, detail string) {
+	t.Helper()
+	TestAccPreCheck(t)
+
+	endpoint := strings.TrimRight(os.Getenv("COOLIFY_ENDPOINT"), "/")
+	token := os.Getenv("COOLIFY_TOKEN")
+	path := endpoint + "/api/v1/notifications/email"
+	body := `{"smtp_ehlo_domain":"` + smtpEhloDomainProbeValue + `"}`
+	req, err := http.NewRequest(http.MethodPatch, path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building smtp_ehlo_domain probe request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Sprintf("smtp_ehlo_domain extra-key probe failed (cannot reach Coolify): %v", err)
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	msg := strings.ToLower(string(raw))
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusUnauthorized, http.StatusForbidden:
+		return true, ""
+	case http.StatusUnprocessableEntity:
+		if isExtraKeyNotAllowed(msg) {
+			return false, fmt.Sprintf("Coolify extra-key 422s smtp_ehlo_domain (need tip after coollabsio/coolify#11398). Body: %s",
+				truncateForSkip(string(raw), 200))
+		}
+		// Validation 422 (invalid hostname) means the field is allowed.
+		return true, ""
+	case http.StatusNotFound, http.StatusMethodNotAllowed:
+		return false, fmt.Sprintf("Coolify has no email notification PATCH (HTTP %d). Body: %s",
+			resp.StatusCode, truncateForSkip(string(raw), 200))
+	default:
+		if resp.StatusCode >= 500 {
+			return false, fmt.Sprintf("smtp_ehlo_domain extra-key probe returned HTTP %d: %s",
+				resp.StatusCode, truncateForSkip(string(raw), 200))
+		}
+		// Other 4xx still means a handler ran and did not extra-key reject.
+		return true, ""
+	}
+}
+
+// AccTestSkipIfNoSMTPEhloDomain skips when PATCH extra-key 422s
+// smtp_ehlo_domain (Coolify before #11398). When COOLIFY_REQUIRE_TIP_APIS=1
+// a missing field fails instead of skips.
+func AccTestSkipIfNoSMTPEhloDomain(t *testing.T) {
+	t.Helper()
+	ok, detail := coolifyAcceptsSMTPEhloDomain(t)
+	if !ok {
+		accTestMissingFeature(t, "%s", detail)
+	}
+}
+
+// AccTestSMTPEhloDomainAccepted reports whether extra-key PATCH accepts
+// smtp_ehlo_domain. It does not skip or fail.
+func AccTestSMTPEhloDomainAccepted(t *testing.T) bool {
+	t.Helper()
+	ok, _ := coolifyAcceptsSMTPEhloDomain(t)
+	return ok
+}
+
 // AccTestSkipIfCoolifyBelow skips (or fails with COOLIFY_REQUIRE_TIP_APIS=1)
 // when the connected Coolify version is older than min (e.g. "4.3.0").
 func AccTestSkipIfCoolifyBelow(t *testing.T, min string) {

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -892,13 +892,15 @@ func coolifyAcceptsSMTPEhloDomain(t *testing.T) (ok bool, detail string) {
 }
 
 // AccTestSkipIfNoSMTPEhloDomain skips when PATCH extra-key 422s
-// smtp_ehlo_domain (Coolify before #11398). When COOLIFY_REQUIRE_TIP_APIS=1
-// a missing field fails instead of skips.
+// smtp_ehlo_domain (Coolify before #11398). Soft-skip even when
+// COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0 and extra-key 422s
+// this field. Do not use AccTestSkipIfCoolifyBelow (that helper plus
+// the flag is a hard fail on the version string).
 func AccTestSkipIfNoSMTPEhloDomain(t *testing.T) {
 	t.Helper()
 	ok, detail := coolifyAcceptsSMTPEhloDomain(t)
 	if !ok {
-		accTestMissingFeature(t, "%s", detail)
+		t.Skip(detail)
 	}
 }
 

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -274,3 +274,94 @@ func TestIsControllerResourceNotFound(t *testing.T) {
 		t.Fatal("plain not found. must not look like controller resource 404")
 	}
 }
+
+func TestIsExtraKeyNotAllowed(t *testing.T) {
+	if !isExtraKeyNotAllowed(`{"message":"validation failed.","errors":{"smtp_ehlo_domain":["this field is not allowed."]}}`) {
+		t.Fatal("expected extra-key 422 body to match")
+	}
+	if isExtraKeyNotAllowed(`{"message":"the smtp ehlo domain field must be a valid hostname."}`) {
+		t.Fatal("hostname validation 422 must not look like extra-key")
+	}
+}
+
+func TestAccTestSkipIfNoSMTPEhloDomain_ExtraKey(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation failed.","errors":{"smtp_ehlo_domain":["This field is not allowed."]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoSMTPEhloDomain(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoSMTPEhloDomain to skip on extra-key 422")
+	}
+}
+
+func TestAccTestSkipIfNoSMTPEhloDomain_ValidationPresent(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode probe body: %v", err)
+		}
+		if body["smtp_ehlo_domain"] != smtpEhloDomainProbeValue {
+			t.Fatalf("probe key = %v, want %q", body["smtp_ehlo_domain"], smtpEhloDomainProbeValue)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"The smtp ehlo domain field must be a valid hostname."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	AccTestSkipIfNoSMTPEhloDomain(t)
+}
+
+func TestAccTestSMTPEhloDomainAccepted_OK(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"smtp_ehlo_domain":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	if !AccTestSMTPEhloDomainAccepted(t) {
+		t.Fatal("expected 200 PATCH to accept smtp_ehlo_domain")
+	}
+}

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -312,6 +312,16 @@ func TestAccTestSkipIfNoSMTPEhloDomain_ExtraKey(t *testing.T) {
 	if reached {
 		t.Fatal("expected AccTestSkipIfNoSMTPEhloDomain to skip on extra-key 422")
 	}
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "1")
+	reachedTip := false
+	t.Run("skip-under-require-tip", func(t *testing.T) {
+		AccTestSkipIfNoSMTPEhloDomain(t)
+		reachedTip = true
+	})
+	if reachedTip {
+		t.Fatal("smtp_ehlo extra-key 422 must soft-skip under COOLIFY_REQUIRE_TIP_APIS=1")
+	}
 }
 
 func TestAccTestSkipIfNoSMTPEhloDomain_ValidationPresent(t *testing.T) {

--- a/internal/client/instance_email.go
+++ b/internal/client/instance_email.go
@@ -66,8 +66,13 @@ func (c *Client) UpdateInstanceEmailSettings(ctx context.Context, input UpdateIn
 
 // SupportsInstanceEmailSettings reports whether GET/PATCH /settings/email exists.
 // The route landed in Coolify v4.3.10. Empty CoolifyVersion reports true.
+// A 4.3.0 version string also reports true (CI edge version lie; same as
+// SupportsSMTPEhloDomain). Acc tests still GET-probe the route.
 func (c *Client) SupportsInstanceEmailSettings() bool {
 	if c == nil || c.CoolifyVersion == "" {
+		return true
+	}
+	if versionStringLagsTip(c.CoolifyVersion) {
 		return true
 	}
 	return IsVersionAtLeast(c.CoolifyVersion, minSMTPEhloDomainVersion)

--- a/internal/client/instance_email_test.go
+++ b/internal/client/instance_email_test.go
@@ -165,6 +165,8 @@ func TestClient_SupportsInstanceEmailSettings(t *testing.T) {
 		want bool
 	}{
 		{"", true},
+		{"4.3.0", true},
+		{"v4.3.0-edge", true},
 		{"4.3.9", false},
 		{"v4.3.9", false},
 		{"4.3.10", true},

--- a/internal/client/notifications_test.go
+++ b/internal/client/notifications_test.go
@@ -149,6 +149,7 @@ func TestClient_EmailNotifications_SMTPEhloDomainVersionGate(t *testing.T) {
 		wantKey bool
 	}{
 		{"4.3.9 withholds", "4.3.9", false},
+		{"4.3.0 sends (CI edge version lie)", "4.3.0", true},
 		{"4.3.10 sends", "4.3.10", true},
 		{"4.4-rc.1 sends", "4.4-rc.1", true},
 		{"empty version sends", "", true},

--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -102,12 +102,30 @@ func (c *Client) SupportsApplicationSettingsV43() bool {
 // v4.3.9 extra-key 422s.
 const minSMTPEhloDomainVersion = "4.3.10"
 
+// versionStringLagsTip reports GET /api/v1/version values that Coolify
+// :edge has used while already shipping later tip APIs.
+//
+// CI edge has reported "4.3.0" after tag v4.3.10 fields such as
+// smtp_ehlo_domain landed. Treat that string as "maybe tip" so the
+// provider sends the field. A real 4.3.0 install extra-key 422s if the
+// user sets a tip-only attribute.
+func versionStringLagsTip(ver string) bool {
+	v := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(ver)), "v")
+	return strings.HasPrefix(v, "4.3.0")
+}
+
 // SupportsSMTPEhloDomain reports whether the connected instance accepts
 // smtp_ehlo_domain on email notification GET/PATCH.
 //
 // Empty CoolifyVersion reports true (same rationale as SupportsApplicationSettings).
+// A 4.3.0 version string also reports true: CI edge lies with that
+// string while shipping later tip fields. Acc tests must still extra-key
+// probe before writing so a real 4.3.0 extra-key 422 is skipped.
 func (c *Client) SupportsSMTPEhloDomain() bool {
 	if c == nil || c.CoolifyVersion == "" {
+		return true
+	}
+	if versionStringLagsTip(c.CoolifyVersion) {
 		return true
 	}
 	return IsVersionAtLeast(c.CoolifyVersion, minSMTPEhloDomainVersion)

--- a/internal/client/version_gate_test.go
+++ b/internal/client/version_gate_test.go
@@ -185,6 +185,8 @@ func TestSupportsSMTPEhloDomain(t *testing.T) {
 	}{
 		{"4.3.9", false},
 		{"v4.3.9", false},
+		{"4.3.0", true}, // CI edge version lie
+		{"v4.3.0-edge", true},
 		{"4.3.10", true},
 		{"v4.3.10", true},
 		{"4.4.0", true},

--- a/internal/service/instanceemail/data_source_acc_test.go
+++ b/internal/service/instanceemail/data_source_acc_test.go
@@ -1,14 +1,10 @@
 package instanceemail_test
 
 import (
-	"context"
-	"testing"
-	"time"
-
 	"fmt"
+	"testing"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -16,16 +12,6 @@ import (
 func TestAccInstanceEmailSettingsDataSource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	accSkipIfNoInstanceEmailAPI(t)
-	c := acctest.AccTestClient(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	ver, err := c.GetVersion(ctx)
-	if err != nil {
-		t.Fatalf("reading Coolify version: %v", err)
-	}
-	if !client.IsVersionAtLeast(ver, "4.3.10") {
-		t.Skipf("Coolify %s is below 4.3.10; instance email settings not on this version string", ver)
-	}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),

--- a/internal/service/instanceemail/resource_acc_test.go
+++ b/internal/service/instanceemail/resource_acc_test.go
@@ -1,16 +1,13 @@
 package instanceemail_test
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -51,59 +48,54 @@ func accSkipIfNoInstanceEmailAPI(t *testing.T) {
 
 // TestAccInstanceEmailSettingsResource exercises GET/PATCH /settings/email.
 // Soft-skip when the route is missing. Do not use AccTestSkipIfCoolifyBelow(4.3.10):
-// CI edge often reports 4.3.0 and COOLIFY_REQUIRE_TIP_APIS=1 would fail that floor.
+// CI edge often reports 4.3.0. smtp_ehlo_domain is extra-key probed, not
+// version-gated.
 func TestAccInstanceEmailSettingsResource(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	accSkipIfNoInstanceEmailAPI(t)
-	c := acctest.AccTestClient(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	ver, err := c.GetVersion(ctx)
-	if err != nil {
-		t.Fatalf("reading Coolify version: %v", err)
-	}
-	if !client.IsVersionAtLeast(ver, "4.3.10") {
-		t.Skipf("Coolify %s is below 4.3.10; instance email settings not on this version string", ver)
-	}
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: acctest.ConfigProviderBlock() + `
+	steps := []resource.TestStep{
+		{
+			Config: acctest.ConfigProviderBlock() + `
 resource "coolify_instance_email_settings" "test" {
   smtp_enabled    = false
   resend_enabled  = false
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "id", "current"),
-					resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "smtp_enabled", "false"),
-					resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "resend_enabled", "false"),
-				),
-			},
-			{
-				Config: acctest.ConfigProviderBlock() + `
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "id", "current"),
+				resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "smtp_enabled", "false"),
+				resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "resend_enabled", "false"),
+			),
+		},
+	}
+	if acctest.AccTestSMTPEhloDomainAccepted(t) {
+		steps = append(steps, resource.TestStep{
+			Config: acctest.ConfigProviderBlock() + `
 resource "coolify_instance_email_settings" "test" {
   smtp_enabled     = false
   resend_enabled   = false
   smtp_ehlo_domain = "mail.example.com"
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "smtp_ehlo_domain", "mail.example.com"),
-				),
-			},
-			{
-				ResourceName:      "coolify_instance_email_settings.test",
-				ImportState:       true,
-				ImportStateId:     "current",
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"smtp_from_address", "smtp_from_name", "smtp_host",
-					"smtp_username", "smtp_password", "resend_api_key",
-				},
-			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coolify_instance_email_settings.test", "smtp_ehlo_domain", "mail.example.com"),
+			),
+		})
+	}
+	steps = append(steps, resource.TestStep{
+		ResourceName:      "coolify_instance_email_settings.test",
+		ImportState:       true,
+		ImportStateId:     "current",
+		ImportStateVerify: true,
+		ImportStateVerifyIgnore: []string{
+			"smtp_from_address", "smtp_from_name", "smtp_host",
+			"smtp_username", "smtp_password", "resend_api_key",
 		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps:                    steps,
 	})
 }

--- a/internal/service/notificationemail/resource_acc_test.go
+++ b/internal/service/notificationemail/resource_acc_test.go
@@ -1,12 +1,9 @@
 package notificationemail_test
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/acctest"
-	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -67,22 +64,12 @@ resource "coolify_notification_email" "test" {
 }
 
 // TestAccEmailNotificationResource_SMTPEhloDomain writes smtp_ehlo_domain
-// (Coolify tip after #11398). Soft-skip when the instance version string is
-// below 4.3.10. Do not use AccTestSkipIfCoolifyBelow: CI edge often reports
-// 4.3.0 and COOLIFY_REQUIRE_TIP_APIS=1 would fail a 4.3.10 floor.
+// (Coolify tip after #11398). Extra-key PATCH probe, not version string:
+// CI edge often reports 4.3.0 while already accepting the field.
 func TestAccEmailNotificationResource_SMTPEhloDomain(t *testing.T) {
 	acctest.AccTestSkipIfNoTFAcc(t)
 	acctest.AccTestSkipIfNoNotificationAPI(t)
-	c := acctest.AccTestClient(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	ver, err := c.GetVersion(ctx)
-	if err != nil {
-		t.Fatalf("reading Coolify version: %v", err)
-	}
-	if !client.IsVersionAtLeast(ver, "4.3.10") {
-		t.Skipf("smtp_ehlo_domain needs Coolify >= 4.3.10 (instance reports %s)", ver)
-	}
+	acctest.AccTestSkipIfNoSMTPEhloDomain(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),


### PR DESCRIPTION
## Summary

Acceptance tests for `smtp_ehlo_domain` now extra-key PATCH-probe Coolify instead of trusting `GET /version`.

## Problem

CI `coollabsio/coolify:edge` reports Coolify `4.3.0`. A 4.3.10 version skip (or `AccTestSkipIfCoolifyBelow`) never writes the field. With `COOLIFY_REQUIRE_TIP_APIS=1` that skip becomes a hard fail.

## Change

- `AccTestSkipIfNoSMTPEhloDomain` PATCHes an invalid hostname. Extra-key 422 skips (or fails when tip APIs are required). Hostname validation 422 means the field is allowed.
- `SupportsSMTPEhloDomain` / `SupportsInstanceEmailSettings` treat a `4.3.0` version string as maybe-tip so the provider sends the field on CI edge.
- Instance email CRUD no longer version-skips; the smtp_ehlo step is optional when the extra-key probe rejects.

## Validation

- `gofmt` + `golangci-lint` on the touched packages
- `go test` `./internal/acctest/` `./internal/client/` `./internal/service/notificationemail/` `./internal/service/instanceemail/`

Ref #799
