### PR TITLE
feat: pin Coolify v4.3.14 and prove list-order flatten

### DIFF
--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -45,6 +45,7 @@ data "coolify_application" "example" {
 - `is_consistent_container_name_enabled` (Boolean) Whether Coolify uses a consistent container name for this application. Coolify default is `false`. Set to `true` for apps that keep an exclusive file lock on a persistent volume (SQLite, DuckDB, LMDB, BoltDB). A fixed name makes Docker refuse a second container on the same mounts, so Coolify falls back to stop-then-start instead of a rolling update that would leave the new container unable to open the store while still reporting a successful deploy. Requires Coolify >= v4.3.0.
 - `max_restart_count` (Number) The maximum number of container restarts before Coolify stops the application.
 - `name` (String) The name of the application.
+- `noindex_domains` (List of String) Subset of application domain URLs served with an `X-Robots-Tag: noindex, nofollow` response header (keeps them out of search engines). Entries that are not among the application domains are ignored by Coolify. Requires Coolify >= v4.3.0. Omitted or empty on GET from older Coolify instances.
 - `ports_exposes` (String) The exposed ports.
 - `project_uuid` (String) The UUID of the project the application belongs to.
 - `server_uuid` (String) The UUID of the server the application is deployed on.

--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -13,7 +13,7 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.3.10` | Extracted from: `coollabsio/coolify@v4.3.10`
+Contract version: `v4.3.14` | Extracted from: `coollabsio/coolify@v4.3.14`
 
 ## Summary
 

--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -303,6 +303,10 @@ value the API returned on Read. Common triggers:
   a URL prefix, base64-encoded content)
 - **Default mismatch:** the provider's schema default differs from
   Coolify's actual default
+- **List reorder on `urls` / `noindex_domains`:** Coolify GET may return
+  these lists in a different order than HCL. The provider keeps the HCL
+  order when the set of values matches. If you still see this on an
+  older provider, upgrade, or reorder HCL to match GET as a workaround.
 
 **Fix:**
 1. Upgrade to a `root` API token (fixes most sensitive field issues)
@@ -310,6 +314,8 @@ value the API returned on Read. Common triggers:
    [API Behaviors](/#coolify-api-behaviors) in the docs index)
 3. If the field is a password you set, the token permissions are the
    most likely cause
+4. On `urls` or `noindex_domains`, upgrade the provider (it keeps HCL
+   order) or temporarily match HCL to the GET order
 
 ### Unexpected public domain (`sslip.io` or wildcard FQDN)
 

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -37,7 +37,8 @@ output "coolify_version" {
 | **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
 | **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
-| **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
+| **≥ 4.3.0** | 4.3 application settings, `noindex_domains`, notification channels, S3, volume backup schedules, GPU/log-drain, etc. |
+| **≥ 4.3.10** | Instance email settings and `smtp_ehlo_domain` on team email notifications. Recommended for the full feature set. |
 
 Pinned API contract today: Coolify **v4.3.14** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
@@ -196,7 +197,7 @@ PATCH if any disallowed field is present, so the provider strips them.
 | Topic | Guidance |
 |-------|----------|
 | Minimum Coolify for this provider | **4.1.0** |
-| Recommended Coolify for full feature set | **≥ 4.3.14** (matches current pin) |
+| Recommended Coolify for full feature set | **≥ 4.3.10** |
 | Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
 
 Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -39,14 +39,14 @@ output "coolify_version" {
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
 | **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
 
-Pinned API contract today: Coolify **v4.3.10** (`testdata/contracts/coolify-v4.json`).
+Pinned API contract today: Coolify **v4.3.14** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
 accept `is_force_https_enabled` on `PATCH /services/{uuid}/applications/{app_uuid}`.
 That route stays `nested-service` (use `coolify_service` for the stack).
 v4.3.10 adds instance-wide SMTP settings (`GET`/`PATCH /settings/email`) and
-`smtp_ehlo_domain` on team email notifications. Source tip and `v4.4-rc.1`
-match the 4.3.10 public API. The provider remains usable on 4.1.0+ for the
-common surface.
+`smtp_ehlo_domain` on team email notifications. Tags v4.3.11 through v4.3.14
+and `v4.4-rc.1` match that public API (0 write-path drift). The provider
+remains usable on 4.1.0+ for the common surface.
 
 ## Resources and data sources by Coolify version
 
@@ -196,7 +196,7 @@ PATCH if any disallowed field is present, so the provider strips them.
 | Topic | Guidance |
 |-------|----------|
 | Minimum Coolify for this provider | **4.1.0** |
-| Recommended Coolify for full feature set | **≥ 4.3.10** (matches current pin) |
+| Recommended Coolify for full feature set | **≥ 4.3.14** (matches current pin) |
 | Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
 
 Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -82,7 +82,7 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.0** |
+| **Recommended for full features** | **≥ v4.3.14** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -82,11 +82,14 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.14** |
+| **Recommended for full features** | **≥ v4.3.10** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
-Volume backup schedules and some application settings need **≥ v4.3.0**.
+Volume backup schedules, `noindex_domains`, notifications, and S3 need
+**≥ v4.3.0**. Instance email settings and `smtp_ehlo_domain` need
+**≥ v4.3.10**. The pinned API contract is Coolify **v4.3.14** (extract
+provenance), not a new feature floor.
 
 For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
 and how version gates behave), see

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -38,13 +38,26 @@ resource "coolify_service" "custom" {
   project_uuid = coolify_project.example.uuid
   server_uuid  = coolify_server.example.uuid
 
-  docker_compose_raw = file("docker-compose.yml")
+  docker_compose_raw = <<-EOT
+    services:
+      alpha:
+        image: nginx
+      zebra:
+        image: nginx
+  EOT
 
-  # Assign domains to service containers
-  urls = [{
-    name = "web"
-    url  = "https://app.example.com"
-  }]
+  # urls order is independent of compose order. Coolify GET may return
+  # applications alphabetically; the provider keeps this HCL order.
+  urls = [
+    {
+      name = "zebra"
+      url  = "https://zebra.example.com"
+    },
+    {
+      name = "alpha"
+      url  = "https://alpha.example.com"
+    },
+  ]
 }
 ```
 

--- a/examples/resources/coolify_service/resource.tf
+++ b/examples/resources/coolify_service/resource.tf
@@ -23,11 +23,24 @@ resource "coolify_service" "custom" {
   project_uuid = coolify_project.example.uuid
   server_uuid  = coolify_server.example.uuid
 
-  docker_compose_raw = file("docker-compose.yml")
+  docker_compose_raw = <<-EOT
+    services:
+      alpha:
+        image: nginx
+      zebra:
+        image: nginx
+  EOT
 
-  # Assign domains to service containers
-  urls = [{
-    name = "web"
-    url  = "https://app.example.com"
-  }]
+  # urls order is independent of compose order. Coolify GET may return
+  # applications alphabetically; the provider keeps this HCL order.
+  urls = [
+    {
+      name = "zebra"
+      url  = "https://zebra.example.com"
+    },
+    {
+      name = "alpha"
+      url  = "https://alpha.example.com"
+    },
+  ]
 }

--- a/internal/service/application/common_flatten.go
+++ b/internal/service/application/common_flatten.go
@@ -675,8 +675,8 @@ func flattenNoindexDomains(api []string, dst *types.List) {
 			*dst = types.ListNull(types.StringType)
 			return
 		}
-		// Configured (including empty list): reflect empty API as empty list.
-		*dst = types.ListValueMust(types.StringType, []attr.Value{})
+		// Configured (including empty list): keep current. Coolify < 4.3
+		// omits noindex_domains on GET; writing [] would fight the write gate.
 		return
 	}
 	if dst.IsNull() || dst.IsUnknown() {

--- a/internal/service/application/data_source.go
+++ b/internal/service/application/data_source.go
@@ -46,6 +46,7 @@ type ApplicationDataSourceModel struct {
 	DockerRegistryImageName          types.String `tfsdk:"docker_registry_image_name"`
 	MaxRestartCount                  types.Int64  `tfsdk:"max_restart_count"`
 	IsConsistentContainerNameEnabled types.Bool   `tfsdk:"is_consistent_container_name_enabled"`
+	NoindexDomains                   types.List   `tfsdk:"noindex_domains"`
 }
 
 // NewDataSource returns a new ApplicationDataSource instance.
@@ -146,6 +147,13 @@ func (d *ApplicationDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 					"Requires Coolify >= v4.3.0.",
 				Computed: true,
 			},
+			"noindex_domains": schema.ListAttribute{
+				ElementType: types.StringType,
+				MarkdownDescription: "Subset of application domain URLs served with an `X-Robots-Tag: noindex, nofollow` response header " +
+					"(keeps them out of search engines). Entries that are not among the application domains are ignored by Coolify. " +
+					"Requires Coolify >= v4.3.0. Omitted or empty on GET from older Coolify instances.",
+				Computed: true,
+			},
 		},
 	}
 }
