### PR TITLE
ci: give github-cicd scenario suite 35m for deploy retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,8 +632,10 @@ jobs:
   scenario-tests:
     name: Scenario Tests
     runs-on: ubuntu-latest
-    # core is short; github-cicd waits up to 15m on deploy; hetzner creates VMs.
-    timeout-minutes: 25
+    # core is short. github-cicd waits up to 15m on deploy and retries
+    # once on Coolify build flake; 25m cannot fit first-fail plus retry.
+    # hetzner creates VMs. Keep one suite per job (do not even-split dirs).
+    timeout-minutes: ${{ matrix.timeout }}
     needs: [changes]
     if: >-
       always() &&
@@ -644,7 +646,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [core, github-cicd, hetzner]
+        include:
+          - suite: core
+            timeout: 25
+          - suite: github-cicd
+            timeout: 35
+          - suite: hetzner
+            timeout: 25
     permissions:
       contents: read
       # Playwright browser cache save in setup-coolify.

--- a/.github/workflows/coolify-nightly.yml
+++ b/.github/workflows/coolify-nightly.yml
@@ -250,11 +250,19 @@ jobs:
         needs.prepare.outputs.profile == 'custom'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Same suite timeouts as ci.yml: github-cicd needs 35m for deploy
+    # plus one retry. core/hetzner stay at 25m.
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
-        suite: [core, github-cicd, hetzner]
+        include:
+          - suite: core
+            timeout: 25
+          - suite: github-cicd
+            timeout: 35
+          - suite: hetzner
+            timeout: 25
     env:
       COOLIFY_DATA_DIR: /home/runner/coolify-data
     steps:


### PR DESCRIPTION
## Summary

Give the `github-cicd` scenario suite 35 minutes so a first Coolify deploy fail plus the one allowed retry can finish. `core` and `hetzner` stay at 25 minutes.

## Problem

`acme-github-cicd` waits up to 15 minutes on Coolify deploy and retries once on build flake. After #832, main run 33936018620 cancelled the suite at 25m0s while retrying an apt-fetch flake. A 25 minute job cap cannot fit first-fail plus retry.

This is not "too many tests in one job." `github-cicd` is already its own suite. Splitting dirs or putting the retry in a second job would re-boot Coolify and still need the 15 minute wait.

## Change

- `.github/workflows/ci.yml` and `.github/workflows/coolify-nightly.yml` use a per-suite `timeout-minutes: ${{ matrix.timeout }}` via matrix `include` (`core`/`hetzner` 25, `github-cicd` 35).
- Comments say do not even-split the 18 dirs.

## Validation

- Parsed both workflow files as YAML.
- Confirmed `github-cicd` is 35 and `core`/`hetzner` stay 25 in both files.
- Path filter still excludes `ci.yml` from Scenario Tests, so this workflow-only PR does not boot Coolify.

## Checklist

- [x] Commits have DCO sign-off (`git commit -s` / `Signed-off-by` trailer; CI enforces this)
- [x] Tests added or updated (N/A: timeout config only)
- [x] `make test` passes locally (N/A: no Go change)
- [x] `make fmt` ran (gofmt + go mod tidy) (N/A: YAML only)
- [x] Documentation updated (if adding/changing resources or data sources)
- [x] `make docs` regenerated (if templates changed)
- [x] Examples updated (if adding new resources)
- [x] CHANGELOG.md updated (N/A: CI timeout only)
- [x] No breaking changes to existing resources
