### PR TITLE
fix: wait for social preview confirm before leaving Settings

### DIFF
--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -162,6 +162,9 @@ jobs:
           python3 scripts/upload-social-preview.py
           ```
 
+          The script waits for `PUT /upload/repository-images/` 200. Stay on
+          Settings until it prints `OK:`. A new `og:image` URL is not enough.
+
           > **Skill reference:** `~/.grok/skills/github-web-admin/SKILL.md`
           > (section "Automating social preview updates in CI")
 
@@ -171,11 +174,12 @@ jobs:
           2. Scroll to **Social preview**
           3. Click **Edit** > **Upload an image...**
           4. Select `assets/social-preview.png` from your local checkout (after `git pull`)
-          5. Done
+          5. Wait until the preview box shows the image after a reload (not only the local file picker preview)
 
           ### Verify
 
-          Share the repo URL in a Discord/Slack DM to yourself. The preview card should show the updated stats.
+          `curl -sI` the `og:image` URL. Success is HTTP 200 and `content-type: image/`.
+          Then share the repo URL in a Discord/Slack DM. The card should show the new stats.
 
           ISSUE_BODY
           )

--- a/scripts/test_upload_social_preview.py
+++ b/scripts/test_upload_social_preview.py
@@ -1,0 +1,96 @@
+"""Tests for upload-social-preview.py helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent / "upload-social-preview.py"
+_spec = importlib.util.spec_from_file_location("upload_social_preview", _SCRIPT)
+usp = importlib.util.module_from_spec(_spec)
+sys.modules["upload_social_preview"] = usp
+assert _spec.loader is not None
+_spec.loader.exec_module(usp)
+
+
+class TestIsAuthGate(unittest.TestCase):
+    def test_login_url(self) -> None:
+        self.assertTrue(usp.is_auth_gate("https://github.com/login", ""))
+
+    def test_confirm_access_heading(self) -> None:
+        self.assertTrue(
+            usp.is_auth_gate(
+                "https://github.com/coolify-terraform/terraform-provider-coolify/settings",
+                "Confirm access",
+            )
+        )
+
+    def test_settings_ok(self) -> None:
+        self.assertFalse(
+            usp.is_auth_gate(
+                "https://github.com/coolify-terraform/terraform-provider-coolify/settings",
+                "Settings: coolify-terraform/terraform-provider-coolify",
+            )
+        )
+
+
+class TestIsConfirmResponse(unittest.TestCase):
+    def test_put_200(self) -> None:
+        self.assertTrue(
+            usp.is_confirm_response(
+                "PUT",
+                "https://github.com/upload/repository-images/1969309",
+                200,
+            )
+        )
+
+    def test_policy_post_is_not_confirm(self) -> None:
+        self.assertFalse(
+            usp.is_confirm_response(
+                "POST",
+                "https://github.com/upload/policies/repository-images",
+                201,
+            )
+        )
+
+    def test_put_error_is_not_confirm(self) -> None:
+        self.assertFalse(
+            usp.is_confirm_response(
+                "PUT",
+                "https://github.com/upload/repository-images/1",
+                422,
+            )
+        )
+
+
+class TestPublicPreviewOk(unittest.TestCase):
+    def test_png_200(self) -> None:
+        self.assertTrue(usp.public_preview_ok(200, "image/png"))
+
+    def test_azure_404_html_is_not_proof(self) -> None:
+        self.assertFalse(usp.public_preview_ok(404, "text/html"))
+
+    def test_og_url_host_alone_is_not_enough(self) -> None:
+        # Callers must check HTTP status, not only "repository-images" in URL.
+        self.assertFalse(usp.public_preview_ok(200, "text/html"))
+
+
+class TestExtractConfirmHref(unittest.TestCase):
+    def test_href(self) -> None:
+        href = usp.extract_confirm_href(
+            {
+                "id": 1,
+                "href": "https://repository-images.githubusercontent.com/1/abc",
+            }
+        )
+        self.assertIn("repository-images", href)
+
+    def test_empty(self) -> None:
+        self.assertEqual(usp.extract_confirm_href(None), "")
+        self.assertEqual(usp.extract_confirm_href({}), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_upsert_social_preview_issue.py
+++ b/scripts/test_upsert_social_preview_issue.py
@@ -21,6 +21,13 @@ class TestPlanUpsert(unittest.TestCase):
         plan = usp.plan_upsert([])
         self.assertEqual(plan, {"action": "create", "canonical": None, "close": []})
 
+    def test_closed_only_reopens_oldest(self) -> None:
+        plan = usp.plan_upsert(
+            [],
+            [{"number": 812, "title": usp.ISSUE_TITLE}, {"number": 774, "title": usp.ISSUE_TITLE}],
+        )
+        self.assertEqual(plan, {"action": "reopen", "canonical": 774, "close": []})
+
     def test_one_updates(self) -> None:
         plan = usp.plan_upsert([{"number": 774, "title": usp.ISSUE_TITLE}])
         self.assertEqual(plan, {"action": "update", "canonical": 774, "close": []})
@@ -113,6 +120,25 @@ class TestUpsert(unittest.TestCase):
         plan = usp.upsert("body", gh=gh)
         self.assertEqual(plan["canonical"], 774)
         self.assertEqual(plan["close"], [])
+
+    def test_reopens_closed_singleton(self) -> None:
+        calls: list[list[str]] = []
+
+        def gh(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "list"] and "--state" in args:
+                idx = args.index("--state")
+                if args[idx + 1] == "closed":
+                    return json.dumps([{"number": 774, "title": usp.ISSUE_TITLE}])
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            return ""
+
+        plan = usp.upsert("body after next stats change", gh=gh)
+        self.assertEqual(plan["action"], "reopen")
+        self.assertEqual(plan["canonical"], 774)
+        self.assertTrue(any(c[:3] == ["issue", "reopen", "774"] for c in calls))
+        self.assertFalse(any(c[:2] == ["issue", "create"] for c in calls))
 
 
 if __name__ == "__main__":

--- a/scripts/upload-social-preview.py
+++ b/scripts/upload-social-preview.py
@@ -4,6 +4,11 @@
 GitHub has no API for social preview upload. This script automates the
 web UI via Chrome Remote Debugging (CDP).
 
+The file-attachment widget is: POST /upload/policies/repository-images,
+POST the file to S3, then PUT /upload/repository-images/{id}. That PUT
+is the confirm. Leaving the settings page before it returns 200 aborts
+the blob. A new og:image URL is not proof the public PNG exists.
+
 Requires:
   - Chrome running with --remote-debugging-port=9222
   - Signed in to GitHub in the Chrome profile
@@ -13,46 +18,90 @@ Usage:
   python3 scripts/upload-social-preview.py
 """
 
+from __future__ import annotations
+
 import os
 import sys
-
-from playwright.sync_api import sync_playwright
+import threading
+from typing import Any
 
 REPO = "coolify-terraform/terraform-provider-coolify"
 IMAGE_PATH = os.path.join(os.path.dirname(__file__), "..", "assets", "social-preview.png")
 
 
-def main():
+def is_auth_gate(url: str, heading: str) -> bool:
+    """True when the tab is login, OAuth, or sudo Confirm access."""
+    lower = (url or "").lower()
+    if any(
+        s in lower
+        for s in ("github.com/login", "/login/oauth", "confirm_access", "/sessions")
+    ):
+        return True
+    return (heading or "").strip() in (
+        "Sign in to GitHub",
+        "Confirm access",
+        "Authorize",
+    )
+
+
+def is_confirm_response(method: str, url: str, status: int) -> bool:
+    """True when GitHub accepted the uploaded repository image asset."""
+    return (
+        (method or "").upper() == "PUT"
+        and "/upload/repository-images/" in (url or "")
+        and status == 200
+    )
+
+
+def public_preview_ok(status: int, content_type: str) -> bool:
+    """True when the public repository-images URL actually serves an image."""
+    return status == 200 and "image/" in (content_type or "")
+
+
+def extract_confirm_href(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    href = payload.get("href")
+    return href if isinstance(href, str) else ""
+
+
+def main() -> None:
+    from playwright.sync_api import sync_playwright
+
     image = os.path.abspath(IMAGE_PATH)
     if not os.path.exists(image):
         print(f"Image not found: {image}", file=sys.stderr)
         sys.exit(1)
 
     with sync_playwright() as p:
-        browser = p.chromium.connect_over_cdp("http://localhost:9222")
+        browser = p.chromium.connect_over_cdp("http://localhost:9222", timeout=5000)
         if not browser.contexts:
-            print("No browser contexts found. Open at least one tab in Chrome and try again.", file=sys.stderr)
+            print(
+                "No browser contexts found. Open at least one tab in Chrome and try again.",
+                file=sys.stderr,
+            )
             browser.close()
             sys.exit(1)
         context = browser.contexts[0]
         page = context.new_page()
+        confirmed: dict[str, Any] = {"href": ""}
+        done = threading.Event()
         try:
-            print(f"Navigating to https://github.com/{REPO}/settings ...")
+            print(f"PLAN: upload {image}")
+            print(f"DO: navigate https://github.com/{REPO}/settings")
             page.goto(
                 f"https://github.com/{REPO}/settings",
                 wait_until="domcontentloaded",
                 timeout=60000,
             )
 
-            # Check for login redirect
-            if "login" in page.url or "session" in page.url:
-                print(
-                    "Not signed in to GitHub. Please sign in via the Chrome window.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+            heading = page.evaluate(
+                "() => ((document.querySelector('h1')||{}).innerText||'')"
+            )
+            if is_auth_gate(page.url, heading):
+                print(f"LOGIN_IN_PROGRESS url={page.url} heading={heading!r}")
+                sys.exit(2)
 
-            # Wait for the Social preview heading
             page.wait_for_function(
                 "() => [...document.querySelectorAll('h2')]"
                 ".some(h => h.textContent.includes('Social preview'))",
@@ -60,7 +109,19 @@ def main():
                 timeout=15000,
             )
 
-            # Scroll to it
+            def on_response(resp: Any) -> None:
+                if not is_confirm_response(resp.request.method, resp.url, resp.status):
+                    return
+                href = ""
+                try:
+                    href = extract_confirm_href(resp.json())
+                except Exception:
+                    href = ""
+                confirmed["href"] = href
+                done.set()
+
+            page.on("response", on_response)
+
             page.evaluate(
                 """() => {
                 for (const h of document.querySelectorAll('h2')) {
@@ -72,42 +133,24 @@ def main():
             }"""
             )
 
-            # Open the Edit dropdown
             page.locator("summary:has-text('Edit')").first.click()
-
-            # Upload via file chooser
             with page.expect_file_chooser() as fc_info:
                 page.locator("label[for='repo-image-file-input']").click()
             fc_info.value.set_files(image)
+            print("DO: file selected; waiting for PUT /upload/repository-images/")
 
-            # Wait for upload processing
-            page.wait_for_function(
-                "() => {"
-                "  const fa = document.querySelector("
-                "    'file-attachment.js-upload-repository-image');"
-                "  return fa && !fa.classList.contains('is-default');"
-                "}",
-                polling=500,
-                timeout=15000,
+            if not done.wait(20):
+                print(
+                    "FAIL: confirm PUT /upload/repository-images/ did not return 200",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            print(f"OK: confirm 200 href={confirmed['href']}")
+            print(
+                "NEXT: GET the href; success is image/* 200, "
+                "not merely a repository-images og:image URL"
             )
-
-            print("Social preview uploaded successfully.")
-
-            # Verify via og:image
-            page.goto(
-                f"https://github.com/{REPO}",
-                wait_until="domcontentloaded",
-                timeout=30000,
-            )
-            og = page.evaluate(
-                "() => document.querySelector("
-                "'meta[property=\"og:image\"]')?.content"
-            )
-            if og and "repository-images" in og:
-                print(f"Verified: {og}")
-            else:
-                print(f"Warning: og:image may not have updated yet: {og}")
-
         finally:
             page.close()
             browser.close()

--- a/scripts/upsert-social-preview-issue.py
+++ b/scripts/upsert-social-preview-issue.py
@@ -8,6 +8,8 @@ matched nothing and every release opened a duplicate.
 
 This script lists open issues by title and by the social-preview label,
 keeps the oldest as canonical, updates its body, and closes extras.
+If none are open, it reopens the oldest closed issue with that title
+instead of creating a new number.
 """
 
 from __future__ import annotations

--- a/scripts/upsert-social-preview-issue.py
+++ b/scripts/upsert-social-preview-issue.py
@@ -54,13 +54,23 @@ def collect_candidates(
     return sorted(seen.values(), key=lambda i: int(i["number"]))
 
 
-def plan_upsert(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+def plan_upsert(
+    candidates: list[dict[str, Any]],
+    closed: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     ordered = sorted(candidates, key=lambda i: int(i["number"]))
-    if not ordered:
-        return {"action": "create", "canonical": None, "close": []}
-    canonical = int(ordered[0]["number"])
-    extras = [int(i["number"]) for i in ordered[1:]]
-    return {"action": "update", "canonical": canonical, "close": extras}
+    if ordered:
+        canonical = int(ordered[0]["number"])
+        extras = [int(i["number"]) for i in ordered[1:]]
+        return {"action": "update", "canonical": canonical, "close": extras}
+    closed_ordered = sorted(closed or [], key=lambda i: int(i["number"]))
+    if closed_ordered:
+        return {
+            "action": "reopen",
+            "canonical": int(closed_ordered[0]["number"]),
+            "close": [],
+        }
+    return {"action": "create", "canonical": None, "close": []}
 
 
 def upsert(
@@ -103,7 +113,42 @@ def upsert(
             ]
         )
     )
-    plan = plan_upsert(collect_candidates(by_title, by_label))
+    closed = parse_issues(
+        gh(
+            [
+                "issue",
+                "list",
+                "--state",
+                "closed",
+                "--search",
+                f'in:title "{title}"',
+                "--json",
+                "number,title",
+                "--limit",
+                "50",
+            ]
+        )
+    )
+    closed = [i for i in closed if i.get("title") == title]
+    plan = plan_upsert(collect_candidates(by_title, by_label), closed)
+
+    if plan["action"] == "reopen":
+        canonical = plan["canonical"]
+        gh(["issue", "reopen", str(canonical)])
+        gh(["issue", "edit", str(canonical), "--body", body])
+        gh(
+            [
+                "issue",
+                "edit",
+                str(canonical),
+                "--add-label",
+                f"{label},{READY_LABEL}",
+                "--remove-label",
+                TRIAGE_LABEL,
+            ]
+        )
+        print(f"reopened #{canonical}")
+        return plan
 
     if plan["action"] == "create":
         out = gh(


### PR DESCRIPTION
## Description

Wait for GitHub's `PUT /upload/repository-images/{id}` 200 before leaving Settings. A new `og:image` host is not proof the public PNG exists.

If the reminder issue is closed, reopen the oldest issue with that title instead of creating a new number.

## The problem

`scripts/upload-social-preview.py` treated `file-attachment` class changes and a `repository-images` `og:image` URL as success, then navigated away. That can abort confirm. GitHub can then record the new image id while Azure still 404s.

The upsert path only listed open issues, so closing #774 would open a new reminder.

## The change

- Wait for confirm PUT 200. Stay on Settings. Detect login/sudo.
- Helpers + unit tests for auth gate, confirm response, and public `image/*` 200.
- Upsert reopens the oldest closed title match.
- Reminder issue body: success is `curl -sI` `image/*`, not only a Discord card.

## Validation

`python3 -m unittest scripts.test_upload_social_preview scripts.test_upsert_social_preview_issue`

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated
- [ ] `make test` passes locally (Python scripts only; no Go change)
- [ ] `make fmt` ran (gofmt + go mod tidy)
- [ ] Documentation updated (if adding/changing resources or data sources)
- [ ] `make docs` regenerated (if templates changed)
- [ ] Examples updated (if adding new resources)
- [ ] CHANGELOG.md updated
- [x] No breaking changes to existing resources

Ref #774
Ref #816