@@ -193,6 +201,8 @@ func (d *ApplicationDataSource) Read(ctx context.Context, req datasource.ReadReq
 	} else {
 		config.IsConsistentContainerNameEnabled = types.BoolValue(false)
 	}
+	config.NoindexDomains = types.ListNull(types.StringType)
+	flattenNoindexDomains(app.NoindexDomains, &config.NoindexDomains)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/internal/service/application/data_source_test.go
+++ b/internal/service/application/data_source_test.go
@@ -76,6 +76,45 @@ data "coolify_application" "test" {
 	})
 }
 
+func TestApplicationDataSource_NoindexDomains(t *testing.T) {
+	t.Parallel()
+	app := client.Application{
+		UUID:           "cccc0004-0004-4000-8000-000000000003",
+		Name:           "noindex-ds-app",
+		NoindexDomains: []string{"https://alpha.example.com", "https://zebra.example.com"},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(app)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`
+provider "coolify" {
+  endpoint = %q
+  token    = "test-token"
+}
+
+data "coolify_application" "test" {
+  uuid = "cccc0004-0004-4000-8000-000000000003"
+}
+`, srv.URL),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("data.coolify_application.test", "noindex_domains.#", "2"),
+				resource.TestCheckResourceAttr("data.coolify_application.test", "noindex_domains.0", "https://alpha.example.com"),
+				resource.TestCheckResourceAttr("data.coolify_application.test", "noindex_domains.1", "https://zebra.example.com"),
+			),
+		}},
+	})
+}
+
 func TestApplicationDataSource_ConsistentContainerNameDefault(t *testing.T) {
 	t.Parallel()
 	app := client.Application{

--- a/internal/service/application/flatten_noindex_test.go
+++ b/internal/service/application/flatten_noindex_test.go
@@ -54,16 +54,14 @@ func TestFlattenNoindexDomains_ImportUsesAPIOrder(t *testing.T) {
 	}
 }
 
-func TestFlattenNoindexDomains_EmptyAPIClearsConfigured(t *testing.T) {
+func TestFlattenNoindexDomains_EmptyAPIPreservesConfigured(t *testing.T) {
 	t.Parallel()
 	configured := types.ListValueMust(types.StringType, []attr.Value{
-		types.StringValue("https://gone.example.com"),
+		types.StringValue("https://zebra.example.com"),
 	})
 	flattenNoindexDomains(nil, &configured)
-	if configured.IsNull() {
-		t.Fatal("configured empty API should be empty list, not null")
-	}
-	if got := stringListFromTypes(configured); len(got) != 0 {
-		t.Fatalf("got %v, want empty list", got)
+	got := stringListFromTypes(configured)
+	if len(got) != 1 || got[0] != "https://zebra.example.com" {
+		t.Fatalf("got %v, want configured zebra URL", got)
 	}
 }

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -2648,6 +2648,107 @@ func TestApplicationResource_CreateSendsDestinationUUID(t *testing.T) {
 	})
 }
 
+// TestApplicationResource_NoindexPreservesConfigOrder is the #818/#820
+// regression: Coolify GET may return noindex_domains in a different order
+// than HCL. GET must not echo POST/PATCH body order.
+func TestApplicationResource_NoindexPreservesConfigOrder(t *testing.T) {
+	t.Parallel()
+	app := client.Application{
+		UUID:            "noindex-order-uuid",
+		Name:            "noindex-order-app",
+		GitRepository:   "https://github.com/example/repo",
+		GitBranch:       "main",
+		BuildPack:       "nixpacks",
+		PortsExposes:    "80",
+		ProjectUUID:     "aaaa0001-0001-4000-8000-000000000001",
+		ServerUUID:      "bbbb0001-0001-4000-8000-000000000001",
+		EnvironmentName: "production",
+		Domains:         "https://zebra.example.com,https://alpha.example.com",
+		// Opposite of HCL (zebra, alpha). Never updated from POST/PATCH.
+		NoindexDomains: []string{"https://alpha.example.com", "https://zebra.example.com"},
+	}
+
+	mu := sync.Mutex{}
+	deleted := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/public", func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := decodeRequestBodyMap(t, w, r); !ok {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := decodeRequestBodyMap(t, w, r)
+		if !ok {
+			return
+		}
+		if raw, ok := body["noindex_domains"].([]interface{}); ok {
+			if len(raw) != 2 {
+				t.Errorf("PATCH noindex_domains = %#v, want 2 entries", body["noindex_domains"])
+			} else if first, _ := raw[0].(string); first != "https://zebra.example.com" {
+				t.Errorf("PATCH noindex_domains[0] = %v, want zebra (HCL order)", first)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if deleted {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Fixed GET order (alpha, zebra). Do not echo write-body order.
+		_ = json.NewEncoder(w).Encode(app)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		deleted = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(mux, "v4.3.2"))
+	defer srv.Close()
+
+	cfg := testApplicationResourceConfig(srv.URL, `
+					name             = "noindex-order-app"
+					project_uuid     = "aaaa0001-0001-4000-8000-000000000001"
+					server_uuid      = "bbbb0001-0001-4000-8000-000000000001"
+					git_repository   = "https://github.com/example/repo"
+					build_pack       = "nixpacks"
+					ports_exposes    = "80"
+					domains          = "https://zebra.example.com,https://alpha.example.com"
+					noindex_domains  = ["https://zebra.example.com", "https://alpha.example.com"]
+				`)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_application", "/api/v1/applications/"),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application.test", "uuid", app.UUID),
+					resource.TestCheckResourceAttr("coolify_application.test", "noindex_domains.#", "2"),
+					resource.TestCheckResourceAttr("coolify_application.test", "noindex_domains.0", "https://zebra.example.com"),
+					resource.TestCheckResourceAttr("coolify_application.test", "noindex_domains.1", "https://alpha.example.com"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestApplicationResource_CreateOmitsDestinationUUIDWhenUnset ensures we do
 // not send destination_uuid:null/"" which would change Coolify behavior.
 func TestApplicationResource_CreateOmitsDestinationUUIDWhenUnset(t *testing.T) {

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -2749,6 +2749,92 @@ func TestApplicationResource_NoindexPreservesConfigOrder(t *testing.T) {
 	})
 }
 
+func TestApplicationResource_NoindexKeptOnV42(t *testing.T) {
+	t.Parallel()
+	app := client.Application{
+		UUID:            "noindex-v42-uuid",
+		Name:            "noindex-v42-app",
+		GitRepository:   "https://github.com/example/repo",
+		GitBranch:       "main",
+		BuildPack:       "nixpacks",
+		PortsExposes:    "80",
+		ProjectUUID:     "aaaa0001-0001-4000-8000-000000000001",
+		ServerUUID:      "bbbb0001-0001-4000-8000-000000000001",
+		EnvironmentName: "production",
+		Domains:         "https://zebra.example.com",
+	}
+
+	mu := sync.Mutex{}
+	deleted := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/applications/public", func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := decodeRequestBodyMap(t, w, r); !ok {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
+	})
+	mux.HandleFunc("PATCH /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := decodeRequestBodyMap(t, w, r); !ok {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"uuid": app.UUID})
+	})
+	mux.HandleFunc("GET /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if deleted {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(app)
+	})
+	mux.HandleFunc("DELETE /api/v1/applications/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		deleted = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(mux))
+	defer srv.Close()
+
+	cfg := testApplicationResourceConfig(srv.URL, `
+					name             = "noindex-v42-app"
+					project_uuid     = "aaaa0001-0001-4000-8000-000000000001"
+					server_uuid      = "bbbb0001-0001-4000-8000-000000000001"
+					git_repository   = "https://github.com/example/repo"
+					build_pack       = "nixpacks"
+					ports_exposes    = "80"
+					domains          = "https://zebra.example.com"
+					noindex_domains  = ["https://zebra.example.com"]
+				`)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.CheckDestroy(srv.URL, "coolify_application", "/api/v1/applications/"),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application.test", "uuid", app.UUID),
+					resource.TestCheckResourceAttr("coolify_application.test", "noindex_domains.#", "1"),
+					resource.TestCheckResourceAttr("coolify_application.test", "noindex_domains.0", "https://zebra.example.com"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestApplicationResource_CreateOmitsDestinationUUIDWhenUnset ensures we do
 // not send destination_uuid:null/"" which would change Coolify behavior.
 func TestApplicationResource_CreateOmitsDestinationUUIDWhenUnset(t *testing.T) {

--- a/internal/spectest/list_flatten_policy_test.go
+++ b/internal/spectest/list_flatten_policy_test.go
@@ -73,4 +73,36 @@ func TestResourceListAttributes_HaveOrderPolicy(t *testing.T) {
 			t.Errorf("resourceListPolicy has stale key %s (attribute moved or renamed)", key)
 		}
 	}
+
+	declared := collectTestFuncNames(absRoot)
+	for key, policy := range resourceListPolicy {
+		if !looksLikeTestFunc.MatchString(policy) {
+			continue
+		}
+		if !declared[policy] {
+			t.Errorf("resourceListPolicy[%s] names %s but that test function is missing from *_test.go", key, policy)
+		}
+	}
+}
+
+var looksLikeTestFunc = regexp.MustCompile(`^Test[A-Za-z0-9_]+$`)
+
+var testFuncDecl = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]+)\(`)
+
+func collectTestFuncNames(serviceRoot string) map[string]bool {
+	names := map[string]bool{}
+	_ = filepath.Walk(serviceRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range testFuncDecl.FindAllSubmatch(data, -1) {
+			names[string(m[1])] = true
+		}
+		return nil
+	})
+	return names
 }

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -13,7 +13,7 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.3.10` | Extracted from: `coollabsio/coolify@v4.3.10`
+Contract version: `v4.3.14` | Extracted from: `coollabsio/coolify@v4.3.14`
 
 ## Summary
 

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -303,6 +303,10 @@ value the API returned on Read. Common triggers:
   a URL prefix, base64-encoded content)
 - **Default mismatch:** the provider's schema default differs from
   Coolify's actual default
