### PR TITLE
fix(ci): upsert one social preview reminder issue

### DIFF
--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -141,12 +141,6 @@ jobs:
           DATASOURCES: ${{ steps.stats.outputs.datasources }}
           TESTS: ${{ steps.stats.outputs.tests }}
         run: |
-          # Close any previous reminder issue
-          gh issue list --label social-preview --state open --json number --jq '.[].number' \
-            | while read -r num; do
-                gh issue close "$num" --comment "Superseded by new release."
-              done
-
           BODY=$(cat <<'ISSUE_BODY'
           ## Upload social preview image
 
@@ -189,7 +183,6 @@ jobs:
           BODY="${BODY}
           **Current stats:** ${RESOURCES} resources, ${DATASOURCES} data sources, ${TESTS} tests"
 
-          gh issue create \
-            --title "Upload social preview image" \
-            --label social-preview \
-            --body "$BODY"
+          BODY_FILE=$(mktemp)
+          printf '%s\n' "$BODY" > "$BODY_FILE"
+          python3 scripts/upsert-social-preview-issue.py --body-file "$BODY_FILE"

--- a/scripts/test_upsert_social_preview_issue.py
+++ b/scripts/test_upsert_social_preview_issue.py
@@ -1,0 +1,119 @@
+"""Tests for upsert-social-preview-issue.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent / "upsert-social-preview-issue.py"
+_spec = importlib.util.spec_from_file_location("upsert_social_preview_issue", _SCRIPT)
+usp = importlib.util.module_from_spec(_spec)
+sys.modules["upsert_social_preview_issue"] = usp
+assert _spec.loader is not None
+_spec.loader.exec_module(usp)
+
+
+class TestPlanUpsert(unittest.TestCase):
+    def test_empty_creates(self) -> None:
+        plan = usp.plan_upsert([])
+        self.assertEqual(plan, {"action": "create", "canonical": None, "close": []})
+
+    def test_one_updates(self) -> None:
+        plan = usp.plan_upsert([{"number": 774, "title": usp.ISSUE_TITLE}])
+        self.assertEqual(plan, {"action": "update", "canonical": 774, "close": []})
+
+    def test_keeps_oldest_closes_extras(self) -> None:
+        plan = usp.plan_upsert(
+            [
+                {"number": 812, "title": usp.ISSUE_TITLE},
+                {"number": 774, "title": usp.ISSUE_TITLE},
+            ]
+        )
+        self.assertEqual(plan["action"], "update")
+        self.assertEqual(plan["canonical"], 774)
+        self.assertEqual(plan["close"], [812])
+
+
+class TestCollectCandidates(unittest.TestCase):
+    def test_unions_title_and_label_and_sorts(self) -> None:
+        got = usp.collect_candidates(
+            [{"number": 812, "title": usp.ISSUE_TITLE}],
+            [{"number": 774, "title": usp.ISSUE_TITLE}],
+        )
+        self.assertEqual([i["number"] for i in got], [774, 812])
+
+    def test_dedupes_same_number(self) -> None:
+        got = usp.collect_candidates(
+            [{"number": 774, "title": usp.ISSUE_TITLE}],
+            [{"number": 774, "title": usp.ISSUE_TITLE}],
+        )
+        self.assertEqual(len(got), 1)
+
+
+class TestUpsert(unittest.TestCase):
+    def test_create_when_none_open(self) -> None:
+        calls: list[list[str]] = []
+
+        def gh(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/org/repo/issues/900\n"
+            raise AssertionError(args)
+
+        plan = usp.upsert("body text", gh=gh)
+        self.assertEqual(plan["action"], "create")
+        create = [c for c in calls if c[:2] == ["issue", "create"]]
+        self.assertEqual(len(create), 1)
+        self.assertIn("--label", create[0])
+        self.assertIn(f"{usp.LABEL},{usp.READY_LABEL}", create[0])
+
+    def test_updates_oldest_and_closes_duplicate(self) -> None:
+        calls: list[list[str]] = []
+
+        def gh(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "list"] and "--search" in args:
+                return json.dumps(
+                    [
+                        {"number": 812, "title": usp.ISSUE_TITLE},
+                        {"number": 774, "title": usp.ISSUE_TITLE},
+                    ]
+                )
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            return ""
+
+        plan = usp.upsert("new body", gh=gh)
+        self.assertEqual(plan["canonical"], 774)
+        self.assertEqual(plan["close"], [812])
+        edits = [c for c in calls if c[:2] == ["issue", "edit"] and c[2] == "774"]
+        self.assertTrue(any("--body" in c for c in edits))
+        closes = [c for c in calls if c[:2] == ["issue", "close"]]
+        self.assertEqual(closes[0][2], "812")
+        self.assertIn("Duplicate of #774", " ".join(closes[0]))
+
+    def test_ignores_other_titles_in_search(self) -> None:
+        def gh(args: list[str]) -> str:
+            if args[:2] == ["issue", "list"] and "--search" in args:
+                return json.dumps(
+                    [
+                        {"number": 1, "title": "Unrelated"},
+                        {"number": 774, "title": usp.ISSUE_TITLE},
+                    ]
+                )
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            return ""
+
+        plan = usp.upsert("body", gh=gh)
+        self.assertEqual(plan["canonical"], 774)
+        self.assertEqual(plan["close"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/upsert-social-preview-issue.py
+++ b/scripts/upsert-social-preview-issue.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Keep a single social-preview upload reminder issue.
+
+The Update Social Preview workflow used to close issues labeled
+social-preview and then create a new one. gh issue create did not apply
+that label (issues landed as needs-triage only), so the close query
+matched nothing and every release opened a duplicate.
+
+This script lists open issues by title and by the social-preview label,
+keeps the oldest as canonical, updates its body, and closes extras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any, Callable
+
+ISSUE_TITLE = "Upload social preview image"
+LABEL = "social-preview"
+READY_LABEL = "ready"
+TRIAGE_LABEL = "needs-triage"
+
+GhFn = Callable[[list[str]], str]
+
+
+def run_gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def parse_issues(raw: str) -> list[dict[str, Any]]:
+    data = json.loads(raw or "[]")
+    if not isinstance(data, list):
+        raise ValueError("expected a JSON array of issues")
+    return data
+
+
+def collect_candidates(
+    by_title: list[dict[str, Any]],
+    by_label: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    seen: dict[int, dict[str, Any]] = {}
+    for issue in by_title + by_label:
+        num = int(issue["number"])
+        seen[num] = issue
+    return sorted(seen.values(), key=lambda i: int(i["number"]))
+
+
+def plan_upsert(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    ordered = sorted(candidates, key=lambda i: int(i["number"]))
+    if not ordered:
+        return {"action": "create", "canonical": None, "close": []}
+    canonical = int(ordered[0]["number"])
+    extras = [int(i["number"]) for i in ordered[1:]]
+    return {"action": "update", "canonical": canonical, "close": extras}
+
+
+def upsert(
+    body: str,
+    *,
+    gh: GhFn = run_gh,
+    title: str = ISSUE_TITLE,
+    label: str = LABEL,
+) -> dict[str, Any]:
+    by_title = parse_issues(
+        gh(
+            [
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--search",
+                f'is:open in:title "{title}"',
+                "--json",
+                "number,title",
+                "--limit",
+                "50",
+            ]
+        )
+    )
+    by_title = [i for i in by_title if i.get("title") == title]
+    by_label = parse_issues(
+        gh(
+            [
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                label,
+                "--json",
+                "number,title",
+                "--limit",
+                "50",
+            ]
+        )
+    )
+    plan = plan_upsert(collect_candidates(by_title, by_label))
+
+    if plan["action"] == "create":
+        out = gh(
+            [
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--label",
+                f"{label},{READY_LABEL}",
+                "--body",
+                body,
+            ]
+        )
+        print(f"created {out.strip()}")
+        return plan
+
+    canonical = plan["canonical"]
+    gh(["issue", "edit", str(canonical), "--body", body])
+    gh(
+        [
+            "issue",
+            "edit",
+            str(canonical),
+            "--add-label",
+            f"{label},{READY_LABEL}",
+            "--remove-label",
+            TRIAGE_LABEL,
+        ]
+    )
+    print(f"updated #{canonical}")
+    for num in plan["close"]:
+        gh(
+            [
+                "issue",
+                "close",
+                str(num),
+                "--reason",
+                "completed",
+                "--comment",
+                f"Duplicate of #{canonical}. One social-preview reminder issue only.",
+            ]
+        )
+        print(f"closed #{num} as duplicate of #{canonical}")
+    return plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", required=True, help="Markdown body to write")
+    args = parser.parse_args(argv)
+    with open(args.body_file, encoding="utf-8") as fh:
+        body = fh.read()
+    upsert(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Keep a single social-preview upload reminder issue instead of opening a new one on every release.

## Problem

`.github/workflows/update-social-preview.yml` closed issues labeled `social-preview`, then ran `gh issue create --label social-preview`. The created issues only received `needs-triage` (Issue Triage treats the App as external). The close query matched nothing, so #774 stayed open and #812 was opened with the same title.

## Change

- `scripts/upsert-social-preview-issue.py` finds open issues by title and by the `social-preview` label, keeps the oldest, updates the body, and closes extras.
- Workflow calls that script.
- Unit tests cover create, update, and duplicate-close.
- #812 is already closed as a duplicate of #774.

## Validation

`python3 -m unittest scripts.test_upsert_social_preview_issue -v`

Ref #774
