### PR TITLE
fix(server_proxy): keep planned configuration on apply

### DIFF
--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -439,6 +439,27 @@ stays. `redirect_url` uses `exists()` and does persist.
 path with `redirect_url` (use a resolvable host such as
 `https://example.com`; reserved names like `example.invalid` return 422).
 
+### Server proxy configuration apply writes the stored compose
+
+```
+Error: Provider produced inconsistent result after apply
+.configuration: inconsistent values for sensitive attribute
+```
+
+**Symptom:** updating `coolify_server_proxy.configuration` (for example
+adding a Cloudflare DNS challenge to an existing Traefik compose) fails
+on apply. The planned YAML never lands in Coolify.
+
+**Cause:** Coolify `GET`/`PATCH /servers/{uuid}/proxy` returns
+`configuration` when the token can read sensitive data (`root` or
+`read:sensitive`) and the server already has a stored compose. Provider
+0.1.20 and earlier copied that stored value onto the plan, then PUT it
+back. This is independent of Coolify version (any >= v4.3.0).
+
+**Fix:** upgrade the provider. Until then, write the compose with
+`PUT /api/v1/servers/{uuid}/proxy/configuration` (or the Coolify UI)
+and omit `configuration` from the resource, or keep it matching GET.
+
 ### "forces replacement"
 
 ```

--- a/docs/resources/server_proxy.md
+++ b/docs/resources/server_proxy.md
@@ -30,7 +30,7 @@ resource "coolify_server_proxy" "example" {
 
 ### Optional
 
-- `configuration` (String) Raw proxy configuration written with PUT .../proxy/configuration.
+- `configuration` (String) Raw proxy Docker Compose written with PUT .../proxy/configuration. The provider sends the planned value. Coolify GET/PATCH may also return the previously stored compose when the token can read sensitive data; that response is not used as the PUT body.
 - `generate_exact_labels` (Boolean) Whether to generate exact Docker labels (removes extra labels from containers). Setting `false` is ignored by Coolify today (`$request->has('generate_exact_labels')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.
 - `proxy_type` (String) Proxy type (for example traefik or caddy).
 - `redirect_enabled` (Boolean) Whether HTTP to HTTPS redirect is enabled. Coolify defaults this to `true`. Setting `false` is ignored by Coolify today (`$request->has('redirect_enabled')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.

--- a/internal/service/serverproxy/resource.go
+++ b/internal/service/serverproxy/resource.go
@@ -63,8 +63,12 @@ func (r *serverProxyResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Whether to generate exact Docker labels (removes extra labels from containers). " +
 					"Setting `false` is ignored by Coolify today (`$request->has('generate_exact_labels')` treats JSON `false` as absent). Requires Coolify >= v4.3.0.",
 			},
-			"proxy_type":    schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},
-			"configuration": schema.StringAttribute{Optional: true, MarkdownDescription: "Raw proxy configuration written with PUT .../proxy/configuration."},
+			"proxy_type": schema.StringAttribute{Optional: true, Computed: true, MarkdownDescription: "Proxy type (for example traefik or caddy)."},
+			"configuration": schema.StringAttribute{
+				Optional: true,
+				MarkdownDescription: "Raw proxy Docker Compose written with PUT .../proxy/configuration. " +
+					"The provider sends the planned value. Coolify GET/PATCH may also return the previously stored compose when the token can read sensitive data; that response is not used as the PUT body.",
+			},
 		},
 	}
 }
@@ -121,6 +125,10 @@ func flattenProxy(got *client.ServerProxy, plan *serverProxyModel) {
 func (r *serverProxyResource) apply(ctx context.Context, plan *serverProxyModel) error {
 	uuid := plan.ServerUUID.ValueString()
 	input := proxyUpdateFromPlan(*plan)
+	// GET and PATCH include last_saved_proxy_configuration when the token
+	// can read sensitive data. flattenProxy would copy that into the plan
+	// and PUT would write the previous compose back (#842).
+	plannedConfig := plan.Configuration
 
 	current, err := r.client.GetServerProxy(ctx, uuid)
 	if err != nil && !client.IsNotFound(err) {
@@ -128,6 +136,7 @@ func (r *serverProxyResource) apply(ctx context.Context, plan *serverProxyModel)
 	}
 	if current != nil {
 		flattenProxy(current, plan)
+		plan.Configuration = plannedConfig
 	}
 
 	wantType := ""
@@ -164,8 +173,9 @@ func (r *serverProxyResource) apply(ctx context.Context, plan *serverProxyModel)
 			return err
 		}
 	}
-	if !plan.Configuration.IsNull() && !plan.Configuration.IsUnknown() && plan.Configuration.ValueString() != "" {
-		return r.client.PutServerProxyConfiguration(ctx, uuid, plan.Configuration.ValueString())
+	plan.Configuration = plannedConfig
+	if !plannedConfig.IsNull() && !plannedConfig.IsUnknown() && plannedConfig.ValueString() != "" {
+		return r.client.PutServerProxyConfiguration(ctx, uuid, plannedConfig.ValueString())
 	}
 	return nil
 }

--- a/internal/service/serverproxy/resource_test.go
+++ b/internal/service/serverproxy/resource_test.go
@@ -203,6 +203,103 @@ resource "coolify_server_proxy" "test" {
 	})
 }
 
+// Coolify GET/PATCH /proxy includes last_saved_proxy_configuration when the
+// token can read sensitive data. apply() must PUT the planned compose, not
+// the stored value flattenProxy would copy into the plan (#842).
+func TestServerProxyResource_ConfigurationUpdateKeepsPlanned(t *testing.T) {
+	t.Parallel()
+	const serverUUID = "aaaa0001-0001-4000-8000-000000000001"
+	const existing = "http:\n  routers:\n    old: {}\n"
+	const updated = "http:\n  routers:\n    cloudflare: {}\n"
+	store := map[string]any{"proxy_type": "traefik", "configuration": existing}
+	var mu sync.Mutex
+	var lastPut string
+	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/proxy/configuration") && r.Method == http.MethodPut:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode proxy config: %v", err)
+			}
+			cfg, _ := body["configuration"].(string)
+			if cfg == "" {
+				t.Errorf("expected non-empty configuration in PUT body, got %v", body)
+			}
+			lastPut = cfg
+			store["configuration"] = cfg
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodPatch:
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for k, v := range body {
+				store[k] = v
+			}
+			_ = json.NewEncoder(w).Encode(store)
+		case strings.HasSuffix(r.URL.Path, "/proxy") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(store)
+		default:
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+		}
+	})))
+	defer srv.Close()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid   = "` + serverUUID + `"
+  proxy_type    = "traefik"
+  configuration = <<-EOT
+http:
+  routers:
+    cloudflare: {}
+EOT
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_server_proxy.test", "configuration", updated),
+					func(_ *terraform.State) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if lastPut != updated {
+							return fmt.Errorf("PUT wrote %q, want planned %q", lastPut, updated)
+						}
+						if store["configuration"] != updated {
+							return fmt.Errorf("store configuration=%v", store["configuration"])
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: acctest.ProviderBlockForURL(srv.URL) + `
+resource "coolify_server_proxy" "test" {
+  server_uuid   = "` + serverUUID + `"
+  proxy_type    = "traefik"
+  configuration = <<-EOT
+http:
+  routers:
+    cloudflare: {}
+    extra: {}
+EOT
+}`,
+				Check: func(_ *terraform.State) error {
+					mu.Lock()
+					defer mu.Unlock()
+					const want = "http:\n  routers:\n    cloudflare: {}\n    extra: {}\n"
+					if lastPut != want {
+						return fmt.Errorf("update PUT wrote %q, want %q", lastPut, want)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
 func TestServerProxyResource_CreateAPIError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/templates/guides/common-errors.md.tmpl
+++ b/templates/guides/common-errors.md.tmpl
@@ -439,6 +439,27 @@ stays. `redirect_url` uses `exists()` and does persist.
 path with `redirect_url` (use a resolvable host such as
 `https://example.com`; reserved names like `example.invalid` return 422).
 
+### Server proxy configuration apply writes the stored compose
+
+```
+Error: Provider produced inconsistent result after apply
+.configuration: inconsistent values for sensitive attribute
+```
+
+**Symptom:** updating `coolify_server_proxy.configuration` (for example
+adding a Cloudflare DNS challenge to an existing Traefik compose) fails
+on apply. The planned YAML never lands in Coolify.
+
+**Cause:** Coolify `GET`/`PATCH /servers/{uuid}/proxy` returns
+`configuration` when the token can read sensitive data (`root` or
+`read:sensitive`) and the server already has a stored compose. Provider
+0.1.20 and earlier copied that stored value onto the plan, then PUT it
+back. This is independent of Coolify version (any >= v4.3.0).
+
+**Fix:** upgrade the provider. Until then, write the compose with
+`PUT /api/v1/servers/{uuid}/proxy/configuration` (or the Coolify UI)
+and omit `configuration` from the resource, or keep it matching GET.
+
 ### "forces replacement"
 
 ```


### PR DESCRIPTION
## Summary

Stop `coolify_server_proxy` from writing the previously stored Coolify compose when the user updates `configuration`.

## Problem

`GET` and `PATCH /api/v1/servers/{uuid}/proxy` return `configuration` when the token can read sensitive data and the server already has `last_saved_proxy_configuration`. That has been true since Coolify v4.3.0 (the floor for this resource), including `next`.

`apply()` flattened those responses onto the plan, then PUT the stored compose. Terraform reported `inconsistent result after apply` on `.configuration` (often as a sensitive attribute when the YAML includes a sensitive variable).

## Change

Keep the planned compose across GET/PATCH flatten, then PUT that value.

Adds a unit test that seeds GET with an existing compose and asserts the PUT body is the planned YAML on create and update.

Documents the 0.1.20-and-earlier workaround in the common-errors guide.

## Validation

- Red: `go test -run TestServerProxyResource_ConfigurationUpdateKeepsPlanned ./internal/service/serverproxy/` failed with the same inconsistent-result error as the issue.
- Green: same test plus `go test -race ./internal/service/serverproxy/` and `golangci-lint run ./internal/service/serverproxy/` pass.
- Local reviewer: 0 issues.

Coolify is not running locally, so acceptance tests were not re-run. Acc does not PUT a real proxy compose (that would replace the instance Traefik file).

Closes #842