+- **List reorder on `urls` / `noindex_domains`:** Coolify GET may return
+  these lists in a different order than HCL. The provider keeps the HCL
+  order when the set of values matches. If you still see this on an
+  older provider, upgrade, or reorder HCL to match GET as a workaround.
 
 **Fix:**
 1. Upgrade to a `root` API token (fixes most sensitive field issues)
@@ -310,6 +314,8 @@ value the API returned on Read. Common triggers:
    [API Behaviors](/#coolify-api-behaviors) in the docs index)
 3. If the field is a password you set, the token permissions are the
    most likely cause
+4. On `urls` or `noindex_domains`, upgrade the provider (it keeps HCL
+   order) or temporarily match HCL to the GET order
 
 ### Unexpected public domain (`sslip.io` or wildcard FQDN)
 

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -37,7 +37,8 @@ output "coolify_version" {
 | **&lt; 4.1.0** | Configure fails. Upgrade Coolify. |
 | **4.1.x** | Core resources work. Version-gated 4.2/4.3 attributes stay in state if set, but are **not sent** on write (plan warning). |
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
-| **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
+| **≥ 4.3.0** | 4.3 application settings, `noindex_domains`, notification channels, S3, volume backup schedules, GPU/log-drain, etc. |
+| **≥ 4.3.10** | Instance email settings and `smtp_ehlo_domain` on team email notifications. Recommended for the full feature set. |
 
 Pinned API contract today: Coolify **v4.3.14** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
@@ -196,7 +197,7 @@ PATCH if any disallowed field is present, so the provider strips them.
 | Topic | Guidance |
 |-------|----------|
 | Minimum Coolify for this provider | **4.1.0** |
-| Recommended Coolify for full feature set | **≥ 4.3.14** (matches current pin) |
+| Recommended Coolify for full feature set | **≥ 4.3.10** |
 | Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
 
 Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -39,14 +39,14 @@ output "coolify_version" {
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
 | **≥ 4.3.0** | Full current surface: volume backup schedules, notification channels, `noindex_domains`, GPU/log-drain application settings, etc. |
 
-Pinned API contract today: Coolify **v4.3.10** (`testdata/contracts/coolify-v4.json`).
+Pinned API contract today: Coolify **v4.3.14** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
 accept `is_force_https_enabled` on `PATCH /services/{uuid}/applications/{app_uuid}`.
 That route stays `nested-service` (use `coolify_service` for the stack).
 v4.3.10 adds instance-wide SMTP settings (`GET`/`PATCH /settings/email`) and
-`smtp_ehlo_domain` on team email notifications. Source tip and `v4.4-rc.1`
-match the 4.3.10 public API. The provider remains usable on 4.1.0+ for the
-common surface.
+`smtp_ehlo_domain` on team email notifications. Tags v4.3.11 through v4.3.14
+and `v4.4-rc.1` match that public API (0 write-path drift). The provider
+remains usable on 4.1.0+ for the common surface.
 
 ## Resources and data sources by Coolify version
 
@@ -196,7 +196,7 @@ PATCH if any disallowed field is present, so the provider strips them.
 | Topic | Guidance |
 |-------|----------|
 | Minimum Coolify for this provider | **4.1.0** |
-| Recommended Coolify for full feature set | **≥ 4.3.10** (matches current pin) |
+| Recommended Coolify for full feature set | **≥ 4.3.14** (matches current pin) |
 | Provider package versions | Current 0.1.x line targets Coolify 4.1+ with soft gates for 4.2/4.3 APIs |
 
 Historical "0.2.x / 0.3.x min Coolify" rows in older docs referred to planned

--- a/templates/guides/installation.md.tmpl
+++ b/templates/guides/installation.md.tmpl
@@ -82,7 +82,7 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.0** |
+| **Recommended for full features** | **≥ v4.3.14** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.

--- a/templates/guides/installation.md.tmpl
+++ b/templates/guides/installation.md.tmpl
@@ -82,11 +82,14 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.14** |
+| **Recommended for full features** | **≥ v4.3.10** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
-Volume backup schedules and some application settings need **≥ v4.3.0**.
+Volume backup schedules, `noindex_domains`, notifications, and S3 need
+**≥ v4.3.0**. Instance email settings and `smtp_ehlo_domain` need
+**≥ v4.3.10**. The pinned API contract is Coolify **v4.3.14** (extract
+provenance), not a new feature floor.
 
 For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
 and how version gates behave), see

--- a/testdata/contracts/coolify-v4.3.11.json
+++ b/testdata/contracts/coolify-v4.3.11.json
@@ -1,7 +1,7 @@
 {
-  "version": "v4.3.14",
-  "extracted_from": "coollabsio/coolify@v4.3.14",
-  "extracted_at": "2026-08-28T22:21:11.044106+00:00",
+  "version": "v4.3.11",
+  "extracted_from": "coollabsio/coolify@v4.3.11",
+  "extracted_at": "2026-08-28T22:21:02.502776+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -10490,6 +10490,5 @@
         "api.ability:read"
       ]
     }
-  ],
-  "notes": "Pin is tag v4.3.14. Public API matches v4.3.10 through v4.3.14 and v4.4-rc.1 (0 write-path and route drift). Includes smtp_ehlo_domain on NotificationsController::update_email (coollabsio/coolify#11398) and InstanceEmailSettingsController GET/PATCH /settings/email."
+  ]
 }

