### PR TITLE
test(application): assert v4.2 withhold of max_restart_count

### DIFF
--- a/internal/service/application/common_flatten_test.go
+++ b/internal/service/application/common_flatten_test.go
@@ -705,7 +705,7 @@ func TestFlattenRestartLimitFields(t *testing.T) {
 	})
 }
 
-func TestFlattenRestartLimitFields_PreservesConfiguredMaxRestartCount(t *testing.T) {
+func TestFlattenRestartLimitFields_OmitsAPIKeepsKnownDest(t *testing.T) {
 	t.Parallel()
 	dest := types.Int64Value(3)
 	flattenRestartLimitFields(&client.Application{}, commonAppFields{MaxRestartCount: &dest})

--- a/internal/service/application/resource_test.go
+++ b/internal/service/application/resource_test.go
@@ -1752,6 +1752,7 @@ func TestApplicationResource_MaxRestartCount_V42Withheld(t *testing.T) {
 	}
 	mu := sync.Mutex{}
 	deleted := false
+	var lastPATCH map[string]interface{}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/applications/public", func(w http.ResponseWriter, r *http.Request) {
@@ -1778,7 +1779,8 @@ func TestApplicationResource_MaxRestartCount_V42Withheld(t *testing.T) {
 		var body map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		mu.Lock()
-		defer mu.Unlock()
+		lastPATCH = body
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(currentApp)
 	})
@@ -1807,7 +1809,20 @@ func TestApplicationResource_MaxRestartCount_V42Withheld(t *testing.T) {
 					name             = "restart-limit-v42-app"
 					max_restart_count = 3
 				`),
-				Check: resource.TestCheckResourceAttr("coolify_application.test", "max_restart_count", "3"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_application.test", "max_restart_count", "3"),
+					resource.TestCheckFunc(func(_ *terraform.State) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if lastPATCH == nil {
+							return nil
+						}
+						if _, ok := lastPATCH["max_restart_count"]; ok {
+							return fmt.Errorf("create PATCH included max_restart_count = %v, want withheld on Coolify 4.2", lastPATCH["max_restart_count"])
+						}
+						return nil
+					}),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
The Coolify 4.2 `max_restart_count` resource test only locked flatten preserve. A mock that ignored the PATCH body would still pass if the client sent the key.

## Change

- Record the follow-up PATCH (or its absence). If a PATCH runs, `max_restart_count` must be absent. GET still returns 10. State stays 3.
- Rename `TestFlattenRestartLimitFields_PreservesConfiguredMaxRestartCount` to `TestFlattenRestartLimitFields_OmitsAPIKeepsKnownDest` so it does not claim the GET=10 preserve path.

## Validation

```
go test -count=1 -timeout 180s ./internal/service/application/ \
  -run 'TestApplicationResource_MaxRestartCount|TestFlattenRestartLimitFields'
```

`GOTOOLCHAIN=go1.26.6 golangci-lint run ./internal/service/application/` (0 issues).

Ref #799
