### PR TITLE
feat: pin Coolify v4.3.18 and write missing-backup notifications

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -490,7 +490,7 @@ ImportStateVerifyIgnore: []string{"private_key", "postgres_password"},
 
 - **Resources**: 45/45 direct acceptance coverage
 - **Data Sources**: 44/44 direct acceptance coverage
-- **Total acceptance test functions**: 151
+- **Total acceptance test functions**: 152
 
 ### Primary-field update coverage
 

--- a/docs/guides/api-contract-accuracy.md
+++ b/docs/guides/api-contract-accuracy.md
@@ -13,16 +13,16 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.3.17` | Extracted from: `coollabsio/coolify@v4.3.17`
+Contract version: `v4.3.18` | Extracted from: `coollabsio/coolify@v4.3.18`
 
 ## Summary
 
 | Metric | Count |
 |--------|------:|
-| Public schema fields compared | 318 |
-| Public schema type matches | 318/318 |
-| Public schema nullable matches | 253/318 |
-| Public schema client JSON mappings | 248/318 |
+| Public schema fields compared | 321 |
+| Public schema type matches | 321/321 |
+| Public schema nullable matches | 254/321 |
+| Public schema client JSON mappings | 251/321 |
 | Reusable public schemas compared | 10 |
 | Contract-only / inline-only models documented | 12 |
 
@@ -255,7 +255,7 @@ This section compares the internal source-derived backup model against the publi
 Coolify stores the relation as `s3_storage_id` internally, while the public API accepts `s3_storage_uuid` on request bodies.
 That identifier translation is expected and does not imply a missing top-level S3 CRUD API.
 
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Client JSON mappings: 16/19
+Fields: 22 | Type matches: 22/22 | Nullable matches: 20/22 | Client JSON mappings: 19/22
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Client JSON Mapping |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
@@ -273,6 +273,9 @@ Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Client JSON mapping
 | dump_all | boolean | boolean | yes | yes | false | mapped |
 | enabled | boolean | boolean | yes | yes | true | mapped |
 | frequency | string | string | yes | yes | - | mapped |
+| last_execution_at | string | string | yes | **WRONG** | - | mapped |
+| missing_backup_notification_days | string | string | yes | yes | - | mapped |
+| missing_backup_notification_sent_at | string | string | yes | **WRONG** | - | mapped |
 | number_of_backups_locally | integer | integer | yes | yes | 7 | n/a |
 | s3_storage_id | integer | integer | yes | yes | - | n/a |
 | save_s3 | boolean | boolean | yes | yes | true | mapped |

--- a/docs/guides/coolify-version-support.md
+++ b/docs/guides/coolify-version-support.md
@@ -39,9 +39,10 @@ output "coolify_version" {
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
 | **≥ 4.3.0** | 4.3 application settings, `noindex_domains`, notification channels, S3, volume backup schedules, GPU/log-drain, etc. |
 | **≥ 4.3.10** | Instance email settings and `smtp_ehlo_domain` on team email notifications (email/SMTP floor). |
-| **≥ 4.3.15** | Preview domain PATCH, GET `domain_port_overrides`, restart-limit fields. Recommended for the full feature set. |
+| **≥ 4.3.15** | Preview domain PATCH, GET `domain_port_overrides`, restart-limit fields. |
+| **≥ 4.3.18** | `missing_backup_notification_days` on `coolify_database_backup` (0 disables alerts). GET-only `last_execution_at` and `missing_backup_notification_sent_at`. Recommended for the full feature set. |
 
-Pinned API contract today: Coolify **v4.3.17** (`testdata/contracts/coolify-v4.json`).
+Pinned API contract today: Coolify **v4.3.18** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
 accept `is_force_https_enabled` on `PATCH /services/{uuid}/applications/{app_uuid}`.
 That route stays `nested-service` (use `coolify_service` for the stack).
@@ -49,8 +50,11 @@ v4.3.10 adds instance-wide SMTP settings (`GET`/`PATCH /settings/email`) and
 `smtp_ehlo_domain` on team email notifications. Tags v4.3.15 through v4.3.17
 add restart-limit GET fields, GET-only `domain_port_overrides`, notification
 `restart_limit_reached_*` writes, and `PATCH` preview domains on
-`coolify_application_preview`. `v4.4-rc.1` was cut before those 4.3.15
-fields. The provider remains usable on 4.1.0+ for the common surface.
+`coolify_application_preview`. Tag v4.3.18 adds
+`missing_backup_notification_days` on database backup create/update.
+`v4.4-rc.1` was cut before the 4.3.15 restart-limit fields and before the
+4.3.18 backup notification field. The provider remains usable on 4.1.0+
+for the common surface.
 
 ## Resources and data sources by Coolify version
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -82,15 +82,16 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.15** |
+| **Recommended for full features** | **≥ v4.3.18** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
 Volume backup schedules, `noindex_domains`, notifications, and S3 need
 **≥ v4.3.0**. Instance email settings and `smtp_ehlo_domain` need
 **≥ v4.3.10**. Preview domain PATCH, GET `domain_port_overrides`, and
-restart-limit fields need **≥ v4.3.15**. The pinned API contract is
-Coolify **v4.3.17** (extract provenance), not a new feature floor.
+restart-limit fields need **≥ v4.3.15**. Missing-backup notifications on
+`coolify_database_backup` need **≥ v4.3.18**. The pinned API contract is
+Coolify **v4.3.18** (extract provenance), not a new feature floor.
 
 For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
 and how version gates behave), see

--- a/docs/resources/database_backup.md
+++ b/docs/resources/database_backup.md
@@ -20,12 +20,13 @@ variable "existing_s3_storage_uuid" {
 }
 
 resource "coolify_database_backup" "daily" {
-  database_uuid         = coolify_database_postgresql.example.uuid
-  frequency             = "0 2 * * *"
-  enabled               = true
-  save_s3               = true
-  retain_amount_locally = 7 # Number of backup copies to keep (not days)
-  s3_storage_uuid       = var.existing_s3_storage_uuid
+  database_uuid                    = coolify_database_postgresql.example.uuid
+  frequency                        = "0 2 * * *"
+  enabled                          = true
+  save_s3                          = true
+  retain_amount_locally            = 7 # Number of backup copies to keep (not days)
+  s3_storage_uuid                  = var.existing_s3_storage_uuid
+  missing_backup_notification_days = 2 # Requires Coolify >= v4.3.18
 }
 ```
 