--- a/testdata/contracts/coolify-v4.3.12.json
+++ b/testdata/contracts/coolify-v4.3.12.json
@@ -1,7 +1,7 @@
 {
-  "version": "v4.3.14",
-  "extracted_from": "coollabsio/coolify@v4.3.14",
-  "extracted_at": "2026-08-28T22:21:11.044106+00:00",
+  "version": "v4.3.12",
+  "extracted_from": "coollabsio/coolify@v4.3.12",
+  "extracted_at": "2026-08-28T22:21:05.296057+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -10490,6 +10490,5 @@
         "api.ability:read"
       ]
     }
-  ],
-  "notes": "Pin is tag v4.3.14. Public API matches v4.3.10 through v4.3.14 and v4.4-rc.1 (0 write-path and route drift). Includes smtp_ehlo_domain on NotificationsController::update_email (coollabsio/coolify#11398) and InstanceEmailSettingsController GET/PATCH /settings/email."
+  ]
 }

--- a/testdata/contracts/coolify-v4.3.13.json
+++ b/testdata/contracts/coolify-v4.3.13.json
@@ -1,7 +1,7 @@
 {
-  "version": "v4.3.14",
-  "extracted_from": "coollabsio/coolify@v4.3.14",
-  "extracted_at": "2026-08-28T22:21:11.044106+00:00",
+  "version": "v4.3.13",
+  "extracted_from": "coollabsio/coolify@v4.3.13",
+  "extracted_at": "2026-08-28T22:21:08.208054+00:00",
   "models": {
     "Application": {
       "table": "applications",
@@ -10490,6 +10490,5 @@
         "api.ability:read"
       ]
     }
-  ],
-  "notes": "Pin is tag v4.3.14. Public API matches v4.3.10 through v4.3.14 and v4.4-rc.1 (0 write-path and route drift). Includes smtp_ehlo_domain on NotificationsController::update_email (coollabsio/coolify#11398) and InstanceEmailSettingsController GET/PATCH /settings/email."
+  ]
 }

