### PR TITLE
test(application): write max_restart_count in V43 settings acc

### DIFF
--- a/internal/service/application/acc_primary_field_guard_test.go
+++ b/internal/service/application/acc_primary_field_guard_test.go
@@ -53,3 +53,18 @@ func TestApplicationCRUDFiles_UpdatePrimaryField(t *testing.T) {
 		})
 	}
 }
+
+// TestDockerfileAccV43Settings_MaxRestartCount fails if the dockerfile
+// Coolify >= 4.3 extra drops max_restart_count. A dropped post-create
+// PATCH would then hide behind GET default 10.
+func TestDockerfileAccV43Settings_MaxRestartCount(t *testing.T) {
+	t.Parallel()
+	const path = "resource_dockerfile_acc_test.go"
+	b, err := os.ReadFile(path) //nolint:gosec // test fixture path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(b), "max_restart_count") {
+		t.Errorf("%s V43 settings extra must set max_restart_count", path)
+	}
+}

--- a/internal/service/application/resource_dockerfile_acc_test.go
+++ b/internal/service/application/resource_dockerfile_acc_test.go
@@ -170,9 +170,10 @@ data "coolify_application_logs" "test" {
 }
 
 // TestAccDockerfileApplicationResource_V43Settings exercises Coolify >= v4.3.0
-// application write fields (is_log_drain_enabled, noindex_domains) against a
-// real instance. On tip-edge CI (COOLIFY_REQUIRE_TIP_APIS=1) the version probe
-// fails the run if Coolify is older than 4.3.0; elsewhere it skips.
+// application write fields (is_log_drain_enabled, noindex_domains,
+// max_restart_count) against a real instance. On tip-edge CI
+// (COOLIFY_REQUIRE_TIP_APIS=1) the version probe fails the run if Coolify
+// is older than 4.3.0; elsewhere it skips.
 func TestAccDockerfileApplicationResource_V43Settings(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)
@@ -186,6 +187,7 @@ func TestAccDockerfileApplicationResource_V43Settings(t *testing.T) {
   domains              = "http://acc-v43.example.com"
   is_log_drain_enabled = true
   noindex_domains      = ["http://acc-v43.example.com"]
+  max_restart_count    = 3
 `
 
 	resource.Test(t, resource.TestCase{
@@ -199,6 +201,7 @@ func TestAccDockerfileApplicationResource_V43Settings(t *testing.T) {
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "is_log_drain_enabled", "true"),
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "noindex_domains.#", "1"),
 					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "noindex_domains.0", "http://acc-v43.example.com"),
+					resource.TestCheckResourceAttr("coolify_application_dockerfile.test", "max_restart_count", "3"),
 				),
 			},
 			{


### PR DESCRIPTION
The dockerfile Coolify >= 4.3 acc extra already writes log drain and noindex. It never set `max_restart_count`, so a dropped post-create PATCH would hide behind GET default 10.

## Change

- Set `max_restart_count = 3` and check the attribute in `TestAccDockerfileApplicationResource_V43Settings`.
- Guard `TestDockerfileAccV43Settings_MaxRestartCount` so the extra cannot drop the field silently.

## Validation

```
go test -count=1 -timeout 60s ./internal/service/application/ \
  -run 'TestApplicationCRUDFiles_UpdatePrimaryField|TestDockerfileAcc'
```

Guard was red before the HCL line, green after.

Ref #799