@@ -43,6 +44,7 @@ resource "coolify_database_backup" "daily" {
 - `databases_to_backup` (String) Comma-separated list of database names to back up selectively. Defaults to the primary database name if not specified.
 - `dump_all` (Boolean) Whether to dump all databases.
 - `enabled` (Boolean) Whether the backup schedule is active.
+- `missing_backup_notification_days` (Number) Days without a backup execution before Coolify sends a missing-backup notification. `0` disables alerts. Valid range is 0-365. Requires Coolify >= v4.3.18. Absent from `v4.4-rc.1` (that rc was cut before the field). On older instances the provider keeps the value in state and does not send it.
 - `retain_amount_locally` (Number) Number of backup copies to retain locally.
 - `retain_amount_s3` (Number) Number of backup copies to retain in S3.
 - `retain_days_locally` (Number) Number of days to retain backups locally.
@@ -58,6 +60,8 @@ resource "coolify_database_backup" "daily" {
 - `description` (String) Optional description of the backup schedule. Read-only: Coolify does not accept this field on the public create/update backup API (UI-only write). Present when set out-of-band.
 - `disable_local_backup` (Boolean) Whether local backup retention is disabled. Read-only: Coolify does not accept this field on the public create/update backup API (UI-only write).
 - `id` (Number) The numeric ID of the backup configuration.
+- `last_execution_at` (String) Timestamp of the last backup execution. Read-only. Coolify >= v4.3.18.
+- `missing_backup_notification_sent_at` (String) Timestamp of the last missing-backup notification. Read-only. Coolify >= v4.3.18.
 - `uuid` (String) The UUID of the backup configuration.
 
 ## Import

--- a/examples/resources/coolify_database_backup/resource.tf
+++ b/examples/resources/coolify_database_backup/resource.tf
@@ -5,10 +5,11 @@ variable "existing_s3_storage_uuid" {
 }
 
 resource "coolify_database_backup" "daily" {
-  database_uuid         = coolify_database_postgresql.example.uuid
-  frequency             = "0 2 * * *"
-  enabled               = true
-  save_s3               = true
-  retain_amount_locally = 7 # Number of backup copies to keep (not days)
-  s3_storage_uuid       = var.existing_s3_storage_uuid
+  database_uuid                    = coolify_database_postgresql.example.uuid
+  frequency                        = "0 2 * * *"
+  enabled                          = true
+  save_s3                          = true
+  retain_amount_locally            = 7 # Number of backup copies to keep (not days)
+  s3_storage_uuid                  = var.existing_s3_storage_uuid
+  missing_backup_notification_days = 2 # Requires Coolify >= v4.3.18
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -913,6 +913,78 @@ func AccTestSMTPEhloDomainAccepted(t *testing.T) bool {
 	return ok
 }
 
+// missingBackupNotificationDaysProbeDB is a fake database UUID. Coolify
+// validates missing_backup_notification_days before looking the database
+// up, so -1 extra-key/min probes do not create a backup.
+const missingBackupNotificationDaysProbeDB = "00000000-0000-4000-8000-000000000099"
+
+// coolifyAcceptsMissingBackupNotificationDays POSTs an invalid
+// missing_backup_notification_days (-1) on backup create. ok is true
+// when Coolify treated the key as allowed (validation 422). Extra-key
+// 422 or 404 (old API looks up the database before extra-field check)
+// means the field is absent. Do not use AccTestSkipIfCoolifyBelow:
+// CI edge reports 4.3.0 while already shipping v4.3.18 fields.
+func coolifyAcceptsMissingBackupNotificationDays(t *testing.T) (ok bool, detail string) {
+	t.Helper()
+	TestAccPreCheck(t)
+
+	endpoint := strings.TrimRight(os.Getenv("COOLIFY_ENDPOINT"), "/")
+	token := os.Getenv("COOLIFY_TOKEN")
+	path := endpoint + "/api/v1/databases/" + missingBackupNotificationDaysProbeDB + "/backups"
+	body := `{"frequency":"0 2 * * *","missing_backup_notification_days":-1}`
+	req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building missing_backup_notification_days probe request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Sprintf("missing_backup_notification_days extra-key probe failed (cannot reach Coolify): %v", err)
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	msg := strings.ToLower(string(raw))
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusUnauthorized, http.StatusForbidden:
+		return true, ""
+	case http.StatusUnprocessableEntity:
+		if isExtraKeyNotAllowed(msg) {
+			return false, fmt.Sprintf("Coolify extra-key 422s missing_backup_notification_days (need Coolify >= v4.3.18). Body: %s",
+				truncateForSkip(string(raw), 200))
+		}
+		// Validation 422 (min:0) means the field is allowed.
+		return true, ""
+	case http.StatusNotFound, http.StatusMethodNotAllowed:
+		// Old create_backup looks up the database before extra-field
+		// check, so a fake UUID 404s when the key is not in the
+		// validator. Treat as absent.
+		return false, fmt.Sprintf("Coolify has no missing_backup_notification_days write (HTTP %d). Body: %s",
+			resp.StatusCode, truncateForSkip(string(raw), 200))
+	default:
+		if resp.StatusCode >= 500 {
+			return false, fmt.Sprintf("missing_backup_notification_days extra-key probe returned HTTP %d: %s",
+				resp.StatusCode, truncateForSkip(string(raw), 200))
+		}
+		return true, ""
+	}
+}
+
+// AccTestSkipIfNoMissingBackupNotificationDays skips when backup create
+// extra-key 422s or 404s missing_backup_notification_days (Coolify
+// before v4.3.18, or v4.4-rc.1). Soft-skip even when
+// COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0.
+func AccTestSkipIfNoMissingBackupNotificationDays(t *testing.T) {
+	t.Helper()
+	ok, detail := coolifyAcceptsMissingBackupNotificationDays(t)
+	if !ok {
+		t.Skip(detail)
+	}
+}
+
 // AccTestSkipIfNoPreviewDomainUpdate skips when PATCH
 // /applications/{uuid}/previews/{pr} is an unmatched route (plain
 // "Not found." or empty). Soft-skip unmatched 404/405 even when

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -358,6 +358,105 @@ func TestAccTestSkipIfNoSMTPEhloDomain_ValidationPresent(t *testing.T) {
 	AccTestSkipIfNoSMTPEhloDomain(t)
 }
 
+func TestAccTestSkipIfNoMissingBackupNotificationDays_ExtraKey(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{uuid}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation failed.","errors":{"missing_backup_notification_days":["This field is not allowed."]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoMissingBackupNotificationDays(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoMissingBackupNotificationDays to skip on extra-key 422")
+	}
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "1")
+	reachedTip := false
+	t.Run("skip-under-require-tip", func(t *testing.T) {
+		AccTestSkipIfNoMissingBackupNotificationDays(t)
+		reachedTip = true
+	})
+	if reachedTip {
+		t.Fatal("missing_backup_notification_days extra-key 422 must soft-skip under COOLIFY_REQUIRE_TIP_APIS=1")
+	}
+}
+
+func TestAccTestSkipIfNoMissingBackupNotificationDays_ValidationPresent(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{uuid}/backups", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode probe body: %v", err)
+		}
+		if body["missing_backup_notification_days"] != float64(-1) {
+			t.Fatalf("probe days = %v, want -1", body["missing_backup_notification_days"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation failed.","errors":{"missing_backup_notification_days":["The missing backup notification days must be at least 0."]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	AccTestSkipIfNoMissingBackupNotificationDays(t)
+}
+
+func TestAccTestSkipIfNoMissingBackupNotificationDays_NotFound(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.17"})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{uuid}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Database not found."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoMissingBackupNotificationDays(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoMissingBackupNotificationDays to skip on 404")
+	}
+}
+
 func TestAccTestSkipIfNoPreviewDomainUpdate_PlainNotFound(t *testing.T) {
 	resetAccTestCaches()
 	defer resetAccTestCaches()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2225,6 +2225,48 @@ func TestClient_CreateDatabaseBackup(t *testing.T) {
 	assert.True(t, b.Enabled)
 }
 
+func TestClient_CreateDatabaseBackup_MissingBackupNotificationDaysVersionGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		wantKey bool
+	}{
+		{"4.3.17 withholds", "4.3.17", false},
+		{"4.3.0 sends (CI edge version lie)", "4.3.0", true},
+		{"4.3.18 sends", "4.3.18", true},
+		{"4.4-rc.1 withholds", "4.4-rc.1", false},
+		{"empty version sends", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var lastPost map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&lastPost))
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(DatabaseBackup{UUID: "bk-new"})
+			}))
+			defer srv.Close()
+			c := New(srv.URL, "test-token")
+			c.CoolifyVersion = tt.version
+			days := int64(3)
+			_, err := c.CreateDatabaseBackup(context.Background(), "db-uuid-1", CreateDatabaseBackupInput{
+				Frequency:                     "0 2 * * *",
+				Enabled:                       true,
+				MissingBackupNotificationDays: &days,
+			})
+			require.NoError(t, err)
+			_, sent := lastPost["missing_backup_notification_days"]
+			if sent != tt.wantKey {
+				t.Errorf("Coolify %q: missing_backup_notification_days sent=%v, want %v (body=%v)",
+					tt.version, sent, tt.wantKey, lastPost)
+			}
+		})
+	}
+}
+
 func TestClient_UpdateDatabaseBackup(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/databases.go
+++ b/internal/client/databases.go
@@ -347,6 +347,14 @@ type DatabaseBackup struct {
 	RetainDaysS3          *int64   `json:"database_backup_retention_days_s3,omitempty"`
 	RetainMaxStorageS3    *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
 	Timeout               *int64   `json:"timeout,omitempty"`
+	// MissingBackupNotificationDays is days without an execution before
+	// Coolify sends a missing-backup alert. 0 disables alerts.
+	// Requires Coolify >= v4.3.18. Absent from v4.4-rc.1.
+	MissingBackupNotificationDays *int64 `json:"missing_backup_notification_days,omitempty"`
+	// LastExecutionAt is GET-only (runtime). Coolify jobs update it.
+	LastExecutionAt string `json:"last_execution_at,omitempty"`
+	// MissingBackupNotificationSentAt is GET-only (runtime).
+	MissingBackupNotificationSentAt string `json:"missing_backup_notification_sent_at,omitempty"`
 }
 
 type CreateDatabaseBackupInput struct {
@@ -364,6 +372,8 @@ type CreateDatabaseBackupInput struct {
 	RetainDaysS3          *int64   `json:"database_backup_retention_days_s3,omitempty"`
 	RetainMaxStorageS3    *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
 	Timeout               *int64   `json:"timeout,omitempty"`
+	// MissingBackupNotificationDays requires Coolify >= v4.3.18.
+	MissingBackupNotificationDays *int64 `json:"missing_backup_notification_days,omitempty"`
 }
 
 type UpdateDatabaseBackupInput struct {
@@ -380,6 +390,8 @@ type UpdateDatabaseBackupInput struct {
 	RetainDaysS3          *int64   `json:"database_backup_retention_days_s3,omitempty"`
 	RetainMaxStorageS3    *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
 	Timeout               *int64   `json:"timeout,omitempty"`
+	// MissingBackupNotificationDays requires Coolify >= v4.3.18.
+	MissingBackupNotificationDays *int64 `json:"missing_backup_notification_days,omitempty"`
 }
 
 func (c *Client) ListDatabaseBackups(ctx context.Context, dbUUID string) ([]DatabaseBackup, error) {
@@ -391,6 +403,9 @@ func (c *Client) ListDatabaseBackups(ctx context.Context, dbUUID string) ([]Data
 }
 
 func (c *Client) CreateDatabaseBackup(ctx context.Context, dbUUID string, input CreateDatabaseBackupInput) (*DatabaseBackup, error) {
+	if !c.SupportsMissingBackupNotificationDays() {
+		input.MissingBackupNotificationDays = nil
+	}
 	var b DatabaseBackup
 	if err := c.doWithStatus(ctx, http.MethodPost, fmt.Sprintf("/api/v1/databases/%s/backups", url.PathEscape(dbUUID)), input, &b, http.StatusCreated); err != nil {
 		return nil, fmt.Errorf("creating backup for database %s: %w", dbUUID, err)
@@ -400,6 +415,9 @@ func (c *Client) CreateDatabaseBackup(ctx context.Context, dbUUID string, input 
 }
 
 func (c *Client) UpdateDatabaseBackup(ctx context.Context, dbUUID string, backupUUID string, input UpdateDatabaseBackupInput) (*DatabaseBackup, error) {
+	if !c.SupportsMissingBackupNotificationDays() {
+		input.MissingBackupNotificationDays = nil
+	}
 	var b DatabaseBackup
 	if err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/api/v1/databases/%s/backups/%s", url.PathEscape(dbUUID), url.PathEscape(backupUUID)), input, &b); err != nil {
 		return nil, fmt.Errorf("updating backup %s for database %s: %w", backupUUID, dbUUID, err)

--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -154,6 +154,43 @@ func (c *Client) SupportsSMTPEhloDomain() bool {
 	return IsVersionAtLeast(c.CoolifyVersion, minSMTPEhloDomainVersion)
 }
 
+// minMissingBackupNotificationDaysVersion is the first Coolify git tag
+// whose database backup create/update allow lists include
+// missing_backup_notification_days.
+//
+// The field landed in tag v4.3.18 (and later 4.3.x tip). It is absent
+// from v4.3.17 and from v4.4-rc.1 (that rc was cut before the field).
+const minMissingBackupNotificationDaysVersion = "4.3.18"
+
+// versionIs44Prerelease reports Coolify 4.4 release-candidate version
+// strings. Those cuts predate missing_backup_notification_days.
+func versionIs44Prerelease(ver string) bool {
+	v := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(ver)), "v")
+	return strings.HasPrefix(v, "4.4-rc") || strings.HasPrefix(v, "4.4.0-rc")
+}
+
+// SupportsMissingBackupNotificationDays reports whether the connected
+// instance accepts missing_backup_notification_days on database backup
+// create and update.
+//
+// Empty CoolifyVersion reports true (same rationale as SupportsApplicationSettings).
+// A 4.3.0 version string also reports true: CI edge lies with that
+// string while shipping later tip fields. Acc tests must still extra-key
+// probe before writing so a real 4.3.0 extra-key 422 is skipped.
+// 4.4-rc.* reports false: v4.4-rc.1 was cut without the write field.
+func (c *Client) SupportsMissingBackupNotificationDays() bool {
+	if c == nil || c.CoolifyVersion == "" {
+		return true
+	}
+	if versionIs44Prerelease(c.CoolifyVersion) {
+		return false
+	}
+	if versionStringLagsTip(c.CoolifyVersion) {
+		return true
+	}
+	return IsVersionAtLeast(c.CoolifyVersion, minMissingBackupNotificationDaysVersion)
+}
+
 // IsVersionAtLeast compares two semver-like version strings (e.g. "4.0.0").
 // Returns true if actual >= minimum. Non-parseable versions return true
 // to avoid blocking on unexpected version formats.

--- a/internal/client/version_gate_test.go
+++ b/internal/client/version_gate_test.go
@@ -207,6 +207,39 @@ func TestSupportsSMTPEhloDomain(t *testing.T) {
 	}
 }
 
+func TestSupportsMissingBackupNotificationDays(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"4.3.17", false},
+		{"v4.3.17", false},
+		{"4.3.0", true}, // CI edge version lie
+		{"v4.3.0-edge", true},
+		{"4.3.18", true},
+		{"v4.3.18", true},
+		{"4.3.19", true},
+		{"4.4.0", true},
+		{"4.4-rc.1", false}, // cut before the write field
+		{"v4.4-rc.1", false},
+		{"4.4.0-rc.1", false},
+		{"", true},
+		{"not-a-version", true},
+	}
+	for _, tt := range tests {
+		c := &Client{CoolifyVersion: tt.version}
+		if got := c.SupportsMissingBackupNotificationDays(); got != tt.want {
+			t.Errorf("SupportsMissingBackupNotificationDays(%q) = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+	var nilClient *Client
+	if !nilClient.SupportsMissingBackupNotificationDays() {
+		t.Error("nil client should assume newest behaviour rather than panic")
+	}
+}
+
 func TestSupportsPreviewDomainUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/database/backup/resource.go
+++ b/internal/service/database/backup/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/flex"
 	"github.com/coolify-terraform/terraform-provider-coolify/internal/validate"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -36,25 +37,28 @@ type databaseBackupResource struct {
 }
 
 type databaseBackupResourceModel struct {
-	ID                    types.Int64  `tfsdk:"id"`
-	UUID                  types.String `tfsdk:"uuid"`
-	DatabaseUUID          types.String `tfsdk:"database_uuid"`
-	Frequency             types.String `tfsdk:"frequency"`
-	Enabled               types.Bool   `tfsdk:"enabled"`
-	Description           types.String `tfsdk:"description"`
-	DisableLocalBackup    types.Bool   `tfsdk:"disable_local_backup"`
-	SaveS3                types.Bool   `tfsdk:"save_s3"`
-	S3StorageUUID         types.String `tfsdk:"s3_storage_uuid"`
-	DatabasesToBackup     types.String `tfsdk:"databases_to_backup"`
-	DumpAll               types.Bool   `tfsdk:"dump_all"`
-	BackupNow             types.Bool   `tfsdk:"backup_now"`
-	RetainAmountLocally   types.Int64  `tfsdk:"retain_amount_locally"`
-	RetainDaysLocally     types.Int64  `tfsdk:"retain_days_locally"`
-	RetainMaxStorageLocal types.Int64  `tfsdk:"retain_max_storage_locally"`
-	RetainAmountS3        types.Int64  `tfsdk:"retain_amount_s3"`
-	RetainDaysS3          types.Int64  `tfsdk:"retain_days_s3"`
-	RetainMaxStorageS3    types.Int64  `tfsdk:"retain_max_storage_s3"`
-	Timeout               types.Int64  `tfsdk:"timeout"`
+	ID                              types.Int64  `tfsdk:"id"`
+	UUID                            types.String `tfsdk:"uuid"`
+	DatabaseUUID                    types.String `tfsdk:"database_uuid"`
+	Frequency                       types.String `tfsdk:"frequency"`
+	Enabled                         types.Bool   `tfsdk:"enabled"`
+	Description                     types.String `tfsdk:"description"`
+	DisableLocalBackup              types.Bool   `tfsdk:"disable_local_backup"`
+	SaveS3                          types.Bool   `tfsdk:"save_s3"`
+	S3StorageUUID                   types.String `tfsdk:"s3_storage_uuid"`
+	DatabasesToBackup               types.String `tfsdk:"databases_to_backup"`
+	DumpAll                         types.Bool   `tfsdk:"dump_all"`
+	BackupNow                       types.Bool   `tfsdk:"backup_now"`
+	RetainAmountLocally             types.Int64  `tfsdk:"retain_amount_locally"`
+	RetainDaysLocally               types.Int64  `tfsdk:"retain_days_locally"`
+	RetainMaxStorageLocal           types.Int64  `tfsdk:"retain_max_storage_locally"`
+	RetainAmountS3                  types.Int64  `tfsdk:"retain_amount_s3"`
+	RetainDaysS3                    types.Int64  `tfsdk:"retain_days_s3"`
+	RetainMaxStorageS3              types.Int64  `tfsdk:"retain_max_storage_s3"`
+	Timeout                         types.Int64  `tfsdk:"timeout"`
+	MissingBackupNotificationDays   types.Int64  `tfsdk:"missing_backup_notification_days"`
+	LastExecutionAt                 types.String `tfsdk:"last_execution_at"`
+	MissingBackupNotificationSentAt types.String `tfsdk:"missing_backup_notification_sent_at"`
 }
 
 func NewResource() resource.Resource { return &databaseBackupResource{} }
@@ -189,6 +193,26 @@ func (r *databaseBackupResource) Schema(_ context.Context, _ resource.SchemaRequ
 				PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 				Validators:          []validator.Int64{int64validator.Between(60, 36000)},
 			},
+			"missing_backup_notification_days": schema.Int64Attribute{
+				MarkdownDescription: "Days without a backup execution before Coolify sends a missing-backup notification. " +
+					"`0` disables alerts. Valid range is 0-365. " +
+					"Requires Coolify >= v4.3.18. Absent from `v4.4-rc.1` (that rc was cut before the field). " +
+					"On older instances the provider keeps the value in state and does not send it.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+				Validators:    []validator.Int64{int64validator.Between(0, 365)},
+			},
+			"last_execution_at": schema.StringAttribute{
+				MarkdownDescription: "Timestamp of the last backup execution. Read-only. Coolify >= v4.3.18.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"missing_backup_notification_sent_at": schema.StringAttribute{
+				MarkdownDescription: "Timestamp of the last missing-backup notification. Read-only. Coolify >= v4.3.18.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -245,6 +269,7 @@ func (r *databaseBackupResource) Create(ctx context.Context, req resource.Create
 	input.RetainDaysS3 = flex.Int64PtrFromFramework(plan.RetainDaysS3)
 	input.RetainMaxStorageS3 = flex.Float64PtrFromInt64Framework(plan.RetainMaxStorageS3)
 	input.Timeout = flex.Int64PtrFromFramework(plan.Timeout)
+	input.MissingBackupNotificationDays = flex.Int64PtrFromFramework(plan.MissingBackupNotificationDays)
 
 	created, err := r.client.CreateDatabaseBackup(ctx, plan.DatabaseUUID.ValueString(), input)
 	if err != nil {
@@ -256,39 +281,8 @@ func (r *databaseBackupResource) Create(ctx context.Context, req resource.Create
 	// the full backup object. Save partial state immediately so the
 	// resource is tracked even if the follow-up read fails.
 	plan.UUID = types.StringValue(created.UUID)
-	if plan.ID.IsUnknown() {
-		plan.ID = types.Int64Null()
-	}
-	if plan.Enabled.IsUnknown() {
-		plan.Enabled = types.BoolNull()
-	}
-	if plan.SaveS3.IsUnknown() {
-		plan.SaveS3 = types.BoolNull()
-	}
-	if plan.DumpAll.IsUnknown() {
-		plan.DumpAll = types.BoolNull()
-	}
-	if plan.RetainAmountLocally.IsUnknown() {
-		plan.RetainAmountLocally = types.Int64Null()
-	}
-	if plan.RetainDaysLocally.IsUnknown() {
-		plan.RetainDaysLocally = types.Int64Null()
-	}
-	if plan.RetainMaxStorageLocal.IsUnknown() {
-		plan.RetainMaxStorageLocal = types.Int64Null()
-	}
-	if plan.RetainAmountS3.IsUnknown() {
-		plan.RetainAmountS3 = types.Int64Null()
-	}
-	if plan.RetainDaysS3.IsUnknown() {
-		plan.RetainDaysS3 = types.Int64Null()
-	}
-	if plan.RetainMaxStorageS3.IsUnknown() {
-		plan.RetainMaxStorageS3 = types.Int64Null()
-	}
-	if plan.Timeout.IsUnknown() {
-		plan.Timeout = types.Int64Null()
-	}
+	nullUnknownBackupComputed(&plan)
+	warnUnsupportedMissingBackupNotificationDays(r.client, plan, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -376,21 +370,23 @@ func (r *databaseBackupResource) Update(ctx context.Context, req resource.Update
 	backupID := int(state.ID.ValueInt64())
 
 	input := client.UpdateDatabaseBackupInput{
-		Frequency:             flex.StringIfChanged(plan.Frequency, state.Frequency),
-		Enabled:               flex.BoolIfChanged(plan.Enabled, state.Enabled),
-		SaveS3:                flex.BoolIfChanged(plan.SaveS3, state.SaveS3),
-		S3StorageID:           flex.StringPtrForUpdate(plan.S3StorageUUID, state.S3StorageUUID),
-		DatabasesToBackup:     flex.StringPtrForUpdate(plan.DatabasesToBackup, state.DatabasesToBackup),
-		DumpAll:               flex.BoolIfChanged(plan.DumpAll, state.DumpAll),
-		RetainAmountLocally:   flex.Int64IfChanged(plan.RetainAmountLocally, state.RetainAmountLocally),
-		RetainDaysLocally:     flex.Int64IfChanged(plan.RetainDaysLocally, state.RetainDaysLocally),
-		RetainMaxStorageLocal: flex.Float64IfChangedFromInt64(plan.RetainMaxStorageLocal, state.RetainMaxStorageLocal),
-		RetainAmountS3:        flex.Int64IfChanged(plan.RetainAmountS3, state.RetainAmountS3),
-		RetainDaysS3:          flex.Int64IfChanged(plan.RetainDaysS3, state.RetainDaysS3),
-		RetainMaxStorageS3:    flex.Float64IfChangedFromInt64(plan.RetainMaxStorageS3, state.RetainMaxStorageS3),
-		Timeout:               flex.Int64IfChanged(plan.Timeout, state.Timeout),
+		Frequency:                     flex.StringIfChanged(plan.Frequency, state.Frequency),
+		Enabled:                       flex.BoolIfChanged(plan.Enabled, state.Enabled),
+		SaveS3:                        flex.BoolIfChanged(plan.SaveS3, state.SaveS3),
+		S3StorageID:                   flex.StringPtrForUpdate(plan.S3StorageUUID, state.S3StorageUUID),
+		DatabasesToBackup:             flex.StringPtrForUpdate(plan.DatabasesToBackup, state.DatabasesToBackup),
+		DumpAll:                       flex.BoolIfChanged(plan.DumpAll, state.DumpAll),
+		RetainAmountLocally:           flex.Int64IfChanged(plan.RetainAmountLocally, state.RetainAmountLocally),
+		RetainDaysLocally:             flex.Int64IfChanged(plan.RetainDaysLocally, state.RetainDaysLocally),
+		RetainMaxStorageLocal:         flex.Float64IfChangedFromInt64(plan.RetainMaxStorageLocal, state.RetainMaxStorageLocal),
+		RetainAmountS3:                flex.Int64IfChanged(plan.RetainAmountS3, state.RetainAmountS3),
+		RetainDaysS3:                  flex.Int64IfChanged(plan.RetainDaysS3, state.RetainDaysS3),
+		RetainMaxStorageS3:            flex.Float64IfChangedFromInt64(plan.RetainMaxStorageS3, state.RetainMaxStorageS3),
+		Timeout:                       flex.Int64IfChanged(plan.Timeout, state.Timeout),
+		MissingBackupNotificationDays: flex.Int64IfChanged(plan.MissingBackupNotificationDays, state.MissingBackupNotificationDays),
 	}
 
+	warnUnsupportedMissingBackupNotificationDays(r.client, plan, &resp.Diagnostics)
 	if _, err := r.client.UpdateDatabaseBackup(ctx, dbUUID, state.UUID.ValueString(), input); err != nil {
 		resp.Diagnostics.AddError("Error updating database backup", fmt.Sprintf("backup %s for database %s: %s", state.UUID.ValueString(), dbUUID, err))
 		return
@@ -548,6 +544,51 @@ func (r *databaseBackupResource) readBackup(ctx context.Context, dbUUID string, 
 	return nil, nil
 }
 
+func nullUnknownBackupComputed(plan *databaseBackupResourceModel) {
+	if plan.ID.IsUnknown() {
+		plan.ID = types.Int64Null()
+	}
+	if plan.Enabled.IsUnknown() {
+		plan.Enabled = types.BoolNull()
+	}
+	if plan.SaveS3.IsUnknown() {
+		plan.SaveS3 = types.BoolNull()
+	}
+	if plan.DumpAll.IsUnknown() {
+		plan.DumpAll = types.BoolNull()
+	}
+	if plan.RetainAmountLocally.IsUnknown() {
+		plan.RetainAmountLocally = types.Int64Null()
+	}
+	if plan.RetainDaysLocally.IsUnknown() {
+		plan.RetainDaysLocally = types.Int64Null()
+	}
+	if plan.RetainMaxStorageLocal.IsUnknown() {
+		plan.RetainMaxStorageLocal = types.Int64Null()
+	}
+	if plan.RetainAmountS3.IsUnknown() {
+		plan.RetainAmountS3 = types.Int64Null()
+	}
+	if plan.RetainDaysS3.IsUnknown() {
+		plan.RetainDaysS3 = types.Int64Null()
+	}
+	if plan.RetainMaxStorageS3.IsUnknown() {
+		plan.RetainMaxStorageS3 = types.Int64Null()
+	}
+	if plan.Timeout.IsUnknown() {
+		plan.Timeout = types.Int64Null()
+	}
+	if plan.MissingBackupNotificationDays.IsUnknown() {
+		plan.MissingBackupNotificationDays = types.Int64Null()
+	}
+	if plan.LastExecutionAt.IsUnknown() {
+		plan.LastExecutionAt = types.StringNull()
+	}
+	if plan.MissingBackupNotificationSentAt.IsUnknown() {
+		plan.MissingBackupNotificationSentAt = types.StringNull()
+	}
+}
+
 func flattenDatabaseBackup(b *client.DatabaseBackup, m *databaseBackupResourceModel) {
 	m.ID = types.Int64Value(int64(b.ID))
 	m.UUID = types.StringValue(b.UUID)
@@ -576,4 +617,42 @@ func flattenDatabaseBackup(b *client.DatabaseBackup, m *databaseBackupResourceMo
 	m.RetainDaysS3 = flex.Int64PtrToFramework(b.RetainDaysS3)
 	m.RetainMaxStorageS3 = flex.Float64PtrToInt64Framework(b.RetainMaxStorageS3)
 	m.Timeout = flex.Int64PtrToFramework(b.Timeout)
+	if b.MissingBackupNotificationDays != nil {
+		m.MissingBackupNotificationDays = types.Int64Value(*b.MissingBackupNotificationDays)
+	} else if m.MissingBackupNotificationDays.IsUnknown() {
+		m.MissingBackupNotificationDays = types.Int64Null()
+	}
+	if b.LastExecutionAt != "" {
+		m.LastExecutionAt = types.StringValue(b.LastExecutionAt)
+	} else if m.LastExecutionAt.IsUnknown() {
+		m.LastExecutionAt = types.StringNull()
+	}
+	if b.MissingBackupNotificationSentAt != "" {
+		m.MissingBackupNotificationSentAt = types.StringValue(b.MissingBackupNotificationSentAt)
+	} else if m.MissingBackupNotificationSentAt.IsUnknown() {
+		m.MissingBackupNotificationSentAt = types.StringNull()
+	}
+}
+
+func warnUnsupportedMissingBackupNotificationDays(c *client.Client, plan databaseBackupResourceModel, diags *diag.Diagnostics) {
+	if diags == nil || c == nil || c.SupportsMissingBackupNotificationDays() {
+		return
+	}
+	if plan.MissingBackupNotificationDays.IsNull() || plan.MissingBackupNotificationDays.IsUnknown() {
+		return
+	}
+	ver := c.CoolifyVersion
+	if ver == "" {
+		ver = "unknown"
+	}
+	diags.AddWarning(
+		"Coolify version cannot write missing_backup_notification_days",
+		fmt.Sprintf(
+			"This Coolify instance (%s) does not accept missing_backup_notification_days (added in Coolify v4.3.18). "+
+				"The provider will keep the value in Terraform state but will not send it to the Coolify API. "+
+				"Upgrade to Coolify v4.3.18 or later, or remove missing_backup_notification_days from configuration. "+
+				"v4.4-rc.1 was cut before this field.",
+			ver,
+		),
+	)
 }

--- a/internal/service/database/backup/resource_acc_test.go
+++ b/internal/service/database/backup/resource_acc_test.go
@@ -87,6 +87,61 @@ resource "coolify_database_backup" "test" {
 // TestAccDatabaseBackupResource_S3 — S3 backup workflow against real MinIO
 // ---------------------------------------------------------------------------
 
+func TestAccDatabaseBackupResource_MissingBackupNotificationDays(t *testing.T) {
+	t.Parallel()
+	acctest.AccTestSkipIfNoTFAcc(t)
+	acctest.TestAccPreCheck(t)
+	acctest.AccTestSkipIfNoMissingBackupNotificationDays(t)
+	serverUUID := acctest.AccTestServerUUID(t)
+	name := acctest.RandomWithPrefix("tf-acc-bkp-miss")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             acctest.AccCheckNestedDestroy("coolify_database_backup", "database_uuid", "/api/v1/databases/%s/backups"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupMissingNotificationConfig(name, serverUUID, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_backup.test", "missing_backup_notification_days", "3"),
+					resource.TestCheckResourceAttrSet("coolify_database_backup.test", "uuid"),
+				),
+			},
+			{
+				Config:             testAccBackupMissingNotificationConfig(name, serverUUID, 3),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccBackupMissingNotificationConfig(name, serverUUID, 7),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_backup.test", "missing_backup_notification_days", "7"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBackupMissingNotificationConfig(name, serverUUID string, days int) string {
+	return acctest.ConfigProviderBlock() + fmt.Sprintf(`
+resource "coolify_project" "test" {
+  name = %[1]q
+}
+
+resource "coolify_database_postgresql" "test" {
+  project_uuid = coolify_project.test.uuid
+  server_uuid  = %[2]q
+  name         = %[1]q
+}
+
+resource "coolify_database_backup" "test" {
+  database_uuid                    = coolify_database_postgresql.test.uuid
+  frequency                        = "0 2 * * *"
+  enabled                          = true
+  missing_backup_notification_days = %[3]d
+}
+`, name, serverUUID, days)
+}
+
 func TestAccDatabaseBackupResource_S3(t *testing.T) {
 	t.Parallel()
 	acctest.AccTestSkipIfNoTFAcc(t)

--- a/internal/service/database/backup/resource_test.go
+++ b/internal/service/database/backup/resource_test.go
@@ -34,10 +34,17 @@ type mockBackupState struct {
 	s3StorageID       string
 	databasesToBackup string
 	retainDays        *int64
+	missingDays       *int64
+	sawMissingDays    bool
+	lastExecutionAt   string
 	deleted           bool
 }
 
 func newMockBackupServer() (*httptest.Server, *mockBackupState) {
+	return newMockBackupServerVersion(acctest.DefaultTestCoolifyVersion)
+}
+
+func newMockBackupServerVersion(version string) (*httptest.Server, *mockBackupState) {
 	state := &mockBackupState{
 		id:     42,
 		uuid:   "bkp-uuid-001",
@@ -47,7 +54,7 @@ func newMockBackupServer() (*httptest.Server, *mockBackupState) {
 		// matching values masked body serialization bugs.
 	}
 
-	srv := httptest.NewServer(acctest.WithVersionEndpoint(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(acctest.WithVersionEndpointVersion(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		state.mu.Lock()
 		defer state.mu.Unlock()
@@ -74,6 +81,13 @@ func newMockBackupServer() (*httptest.Server, *mockBackupState) {
 			if v, ok := body["database_backup_retention_amount_locally"].(float64); ok {
 				i := int64(v)
 				state.retainDays = &i
+			}
+			if v, ok := body["missing_backup_notification_days"]; ok {
+				state.sawMissingDays = true
+				if f, ok := v.(float64); ok {
+					i := int64(f)
+					state.missingDays = &i
+				}
 			}
 			// Real Coolify API returns only uuid+message on create.
 			w.WriteHeader(http.StatusCreated)
@@ -129,6 +143,13 @@ func newMockBackupServer() (*httptest.Server, *mockBackupState) {
 					}
 				}
 			}
+			if v, ok := body["missing_backup_notification_days"]; ok {
+				state.sawMissingDays = true
+				if f, ok := v.(float64); ok {
+					i := int64(f)
+					state.missingDays = &i
+				}
+			}
 			// Real Coolify API returns only message on update.
 			json.NewEncoder(w).Encode(map[string]string{"message": "Database backup configuration updated"})
 
@@ -142,7 +163,7 @@ func newMockBackupServer() (*httptest.Server, *mockBackupState) {
 			w.WriteHeader(http.StatusNotFound)
 			json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
 		}
-	})))
+	}), version))
 	return srv, state
 }
 
@@ -164,6 +185,12 @@ func backupResponse(s *mockBackupState) map[string]interface{} {
 	}
 	if s.retainDays != nil {
 		resp["database_backup_retention_amount_locally"] = *s.retainDays
+	}
+	if s.missingDays != nil {
+		resp["missing_backup_notification_days"] = *s.missingDays
+	}
+	if s.lastExecutionAt != "" {
+		resp["last_execution_at"] = s.lastExecutionAt
 	}
 	return resp
 }
@@ -687,6 +714,94 @@ func TestDatabaseBackupResource_S3RoundTrip(t *testing.T) {
 				`),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestDatabaseBackupResource_MissingBackupNotificationDays(t *testing.T) {
+	t.Parallel()
+	srv, state := newMockBackupServerVersion("v4.3.18")
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             checkBackupDestroy(srv.URL),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackupConfig(srv.URL, `
+					database_uuid                     = "eeee0001-0001-4000-8000-000000000001"
+					frequency                         = "0 2 * * *"
+					enabled                           = true
+					missing_backup_notification_days  = 3
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_backup.test", "missing_backup_notification_days", "3"),
+					func(_ *terraform.State) error {
+						state.mu.Lock()
+						defer state.mu.Unlock()
+						if !state.sawMissingDays {
+							return fmt.Errorf("expected POST missing_backup_notification_days")
+						}
+						if state.missingDays == nil || *state.missingDays != 3 {
+							return fmt.Errorf("store missing days = %v, want 3", state.missingDays)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: testBackupConfig(srv.URL, `
+					database_uuid                     = "eeee0001-0001-4000-8000-000000000001"
+					frequency                         = "0 2 * * *"
+					enabled                           = true
+					missing_backup_notification_days  = 7
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_backup.test", "missing_backup_notification_days", "7"),
+				),
+			},
+			{
+				Config: testBackupConfig(srv.URL, `
+					database_uuid                     = "eeee0001-0001-4000-8000-000000000001"
+					frequency                         = "0 2 * * *"
+					enabled                           = true
+					missing_backup_notification_days  = 7
+				`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestDatabaseBackupResource_MissingBackupNotificationDaysWithheldOnOldCoolify(t *testing.T) {
+	t.Parallel()
+	srv, state := newMockBackupServer() // default mock version is v4.2.0-test
+	defer srv.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.TestProtoV6ProviderFactories(),
+		CheckDestroy:             checkBackupDestroy(srv.URL),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackupConfig(srv.URL, `
+					database_uuid                     = "eeee0001-0001-4000-8000-000000000001"
+					frequency                         = "0 2 * * *"
+					enabled                           = true
+					missing_backup_notification_days  = 5
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coolify_database_backup.test", "missing_backup_notification_days", "5"),
+					func(_ *terraform.State) error {
+						state.mu.Lock()
+						defer state.mu.Unlock()
+						if state.sawMissingDays {
+							return fmt.Errorf("expected missing_backup_notification_days withheld on old Coolify")
+						}
+						return nil
+					},
+				),
 			},
 		},
 	})

--- a/templates/guides/api-contract-accuracy.md.tmpl
+++ b/templates/guides/api-contract-accuracy.md.tmpl
@@ -13,16 +13,16 @@ Coolify contract extracted from the real application code.
 > `reviewed drift` means the pinned spec and source contract disagree on nullability, but the provider already handles the field safely and no runtime fix is needed.
 > `mapped` means the field name appears in the provider's internal client JSON structs. It does not guarantee Terraform schema exposure, read-after-write round trips, or full CRUD behavior.
 
-Contract version: `v4.3.17` | Extracted from: `coollabsio/coolify@v4.3.17`
+Contract version: `v4.3.18` | Extracted from: `coollabsio/coolify@v4.3.18`
 
 ## Summary
 
 | Metric | Count |
 |--------|------:|
-| Public schema fields compared | 318 |
-| Public schema type matches | 318/318 |
-| Public schema nullable matches | 253/318 |
-| Public schema client JSON mappings | 248/318 |
+| Public schema fields compared | 321 |
+| Public schema type matches | 321/321 |
+| Public schema nullable matches | 254/321 |
+| Public schema client JSON mappings | 251/321 |
 | Reusable public schemas compared | 10 |
 | Contract-only / inline-only models documented | 12 |
 
@@ -255,7 +255,7 @@ This section compares the internal source-derived backup model against the publi
 Coolify stores the relation as `s3_storage_id` internally, while the public API accepts `s3_storage_uuid` on request bodies.
 That identifier translation is expected and does not imply a missing top-level S3 CRUD API.
 
-Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Client JSON mappings: 16/19
+Fields: 22 | Type matches: 22/22 | Nullable matches: 20/22 | Client JSON mappings: 19/22
 
 | Field | Contract Type | Spec Type | Type Match | Nullable Match | Default | Client JSON Mapping |
 |-------|:---:|:---:|:---:|:---:|---------|:---:|
@@ -273,6 +273,9 @@ Fields: 19 | Type matches: 19/19 | Nullable matches: 19/19 | Client JSON mapping
 | dump_all | boolean | boolean | yes | yes | false | mapped |
 | enabled | boolean | boolean | yes | yes | true | mapped |
 | frequency | string | string | yes | yes | - | mapped |
+| last_execution_at | string | string | yes | **WRONG** | - | mapped |
+| missing_backup_notification_days | string | string | yes | yes | - | mapped |
+| missing_backup_notification_sent_at | string | string | yes | **WRONG** | - | mapped |
 | number_of_backups_locally | integer | integer | yes | yes | 7 | n/a |
 | s3_storage_id | integer | integer | yes | yes | - | n/a |
 | save_s3 | boolean | boolean | yes | yes | true | mapped |

--- a/templates/guides/coolify-version-support.md.tmpl
+++ b/templates/guides/coolify-version-support.md.tmpl
@@ -39,9 +39,10 @@ output "coolify_version" {
 | **4.2.x** | 4.2 resources and application settings writes work. 4.3-only attributes still withheld with a plan warning. |
 | **≥ 4.3.0** | 4.3 application settings, `noindex_domains`, notification channels, S3, volume backup schedules, GPU/log-drain, etc. |
 | **≥ 4.3.10** | Instance email settings and `smtp_ehlo_domain` on team email notifications (email/SMTP floor). |
-| **≥ 4.3.15** | Preview domain PATCH, GET `domain_port_overrides`, restart-limit fields. Recommended for the full feature set. |
+| **≥ 4.3.15** | Preview domain PATCH, GET `domain_port_overrides`, restart-limit fields. |
+| **≥ 4.3.18** | `missing_backup_notification_days` on `coolify_database_backup` (0 disables alerts). GET-only `last_execution_at` and `missing_backup_notification_sent_at`. Recommended for the full feature set. |
 
-Pinned API contract today: Coolify **v4.3.17** (`testdata/contracts/coolify-v4.json`).
+Pinned API contract today: Coolify **v4.3.18** (`testdata/contracts/coolify-v4.json`).
 Coolify 4.3.6 and 4.3.7 match 4.3.5. From 4.3.8, nested compose service apps
 accept `is_force_https_enabled` on `PATCH /services/{uuid}/applications/{app_uuid}`.
 That route stays `nested-service` (use `coolify_service` for the stack).
@@ -49,8 +50,11 @@ v4.3.10 adds instance-wide SMTP settings (`GET`/`PATCH /settings/email`) and
 `smtp_ehlo_domain` on team email notifications. Tags v4.3.15 through v4.3.17
 add restart-limit GET fields, GET-only `domain_port_overrides`, notification
 `restart_limit_reached_*` writes, and `PATCH` preview domains on
-`coolify_application_preview`. `v4.4-rc.1` was cut before those 4.3.15
-fields. The provider remains usable on 4.1.0+ for the common surface.
+`coolify_application_preview`. Tag v4.3.18 adds
+`missing_backup_notification_days` on database backup create/update.
+`v4.4-rc.1` was cut before the 4.3.15 restart-limit fields and before the
+4.3.18 backup notification field. The provider remains usable on 4.1.0+
+for the common surface.
 
 ## Resources and data sources by Coolify version
 

--- a/templates/guides/installation.md.tmpl
+++ b/templates/guides/installation.md.tmpl
@@ -82,15 +82,16 @@ before using the provider.
 | | Coolify |
 |--|---------|
 | **Minimum (hard floor)** | **v4.1.0** |
-| **Recommended for full features** | **≥ v4.3.15** |
+| **Recommended for full features** | **≥ v4.3.18** |
 
 The API surface changed significantly between v4.0.0 and v4.1.0, so v4.1.0
 is the minimum. Destinations and DO/Vultr provisioning need **≥ v4.2.0**.
 Volume backup schedules, `noindex_domains`, notifications, and S3 need
 **≥ v4.3.0**. Instance email settings and `smtp_ehlo_domain` need
 **≥ v4.3.10**. Preview domain PATCH, GET `domain_port_overrides`, and
-restart-limit fields need **≥ v4.3.15**. The pinned API contract is
-Coolify **v4.3.17** (extract provenance), not a new feature floor.
+restart-limit fields need **≥ v4.3.15**. Missing-backup notifications on
+`coolify_database_backup` need **≥ v4.3.18**. The pinned API contract is
+Coolify **v4.3.18** (extract provenance), not a new feature floor.
 
 For a full resource and attribute matrix (what works on 4.1 vs 4.2 vs 4.3,
 and how version gates behave), see

--- a/testdata/contracts/coolify-v4.3.18.json
+++ b/testdata/contracts/coolify-v4.3.18.json
@@ -10710,6 +10710,5 @@
         "api.ability:read"
       ]
     }
-  ],
-  "notes": "Pin is tag v4.3.18. ScheduledDatabaseBackup.missing_backup_notification_days is writable on create/update (integer 0-365; 0 disables alerts). last_execution_at and missing_backup_notification_sent_at are GET-only runtime timestamps. Those three fields are absent from v4.3.17 and from v4.4-rc.1 (that rc was cut before them). Restart-limit fields, GET domain_port_overrides, and PATCH preview domains remain from v4.3.15. Public API otherwise matches v4.3.15 through v4.3.18."
+  ]
 }

--- a/testdata/specs/coolify-v4.json
+++ b/testdata/specs/coolify-v4.json
@@ -14616,6 +14616,20 @@
                         "description": "Frequency.",
                         "maxLength": 255
                     },
+                    "last_execution_at": {
+                        "type": "string",
+                        "description": "Last execution at.",
+                        "format": "date-time"
+                    },
+                    "missing_backup_notification_days": {
+                        "type": "string",
+                        "description": "Missing backup notification days."
+                    },
+                    "missing_backup_notification_sent_at": {
+                        "type": "string",
+                        "description": "Missing backup notification sent at.",
+                        "format": "date-time"
+                    },
                     "number_of_backups_locally": {
                         "type": "integer",
                         "description": "Number of backups locally.",


### PR DESCRIPTION
Pin the Coolify API contract at v4.3.18 and write `missing_backup_notification_days` on `coolify_database_backup`.

## Problem

Stable Coolify is already 4.3.18 while the provider pin was 4.3.17. Tag v4.3.18 adds a public write field on database backup create/update: days without an execution before Coolify sends a missing-backup alert (`0` disables alerts). The two companion timestamps are GET-only.

## Change

- Extract tagged contract `v4.3.18` and promote `testdata/contracts/coolify-v4.json`.
- Schema: `missing_backup_notification_days` (0-365, Optional+Computed, `UseStateForUnknown`, no Default). Computed `last_execution_at` and `missing_backup_notification_sent_at`.
- Version gate `SupportsMissingBackupNotificationDays` at 4.3.18. CI edge `4.3.0` fail-opens (same class as `smtp_ehlo_domain`). `v4.4-rc.1` withholds: that rc was cut before the field.
- Acc extra-key probe POSTs `missing_backup_notification_days: -1` to a fake database UUID. Validation 422 means the field is allowed. Extra-key 422 or 404 skips (soft-skip even under `COOLIFY_REQUIRE_TIP_APIS=1`).

## Validation

- `go test -race -count=1` on `./internal/client/`, `./internal/acctest/`, `./internal/service/database/backup/`, `./internal/spectest/`
- `make contract-compat`, `make contract-check`, `make counts-check`
- Local `make ci` passed build, lint, test, validate, actionlint, python-test, vulncheck, goreleaser-check, modverify. `check-tfplugindocs` still fails on this host (`--version` has no semver); docs regenerated with `go generate ./internal/provider/`.
- Local Coolify acc instance was down. Acc coverage is the extra-key skip plus CI edge.

## Notes

Ref #799

Leave the channel-watch issue open until nightly (4.4-rc.1), tip, and pin align. Do not merge release-please #845 from this PR.