--- a/testdata/contracts/coolify-v4.3.14.json
+++ b/testdata/contracts/coolify-v4.3.14.json
@@ -10490,6 +10490,5 @@
         "api.ability:read"
       ]
     }
-  ],
-  "notes": "Pin is tag v4.3.14. Public API matches v4.3.10 through v4.3.14 and v4.4-rc.1 (0 write-path and route drift). Includes smtp_ehlo_domain on NotificationsController::update_email (coollabsio/coolify#11398) and InstanceEmailSettingsController GET/PATCH /settings/email."
+  ]
 }


### PR DESCRIPTION
Pin the Coolify contract to v4.3.14 (current stable and GitHub latest), keep `noindex_domains` when GET omits it, and add regression coverage so GET list reorder cannot hide another flatten bug.

## Problem

Stable Coolify is already v4.3.14. The provider pin was still v4.3.10. The channel watch on issue 799 reports 0 write-path drift from 4.3.11 through 4.3.14, so the pin could move without a schema change.

Coolify GET may return `urls` and `noindex_domains` in a different order than HCL. PRs #819 and #820 keep configured order. This branch proves that with a reversed-GET unit test and a policy check that named flatten tests actually exist.

On Coolify older than 4.3.0, GET omits `noindex_domains`. Flatten used to write an empty list, which fought the version write gate (keep HCL in state, do not send) and produced a perpetual plan.

