### PR TITLE
fix(service): preserve configured urls order on read-back

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -490,7 +490,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 45/45 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 149
+- **Total acceptance test functions**: 150
 
 ### Primary-field update coverage
 
@@ -505,7 +505,7 @@ Known splits:
 | All 8 `coolify_database_*` | Create POST accepts `limits_*`. Post-create PATCH sends remaining allow-list fields only. Coolify PATCH `$allowedFields` rejects `is_log_drain_enabled`, `is_include_timestamps`, `enable_ssl`, and other UI-only keys. | Every `TestAcc*DatabaseResource_CRUD` must set and update `limits_memory`. Shared mock PATCH must 422 extra keys. Guard: `TestDatabaseCRUDFiles_SetLimitsMemory`. |
 | `coolify_application` (public git), `coolify_application_private_git`, `coolify_application_github_app` | PATCH accepts `ports_exposes`; description-only Update never proves that write path | Acc CRUD must change `ports_exposes` (3000 to 8080). Guard: `TestApplicationCRUDFiles_UpdatePrimaryField`. |
 | `coolify_application_dockerfile` | Coolify may override `ports_exposes`; health check path is on PATCH `$allowedFields` | Acc CRUD must set and update `health_check_path`. Same guard as above. |
-| `coolify_service` | Create POST accepts `type` plus compose fields. PATCH `$allowedFields` is name/description/compose/network/urls only. Extra keys 422. | `TestAccServiceResource_CreateImport` must change `name`. Guard: `TestServiceCRUDFiles_UpdatePrimaryField`. Write-path: `TestWriteCoverage_ServiceUpdateNoExtraKeys`. |
+| `coolify_service` | Create POST accepts `type` plus compose fields. PATCH `$allowedFields` is name/description/compose/network/urls only. Extra keys 422. GET `applications` order can differ from HCL `urls`. | `TestAccServiceResource_CreateImport` must change `name`. `TestAccServiceResource_URLsOrder` sets two compose services with `urls` in reverse compose order. Guard: `TestServiceCRUDFiles_UpdatePrimaryField`. Write-path: `TestWriteCoverage_ServiceUpdateNoExtraKeys`. |
 
 Description-only Update steps that remain (no known create/update validator
 split on the primary field):

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -69,7 +69,7 @@ resource "coolify_service" "custom" {
 - `name` (String) The name of the service.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `type` (String) The service type from the Coolify service catalog (e.g., `plausible`, `uptime-kuma`, `minio`). Mutually exclusive with `docker_compose_raw`. See the full list in the Coolify UI under Services > New Service, or in the [Coolify source](https://github.com/coollabsio/coolify/tree/v4.x/templates/service). Changing this forces a new resource.
-- `urls` (Attributes List) Domain URL mappings for service containers. Each entry maps a compose service name to one or more comma-separated URLs (e.g., `https://app.example.com`). Read-back reconstructs mappings from the service's application FQDNs. (see [below for nested schema](#nestedatt--urls))
+- `urls` (Attributes List) Domain URL mappings for service containers. Each entry maps a compose service name to one or more comma-separated URLs (e.g., `https://app.example.com`). Read-back matches Coolify application FQDNs by container name and keeps this list's configured order. Coolify GET may return applications in a different order (typically compose or database insertion order). (see [below for nested schema](#nestedatt--urls))
 
 ### Read-Only
 

--- a/internal/service/service/flatten_test.go
+++ b/internal/service/service/flatten_test.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlattenServiceURLs_PreservesConfigOrder(t *testing.T) {
+	t.Parallel()
+
+	current := []serviceURLModel{
+		{Name: types.StringValue("zebra"), URL: types.StringValue("https://zebra.example.com")},
+		{Name: types.StringValue("alpha"), URL: types.StringValue("https://alpha.example.com")},
+	}
+	apps := []client.ServiceApplication{
+		{Name: "alpha", FQDN: "https://alpha.example.com"},
+		{Name: "zebra", FQDN: "https://zebra.example.com"},
+	}
+
+	got := flattenServiceURLs(apps, current)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name.ValueString() != "zebra" || got[1].Name.ValueString() != "alpha" {
+		t.Fatalf("order = [%s, %s], want [zebra, alpha]",
+			got[0].Name.ValueString(), got[1].Name.ValueString())
+	}
+	if got[0].URL.ValueString() != "https://zebra.example.com" {
+		t.Fatalf("zebra url = %q", got[0].URL.ValueString())
+	}
+}
+
+func TestFlattenServiceURLs_NilCurrentStaysNil(t *testing.T) {
+	t.Parallel()
+	apps := []client.ServiceApplication{{Name: "web", FQDN: "https://auto.example.com"}}
+	if got := flattenServiceURLs(apps, nil); got != nil {
+		t.Fatalf("got %#v, want nil", got)
+	}
+}
+
+func TestFlattenServiceURLs_EmptyAppsKeepsCurrent(t *testing.T) {
+	t.Parallel()
+	current := []serviceURLModel{
+		{Name: types.StringValue("web"), URL: types.StringValue("https://app.example.com")},
+	}
+	got := flattenServiceURLs(nil, current)
+	if len(got) != 1 || got[0].Name.ValueString() != "web" {
+		t.Fatalf("got %#v, want current", got)
+	}
+}
+
+func TestFlattenServiceURLs_DropsAPIExtras(t *testing.T) {
+	t.Parallel()
+	current := []serviceURLModel{
+		{Name: types.StringValue("web"), URL: types.StringValue("https://web.example.com")},
+	}
+	apps := []client.ServiceApplication{
+		{Name: "db", FQDN: "https://db.example.com"},
+		{Name: "web", FQDN: "https://web.example.com"},
+	}
+	got := flattenServiceURLs(apps, current)
+	if len(got) != 1 || got[0].Name.ValueString() != "web" {
+		t.Fatalf("got %#v, want only web", got)
+	}
+}
+
+func TestFlattenServiceURLs_KeepsConfiguredWhenAPIMissing(t *testing.T) {
+	t.Parallel()
+	current := []serviceURLModel{
+		{Name: types.StringValue("web"), URL: types.StringValue("https://web.example.com")},
+		{Name: types.StringValue("api"), URL: types.StringValue("https://api.example.com")},
+	}
+	apps := []client.ServiceApplication{
+		{Name: "web", FQDN: "https://web.example.com"},
+	}
+	got := flattenServiceURLs(apps, current)
+	if len(got) != 2 || got[1].Name.ValueString() != "api" {
+		t.Fatalf("got %#v, want web then api", got)
+	}
+}
+
+func TestFlattenServiceURLs_PreservesEquivalentCommaOrder(t *testing.T) {
+	t.Parallel()
+	configured := "https://qbt.example.com:8080,https://prowlarr.example.com:9696"
+	current := []serviceURLModel{
+		{Name: types.StringValue("gluetun"), URL: types.StringValue(configured)},
+	}
+	apps := []client.ServiceApplication{
+		{Name: "gluetun", FQDN: "https://prowlarr.example.com:9696,https://qbt.example.com:8080"},
+	}
+	got := flattenServiceURLs(apps, current)
+	if len(got) != 1 {
+		t.Fatalf("len = %d", len(got))
+	}
+	if got[0].URL.ValueString() != configured {
+		t.Fatalf("url = %q, want configured order", got[0].URL.ValueString())
+	}
+}
+
+func TestFlattenServiceURLs_UsesAPIWhenURLChanges(t *testing.T) {
+	t.Parallel()
+	current := []serviceURLModel{
+		{Name: types.StringValue("web"), URL: types.StringValue("https://old.example.com")},
+	}
+	apps := []client.ServiceApplication{
+		{Name: "web", FQDN: "https://new.example.com"},
+	}
+	got := flattenServiceURLs(apps, current)
+	if got[0].URL.ValueString() != "https://new.example.com" {
+		t.Fatalf("url = %q, want API value", got[0].URL.ValueString())
+	}
+}

--- a/internal/service/service/resource.go
+++ b/internal/service/service/resource.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/client"
@@ -195,7 +197,8 @@ func (r *serviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 			},
 			"urls": schema.ListNestedAttribute{
 				MarkdownDescription: "Domain URL mappings for service containers. Each entry maps a compose service name to one or more comma-separated URLs (e.g., `https://app.example.com`). " +
-					"Read-back reconstructs mappings from the service's application FQDNs.",
+					"Read-back matches Coolify application FQDNs by container name and keeps this list's configured order. " +
+					"Coolify GET may return applications in a different order (typically compose or database insertion order).",
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -532,6 +535,9 @@ func flattenService(svc *client.Service, model *serviceResourceModel) {
 // auto-assigns FQDNs to catalog services, so the API may return application
 // FQDNs even when the user didn't set urls. Without this guard, the flatten
 // causes "inconsistent result after apply" (plan had null, state has values).
+//
+// Coolify GET loads applications as an unordered hasMany, so API list order
+// can differ from HCL. Match by container name and keep the configured order.
 func flattenServiceURLs(apps []client.ServiceApplication, current []serviceURLModel) []serviceURLModel {
 	if current == nil {
 		// User didn't configure urls; don't populate from API.
@@ -540,20 +546,53 @@ func flattenServiceURLs(apps []client.ServiceApplication, current []serviceURLMo
 	if len(apps) == 0 {
 		return current
 	}
-	var urls []serviceURLModel
+	byName := make(map[string]client.ServiceApplication, len(apps))
 	for _, app := range apps {
-		if app.FQDN != "" {
-			urls = append(urls, serviceURLModel{
-				Name: types.StringValue(app.Name),
-				URL:  types.StringValue(app.FQDN),
-			})
+		if app.Name == "" {
+			continue
 		}
+		byName[app.Name] = app
 	}
-	if len(urls) > 0 {
-		return urls
+	out := make([]serviceURLModel, 0, len(current))
+	for _, cfg := range current {
+		app, ok := byName[cfg.Name.ValueString()]
+		if !ok || app.FQDN == "" {
+			out = append(out, cfg)
+			continue
+		}
+		url := types.StringValue(app.FQDN)
+		if serviceURLEquivalent(cfg.URL.ValueString(), app.FQDN) {
+			url = cfg.URL
+		}
+		out = append(out, serviceURLModel{
+			Name: cfg.Name,
+			URL:  url,
+		})
 	}
-	// User had URLs configured but API shows none now (cleared externally).
-	return nil
+	return out
+}
+
+// serviceURLEquivalent treats comma-separated FQDN lists as the same when they
+// contain the same URLs after trim and case fold, regardless of list order.
+func serviceURLEquivalent(configured, api string) bool {
+	if configured == api || strings.EqualFold(configured, api) {
+		return true
+	}
+	return serviceURLTokenKey(configured) == serviceURLTokenKey(api)
+}
+
+func serviceURLTokenKey(s string) string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, strings.ToLower(p))
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 // expandServiceURLs converts the Terraform model to the client input format.

--- a/internal/service/service/resource_acc_test.go
+++ b/internal/service/service/resource_acc_test.go
@@ -74,6 +74,67 @@ resource "coolify_service" "test" {
 `, projectName, serverUUID, serviceName, description)
 }
 
+func TestAccServiceResource_URLsOrder(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	serverUUID := acctest.AccTestServerUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-svc-urls")
+	suffix := acctest.RandomWithPrefix("tf")
+	zebraURL := fmt.Sprintf("https://zebra-%s.example.com", suffix)
+	alphaURL := fmt.Sprintf("https://alpha-%s.example.com", suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.AccCheckDestroy("coolify_service", "/api/v1/services/"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceURLsOrderConfig(name, serverUUID, zebraURL, alphaURL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coolify_service.test", "uuid"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.#", "2"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.name", "zebra"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.url", zebraURL),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.1.name", "alpha"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.1.url", alphaURL),
+				),
+			},
+			{
+				Config:             testAccServiceURLsOrderConfig(name, serverUUID, zebraURL, alphaURL),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccServiceURLsOrderConfig(projectName, serverUUID, zebraURL, alphaURL string) string {
+	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
+resource "coolify_project" "test" {
+  name = %[1]q
+}
+
+resource "coolify_service" "test" {
+  name               = %[1]q
+  project_uuid       = coolify_project.test.uuid
+  server_uuid        = %[2]q
+  instant_deploy     = false
+  docker_compose_raw = <<-EOT
+services:
+  alpha:
+    image: nginx:alpine
+  zebra:
+    image: nginx:alpine
+EOT
+
+  urls = [
+    { name = "zebra", url = %[3]q },
+    { name = "alpha", url = %[4]q },
+  ]
+}
+`, projectName, serverUUID, zebraURL, alphaURL)
+}
+
 func TestAccServiceDataSources(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)

--- a/internal/service/service/resource_test.go
+++ b/internal/service/service/resource_test.go
@@ -1077,6 +1077,105 @@ resource "coolify_service" "test" {
 	})
 }
 
+// TestServiceResource_URLsPreservesConfigOrder is the #818 regression:
+// Coolify GET returns applications in a different order than HCL urls.
+func TestServiceResource_URLsPreservesConfigOrder(t *testing.T) {
+	t.Parallel()
+	mu := sync.Mutex{}
+	deleted := false
+	svcUUID := "svc-urls-order-001"
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/services":
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, `{"error":"invalid json body"}`, http.StatusBadRequest)
+				return
+			}
+			urls, ok := body["urls"].([]interface{})
+			if !ok || len(urls) != 2 {
+				t.Errorf("POST urls = %#v, want 2 entries", body["urls"])
+			} else {
+				first, _ := urls[0].(map[string]interface{})
+				if first["name"] != "zebra" {
+					t.Errorf("POST urls[0].name = %v, want zebra", first["name"])
+				}
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"uuid": svcUUID})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", svcUUID):
+			if deleted {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+			// Alphabetical / insertion order, opposite of the HCL list.
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             svcUUID,
+				"name":             "torrents",
+				"project_uuid":     "aaaa0001-0001-4000-8000-000000000001",
+				"server_uuid":      "bbbb0001-0001-4000-8000-000000000001",
+				"environment_name": "production",
+				"applications": []map[string]interface{}{
+					{"name": "alpha", "fqdn": "https://alpha.example.com"},
+					{"name": "zebra", "fqdn": "https://zebra.example.com"},
+				},
+			})
+
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/api/v1/services/"):
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"uuid": svcUUID})
+
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/api/v1/services/%s", svcUUID):
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+
+	cfg := acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_service" "test" {
+  project_uuid       = "aaaa0001-0001-4000-8000-000000000001"
+  server_uuid        = "bbbb0001-0001-4000-8000-000000000001"
+  docker_compose_raw = "services:\n  alpha:\n    image: nginx\n  zebra:\n    image: nginx\n"
+
+  urls = [
+    { name = "zebra", url = "https://zebra.example.com" },
+    { name = "alpha", url = "https://alpha.example.com" },
+  ]
+}
+`
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_service.test", "uuid", svcUUID),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.#", "2"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.name", "zebra"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.0.url", "https://zebra.example.com"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.1.name", "alpha"),
+					resource.TestCheckResourceAttr("coolify_service.test", "urls.1.url", "https://alpha.example.com"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // ---------------------------------------------------------------------------
 // TestServiceResource_CreateAPIError
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`coolify_service.urls` no longer fails apply when Coolify returns applications in a different order than HCL.

## Problem

`GET /services/{uuid}` loads `applications` as an unordered `hasMany`. The provider rebuilt `urls` from that list index-by-index. Terraform then rejected the apply with "inconsistent result after apply" even when the name/URL pairs were unchanged.

This is a provider flatten bug. It exists on every Coolify version this provider supports (v4.1.0 through current v4.3.x). Reported against provider 0.1.17 and Coolify v4.3.11.

## Change

- Match application FQDNs by container name
- Keep the configured `urls` list order
- Treat comma-separated FQDN lists as the same when they contain the same URLs after trim and case fold
- Still skip populating `urls` when the user did not set them (catalog auto-FQDNs)

## Validation

- Flatten unit tests first failed on current `main` (API order, extras, missing names, comma-order), then passed after the fix
- Resource unit test: mock GET returns `alpha` then `zebra`; HCL is `zebra` then `alpha`; apply and idempotency succeed
- Full `internal/service/service` unit suite passed (`go test -skip TestAcc`, 275s)
- `golangci-lint run ./internal/service/service/` clean
- Local reviewer: 0 issues

Acceptance coverage: `TestAccServiceResource_URLsOrder` creates a two-service compose with `urls` in reverse compose order.

Closes #818