## Change

- Extract `testdata/contracts/coolify-v4.3.11.json` through `coolify-v4.3.14.json`
- Promote `testdata/contracts/coolify-v4.json` to v4.3.14
- Preserve a configured `noindex_domains` list when GET is empty; import still stores null
- Expose computed `noindex_domains` on `data.coolify_application`
- Recommended full-feature Coolify is >= v4.3.10 (instance email and `smtp_ehlo_domain`). Pin v4.3.14 is extract provenance
- `TestApplicationResource_NoindexPreservesConfigOrder` and `TestApplicationResource_NoindexKeptOnV42`
- `TestResourceListAttributes_HaveOrderPolicy` fails if a policy names a missing `Test*` function
- Two-service `coolify_service` example and common-errors notes

Issue 799 stays open. Nightly is still `4.4-rc.1` and tip is `4.3.15`. This PR only moves the pin to the current stable tag.

## Validation

- `go test -count=1 -timeout=180s ./internal/service/application/ -run 'TestFlattenNoindexDomains_|TestApplicationResource_Noindex|TestApplicationDataSource_'`
- `go test -count=1 -timeout=180s ./internal/spectest/ -run 'TestResourceListAttributes_HaveOrderPolicy'`
- Contract extracts compared to v4.3.10: 0 write-path / route / model drift
- Flatten empty-GET test was red (`got [], want configured zebra URL`) then green after the preserve change

Ref #799
Ref #818
