### PR TITLE
ci: compile once on PRs and apply notes from a branch

### DIFF
--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -1,0 +1,45 @@
+# Cheap apply of curated notes onto a GitHub Release.
+# Reads branch release-note-<semver> or vars RELEASE_NOTES +
+# RELEASE_NOTES_TAG. Deletes the notes branch after a successful
+# apply. Does not compile and does not start GoReleaser.
+name: Apply release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.21)"
+        required: true
+        type: string
+
+concurrency:
+  group: apply-release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ inputs.tag }}
+      RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+      RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Apply curated notes
+        run: bash scripts/apply-release-notes.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,14 @@
 # self-hosted runners, see git history before this commit for the
 # full self-hosted config (fork safety guards, PATH normalization,
 # Docker credential workarounds, python3.9 pinning, cache: false).
+#
+# Recipe A: product CI is pull_request + workflow_dispatch + weekly
+# schedule only. There is no merge queue, so do not add merge_group.
+# An empty ci.yml run list on a squash-merge SHA is expected. Do not
+# gh workflow run ci.yml on a green squash SHA.
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -62,11 +65,9 @@ jobs:
               - 'templates/**'
               - 'docs/**'
               - '*.md'
-              # release-please / release override files: not provider docs.
-              # Matching them alone must not force full Validate (fmt, docs gen,
-              # Trivy, Gitleaks) on every version-bump PR.
+              # release-please changelog is not provider docs. Matching it
+              # alone must not force full Validate on every version-bump PR.
               - '!CHANGELOG.md'
-              - '!RELEASE_NOTES.md'
             terraform:
               - 'examples/**/*.tf'
             ci:
@@ -570,8 +571,6 @@ jobs:
           fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             gitleaks detect --source . --config .gitleaks.toml --log-opts="${PR_BASE_SHA}..HEAD" --exit-code 1
-          elif [ "$EVENT_NAME" = "push" ]; then
-            gitleaks detect --source . --config .gitleaks.toml --log-opts="${GIT_BEFORE}..${GIT_AFTER}" --exit-code 1
           else
             gitleaks detect --source . --config .gitleaks.toml --exit-code 1
           fi
@@ -697,7 +696,8 @@ jobs:
       (
         needs.changes.outputs.scenarios == 'true' ||
         github.event_name == 'workflow_dispatch'
-      )
+      ) &&
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please'))
     strategy:
       fail-fast: false
       matrix:
@@ -834,7 +834,8 @@ jobs:
         needs.changes.outputs.ci == 'true' ||
         needs.changes.outputs.scripts == 'true' ||
         github.event_name == 'workflow_dispatch'
-      )
+      ) &&
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,10 @@
 # CodeQL security analysis
+# Recipe A: PR + weekly schedule + dispatch. No push-to-main rebuild.
+# Recipe G: release-please heads keep the required check names
+# (CodeQL (go), CodeQL (actions)) via a cheap stand-in.
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:
@@ -43,23 +44,33 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
+      - name: Release-please stand-in
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please')
+        run: echo 'version-bump PR; CodeQL already ran on the feature PR'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please')
         with:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        if: matrix.language == 'go'
+        if: >-
+          matrix.language == 'go' &&
+          (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please'))
         with:
           go-version-file: go.mod
           cache: false
       - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please')
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
           dependency-caching: true
       - name: Build (Go)
-        if: matrix.build-mode == 'manual'
+        if: >-
+          matrix.build-mode == 'manual' &&
+          (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please'))
         run: GOFIPS140=latest go build ./...
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please')
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -25,9 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: >-
-      github.event_name != 'pull_request' || (
-        github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]'
+      !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please')) &&
+      (
+        github.event_name != 'pull_request' || (
+          github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
+        )
       )
     steps:
       - name: Harden runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  # Triggered automatically when CI completes on main (eliminates polling).
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  # Recipe A/E: cheap release-please on push to main (no product compile).
+  # GoReleaser is the one trusted compile at release_created.
+  push:
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -20,15 +19,32 @@ permissions:
   contents: read
 
 jobs:
+  # W9: after Recipe A, PR setup-go caches do not populate the default-branch
+  # cache. Write the shared Go module cache here with no product compile.
+  cache-go:
+    name: Cache Go modules
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux'
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only run for successful CI triggered by push (not schedule/dispatch).
-    if: >-
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+    if: github.event_name == 'push'
     permissions:
       contents: write
       pull-requests: write
@@ -69,7 +85,6 @@ jobs:
     permissions:
       actions: read
       contents: write
-      pull-requests: write
       # SLSA provenance / GitHub attestations for Scorecard Signed-Releases.
       id-token: write
       attestations: write
@@ -93,42 +108,14 @@ jobs:
             echo "::error::Tag does not point to a commit on main branch"
             exit 1
           fi
-      # CI already verified via workflow_run trigger; only poll on manual dispatch.
-      - name: Verify CI passed
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA=$(git rev-parse HEAD)
-          echo "Checking CI status for commit ${SHA:0:7}..."
-          for attempt in $(seq 1 30); do
-            CONCLUSION=$(gh run list \
-              --commit "$SHA" \
-              --workflow ci.yml \
-              --status completed \
-              --json conclusion \
-              --jq '.[0].conclusion // empty')
-            if [ "$CONCLUSION" = "success" ]; then
-              echo "CI passed (attempt $attempt)"
-              exit 0
-            fi
-            if [ -n "$CONCLUSION" ]; then
-              echo "::error::CI workflow conclusion is '${CONCLUSION}', refusing to release"
-              exit 1
-            fi
-            echo "No completed CI run found yet (attempt $attempt/30), waiting 30s..."
-            sleep 30
-          done
-          echo "::error::No completed CI run for $SHA after 15 minutes. CI may still be running or was never triggered."
-          exit 1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Install Syft for SBOM generation
         uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
-      # Smoke test and goreleaser check removed: both are already covered
-      # by CI (which must pass before this workflow triggers).
+      # Smoke test and goreleaser check live in PR CI. This job is the
+      # one trusted compile at release_created (Recipe E).
       - name: Clean existing release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,24 +126,6 @@ jobs:
             echo "Deleting existing asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y || true
           done
-      # Custom release notes override:
-      # To use curated release notes instead of auto-generated ones, commit a
-      # RELEASE_NOTES.md file to main (via a prep PR) BEFORE merging the
-      # release-please PR. The file must be on main, not on the release-please
-      # branch (release-please force-pushes its branch on every new main commit,
-      # which wipes any extra files). The cleanup step below deletes the file
-      # from main after the release completes.
-      - name: Apply custom release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ env.RELEASE_TAG }}
-        run: |
-          if [ -f RELEASE_NOTES.md ]; then
-            echo "Custom release notes found, updating release body..."
-            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
-          else
-            echo "No custom release notes, using auto-generated notes"
-          fi
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         id: import_gpg
@@ -211,34 +180,16 @@ jobs:
           else
             echo "::warning::No attestation bundles produced; Scorecard provenance may stay incomplete"
           fi
-      # Generate a GitHub App token for the cleanup PR so that push events
-      # trigger CI and auto-approve (GITHUB_TOKEN suppresses both).
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: cleanup-token
-        with:
-          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
-          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
-      - name: Clean up release notes file
+      # Curated notes live on release-note-<semver> or in Actions vars.
+      # Apply after the GitHub Release exists (release-please created it;
+      # GoReleaser uploaded assets). Missing source leaves the auto
+      # changelog. continue-on-error so a notes miss does not fail publish.
+      - name: Apply curated release notes
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
-        run: |
-          if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
-            echo "Removing RELEASE_NOTES.md from main..."
-            # Branch protection prevents direct pushes to main, so create a
-            # short-lived PR to delete the file. The auto-approve workflow
-            # handles approval, and auto-merge closes it once CI passes.
-            BRANCH="chore/cleanup-release-notes-${{ env.RELEASE_TAG }}"
-            gh api "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" \
-              -f sha="$(git rev-parse HEAD)"
-            FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/RELEASE_NOTES.md?ref=$BRANCH" \
-              --jq '.sha')
-            gh api --method DELETE "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
-              -f message="chore: remove release notes override" \
-              -f sha="$FILE_SHA" \
-              -f branch="$BRANCH"
-            PR_URL=$(gh pr create --base main --head "$BRANCH" \
-              --title "chore: remove release notes override" \
-              --body "Auto-cleanup of \`RELEASE_NOTES.md\` after ${{ env.RELEASE_TAG }} release.")
-            gh pr merge "$PR_URL" --auto --squash
-          fi
+          TAG: ${{ env.RELEASE_TAG }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+          RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+        run: bash scripts/apply-release-notes.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,10 @@ values, causing 422 errors on Coolify < v4.1.2 after importing a database.
 
 ## CI
 
-11 GitHub Actions jobs on push to main and PRs (GitHub-hosted ubuntu-latest):
+11 GitHub Actions jobs on pull requests (GitHub-hosted ubuntu-latest).
+Product CI does not run again on push to main; an empty `ci.yml` run list
+on a squash-merge SHA is expected. Do not `gh workflow run ci.yml` on a
+green squash.
 Detect Changes, DCO (PR only), Test (4 package shards), Coverage (merge shards),
 Lint (includes Govulncheck + GoReleaser Check),
 Validate (includes HCL fmt + Docs + Trivy + Gitleaks),
@@ -254,22 +257,28 @@ plus tip scenarios on `edge`. Schedule: daily 06:00 UTC. Also
 Release-please manages versioning and CHANGELOG generation. Two release modes:
 
 - **Automated**: merge the release-please PR as-is. Auto-generated notes ship unchanged.
-- **AI-assisted (curated notes)**: commit a `RELEASE_NOTES.md` file to main via a prep PR,
-  merge it, then merge the release-please PR. The release workflow detects the file and
-  uses it as the GitHub Release body. A cleanup step deletes the file from main afterward.
+- **AI-assisted (curated notes)**: push an orphan one-file branch
+  `release-note-<semver>` (tag `v0.2.0` -> `release-note-0.2.0`) with only
+  `RELEASE_NOTES.md`. Do not commit that file to main. Do not open a notes PR.
+  Do not put notes on `release-please--branches--main` (the next force-push
+  wipes it). After GoReleaser, `scripts/apply-release-notes.sh` copies the
+  notes onto the GitHub Release and deletes the notes branch.
 
-**Important**: `RELEASE_NOTES.md` must be committed to main, NOT to the release-please
-branch. Release-please force-pushes its branch on every new main commit, which wipes any
-extra files added directly to that branch.
+**Release-As** still belongs on main (empty `chore` commit). The notes
+branch is not main.
+
+The GitHub Release page stays the auto changelog until apply succeeds
+(often after GoReleaser). Do not `gh release edit` by hand unless apply
+failed. Re-apply with Actions → **Apply release notes** (no compile).
+After apply, `git ls-remote --heads origin 'release-note-*'` is empty.
 
 The correct sequence for curated releases:
-1. Write `RELEASE_NOTES.md` with user-facing release description
-2. Push it to main via a small PR (e.g., `docs: add release notes for vX.Y.Z`)
-3. Wait for release-please to update its PR (picks up the new commit)
-4. Optional but recommended: Actions → **Coolify Nightly Acc** → Run workflow
+1. Write `RELEASE_NOTES.md` and push it on orphan `release-note-<semver>`
+2. Optional but recommended: Actions → **Coolify Nightly Acc** → Run workflow
    (profile `tip-and-stable` or `all`) on `main` and wait for green
-5. Merge the release-please PR
-6. Release workflow applies the curated notes and cleans up the file
+3. Merge the release-please PR (explicit human yes)
+4. Approve the `release` environment so GoReleaser publishes
+5. Confirm apply succeeded and the notes branch is gone
 
 Published to both [Terraform Registry](https://registry.terraform.io/providers/coolify-terraform/coolify)
 and [OpenTofu Registry](https://search.opentofu.org/provider/coolify-terraform/coolify).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ This provider follows these security principles:
 - Dependabot monitors Go modules and GitHub Actions for updates
 - GitHub Dependency Review checks every PR for known vulnerabilities in new dependencies
 - FOSSA monitors license compliance
-- CodeQL runs on every push and PR for static application security testing (SAST)
+- CodeQL runs on every PR and weekly for static application security testing (SAST)
 - OpenSSF Scorecard runs weekly and reports supply chain security posture
 - Test credentials use placeholder values (`"test-token"`)
 - No real API tokens or secrets are committed to the repository

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -139,7 +139,8 @@ This pipeline catches API drift automatically when Coolify updates its models.
 
 ## CI pipeline
 
-The CI pipeline runs 11 jobs on every push and PR:
+The CI pipeline runs 11 jobs on pull requests (weekly schedule for scanners).
+Product CI does not rebuild on push to main:
 
 | Job | What it checks |
 |-----|---------------|

--- a/scripts/apply-release-notes.sh
+++ b/scripts/apply-release-notes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Apply curated notes to an existing GitHub Release, then delete the
+# notes branch. Notes are not on main.
+#
+# Sources, first match:
+#   1. NOTES_FILE (tests)
+#   2. RELEASE_NOTES.md on branch release-note-<semver> (tag v0.1.2
+#      -> release-note-0.1.2)
+#   3. Actions vars RELEASE_NOTES + RELEASE_NOTES_TAG (tag must match)
+#
+# Missing source is a no-op (auto changelog stays). After a successful
+# apply from the notes branch, that branch is deleted. Variables are
+# left in place; the tag pin stops them applying to a later cut.
+set -euo pipefail
+
+TAG="${TAG:-}"
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+DRY_RUN="${DRY_RUN:-0}"
+DELETE_BRANCH="${DELETE_BRANCH:-1}"
+NOTES_FILE="${NOTES_FILE:-}"
+RELEASE_NOTES="${RELEASE_NOTES:-}"
+RELEASE_NOTES_TAG="${RELEASE_NOTES_TAG:-}"
+
+if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "TAG must look like vX.Y.Z: ${TAG}" >&2
+  exit 1
+fi
+
+if [ -z "${REPO}" ]; then
+  echo "GH_REPO or GITHUB_REPOSITORY required" >&2
+  exit 1
+fi
+
+semver="${TAG#v}"
+branch="${NOTES_BRANCH:-release-note-${semver}}"
+loaded_from_branch=0
+source_label=""
+
+tmp="$(mktemp)"
+cleanup() { rm -f "${tmp}"; }
+trap cleanup EXIT
+
+tag_matches_pin() {
+  local pin="$1"
+  if [ -z "${pin}" ]; then
+    return 1
+  fi
+  if [ "${pin}" = "${TAG}" ] || [ "${pin}" = "${semver}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+if [ -n "${NOTES_FILE}" ] && [ -f "${NOTES_FILE}" ]; then
+  echo "PLAN: file ${NOTES_FILE}"
+  cp "${NOTES_FILE}" "${tmp}"
+  source_label="file:${NOTES_FILE}"
+elif [ -n "${GH_TOKEN:-}" ]; then
+  echo "PLAN: fetch RELEASE_NOTES.md from ${branch}"
+  if gh api "repos/${REPO}/contents/RELEASE_NOTES.md?ref=${branch}" \
+    -H "Accept: application/vnd.github.raw" >"${tmp}"; then
+    loaded_from_branch=1
+    source_label="branch:${branch}"
+  else
+    : >"${tmp}"
+    echo "PLAN: no notes branch ${branch}"
+  fi
+fi
+
+if [ ! -s "${tmp}" ] && [ -n "${RELEASE_NOTES}" ] \
+  && tag_matches_pin "${RELEASE_NOTES_TAG}"; then
+  echo "PLAN: Actions variable RELEASE_NOTES (pin ${RELEASE_NOTES_TAG})"
+  printf '%s\n' "${RELEASE_NOTES}" >"${tmp}"
+  source_label="variable"
+fi
+
+if [ ! -s "${tmp}" ]; then
+  echo "OK: no curated notes for ${TAG}; leaving auto notes"
+  exit 0
+fi
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "DRY_RUN: would apply ${source_label} to ${TAG}"
+  echo "BYTES: $(wc -c <"${tmp}" | tr -d ' ')"
+  if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+    echo "DRY_RUN: would delete branch ${branch}"
+  fi
+  exit 0
+fi
+
+if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+  echo "FAIL: release ${TAG} does not exist" >&2
+  exit 1
+fi
+
+echo "DO: gh release edit ${TAG} from ${source_label}"
+gh release edit "${TAG}" --repo "${REPO}" --notes-file "${tmp}"
+echo "OK: applied notes to ${TAG}"
+
+if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+  echo "DO: delete ${branch}"
+  if gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}"; then
+    echo "DONE: deleted ${branch}"
+  else
+    echo "WARN: could not delete ${branch}; delete it by hand" >&2
+  fi
+fi

--- a/scripts/test_apply_release_notes.py
+++ b/scripts/test_apply_release_notes.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Tests for scripts/apply-release-notes.sh."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "apply-release-notes.sh"
+
+
+def run_script(
+    env: dict[str, str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    merged.pop("GH_TOKEN", None)
+    merged.pop("GITHUB_TOKEN", None)
+    merged.pop("RELEASE_NOTES", None)
+    merged.pop("RELEASE_NOTES_TAG", None)
+    merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=merged,
+        cwd=cwd,
+        check=False,
+    )
+
+
+class ApplyReleaseNotesTests(unittest.TestCase):
+    def test_rejects_bad_tag(self) -> None:
+        r = run_script({"TAG": "canact-v0.1.2", "GH_REPO": "coolify-terraform/terraform-provider-coolify"})
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("vX.Y.Z", r.stderr)
+
+    def test_missing_source_is_noop(self) -> None:
+        r = run_script(
+            {"TAG": "v0.1.2", "GH_REPO": "coolify-terraform/terraform-provider-coolify", "DRY_RUN": "1"}
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_notes_file_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("notes\n", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("DRY_RUN: would apply file:", r.stdout)
+            self.assertIn("BYTES: 6", r.stdout)
+            self.assertNotIn("would delete branch", r.stdout)
+
+    def test_empty_file_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_requires_matching_tag(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "stale notes",
+                "RELEASE_NOTES_TAG": "v0.1.1",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_applies_when_tag_matches(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "from var",
+                "RELEASE_NOTES_TAG": "0.1.2",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("Actions variable", r.stdout)
+        self.assertIn("DRY_RUN: would apply variable to v0.1.2", r.stdout)
+        self.assertNotIn("would delete branch", r.stdout)
+
+    def test_branch_fetch_dry_run_deletes_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake_bin = Path(td) / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "DRY_RUN": "1",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("release-note-0.1.2", r.stdout)
+            self.assertIn("DRY_RUN: would delete branch release-note-0.1.2", r.stdout)
+
+    def test_release_view_fail_skips_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            notes = td_path / "RELEASE_NOTES.md"
+            notes.write_text("curated notes\n", encoding="utf-8")
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "NOTES_FILE": str(notes),
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 1, r.stderr + r.stdout)
+            self.assertIn("does not exist", r.stderr)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertNotIn("release edit", logged)
+
+    def test_delete_fail_warns_and_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = api ] && [ \"$2\" = -X ] && [ \"$3\" = DELETE ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            combined = f"{r.stderr}\n{r.stdout}"
+            self.assertIn("WARN", combined)
+            self.assertIn("could not delete", combined)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertIn("release edit", logged)
+            self.assertIn("DELETE", logged)
+
+    def test_failed_branch_fetch_applies_matching_variable(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            notes_seen = td_path / "notes_seen.txt"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' "
+                "'{\"message\":\"Not Found\","
+                "\"documentation_url\":\"https://docs.github.com\"}'\n"
+                "  exit 1\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  while [ $# -gt 0 ]; do\n"
+                "    if [ \"$1\" = --notes-file ]; then\n"
+                f"      cat \"$2\" > '{notes_seen}'\n"
+                "      break\n"
+                "    fi\n"
+                "    shift\n"
+                "  done\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "coolify-terraform/terraform-provider-coolify",
+                    "GH_TOKEN": "test",
+                    "RELEASE_NOTES": "from var after failed fetch",
+                    "RELEASE_NOTES_TAG": "v0.1.2",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("variable", r.stdout)
+            self.assertTrue(notes_seen.is_file(), r.stderr + r.stdout)
+            seen = notes_seen.read_text(encoding="utf-8")
+            self.assertIn("from var after failed fetch", seen)
+            self.assertNotIn("Not Found", seen)
+            self.assertNotIn("documentation_url", seen)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release edit", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_workflow_triggers.py
+++ b/scripts/test_workflow_triggers.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Lock Recipe A/E/G triggers and the notes-branch apply path."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _on_block(text: str) -> str:
+    start = text.index("\non:")
+    rest = text[start + 1 :]
+    end = rest.index("\njobs:")
+    block = rest[:end]
+    lines = []
+    for line in block.splitlines():
+        stripped = line.split("#", 1)[0].rstrip()
+        if stripped:
+            lines.append(stripped)
+    return "\n".join(lines)
+
+
+class WorkflowTriggerTests(unittest.TestCase):
+    def test_ci_has_no_push_compile(self) -> None:
+        on_block = _on_block((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
+        self.assertIn("pull_request:", on_block)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertIn("schedule:", on_block)
+        self.assertNotIn("push:", on_block)
+        self.assertNotIn("tags:", on_block)
+        self.assertNotIn("merge_group:", on_block)
+
+    def test_codeql_has_no_push_compile(self) -> None:
+        on_block = _on_block((WORKFLOWS / "codeql.yml").read_text(encoding="utf-8"))
+        self.assertIn("pull_request:", on_block)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertIn("schedule:", on_block)
+        self.assertNotIn("push:", on_block)
+        self.assertNotIn("tags:", on_block)
+
+    def test_release_is_push_main_or_dispatch(self) -> None:
+        text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        on_block = _on_block(text)
+        self.assertIn("push:", on_block)
+        self.assertIn("branches: [main]", on_block)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertNotIn("pull_request:", on_block)
+        self.assertNotIn("workflow_run:", on_block)
+        self.assertNotIn("tags:", on_block)
+        self.assertNotRegex(text, r"\bgo test\b")
+        self.assertNotIn("chore/cleanup-release-notes", text)
+        self.assertIn("scripts/apply-release-notes.sh", text)
+        self.assertIn("continue-on-error: true", text)
+
+    def test_release_please_job_does_not_compile(self) -> None:
+        text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        start = text.index("name: Release Please")
+        end = text.index("name: Release\n", start + 1)
+        job = text[start:end]
+        self.assertNotIn("go build", job)
+        self.assertNotIn("go test", job)
+        self.assertNotIn("goreleaser", job.lower())
+        self.assertIn("googleapis/release-please-action@", job)
+
+    def test_cache_go_is_cheap_main_job(self) -> None:
+        text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        self.assertIn("name: Cache Go modules", text)
+        start = text.index("name: Cache Go modules")
+        end = text.index("name: Release Please")
+        job = text[start:end]
+        self.assertIn("cache: true", job)
+        self.assertNotIn("go build", job)
+        self.assertNotIn("go test", job)
+        self.assertIn("github.event_name == 'push'", job)
+
+    def test_apply_release_notes_is_dispatch_only(self) -> None:
+        text = (WORKFLOWS / "apply-release-notes.yml").read_text(encoding="utf-8")
+        on_block = _on_block(text)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertNotIn("pull_request:", on_block)
+        self.assertNotIn("push:", on_block)
+        self.assertNotIn("go build", text)
+        self.assertNotIn("goreleaser-action", text)
+        self.assertIn("scripts/apply-release-notes.sh", text)
+
+    def test_auto_approve_does_not_merge_release_prs(self) -> None:
+        text = (WORKFLOWS / "auto-approve.yml").read_text(encoding="utf-8")
+        self.assertNotIn("gh pr merge", text)
+        self.assertNotIn("pulls.merge", text)
+
+    def test_codeql_standin_on_release_please(self) -> None:
+        sec = (WORKFLOWS / "codeql.yml").read_text(encoding="utf-8")
+        self.assertIn("startsWith(github.head_ref, 'release-please')", sec)
+        self.assertIn(
+            "echo 'version-bump PR; CodeQL already ran on the feature PR'",
+            sec,
+        )
+        for pin in (
+            "github/codeql-action/init@",
+            "github/codeql-action/analyze@",
+        ):
+            idx = sec.index(pin)
+            window = sec[max(0, idx - 400) : idx]
+            self.assertIn(
+                "!startsWith(github.head_ref, 'release-please')", window, pin
+            )
+
+    def test_required_ci_gate_stays_named(self) -> None:
+        ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("name: CI", ci)
+        self.assertIn("name: DCO", ci)
+        self.assertNotIn("RELEASE_NOTES.md", ci)
+
+    def test_optional_jobs_skip_release_please(self) -> None:
+        ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+        acc = ci[ci.index("name: Acceptance Tests") :]
+        scenarios = ci[ci.index("name: Scenario Tests") : ci.index("name: Acceptance Tests")]
+        self.assertIn(
+            "startsWith(github.head_ref, 'release-please')", acc.split("steps:")[0]
+        )
+        self.assertIn(
+            "startsWith(github.head_ref, 'release-please')",
+            scenarios.split("steps:")[0],
+        )
+        fossa = (WORKFLOWS / "fossa.yml").read_text(encoding="utf-8")
+        self.assertIn("startsWith(github.head_ref, 'release-please')", fossa)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/templates/guides/architecture.md.tmpl
+++ b/templates/guides/architecture.md.tmpl
@@ -139,7 +139,8 @@ This pipeline catches API drift automatically when Coolify updates its models.
 
 ## CI pipeline
 
-The CI pipeline runs 11 jobs on every push and PR:
+The CI pipeline runs 11 jobs on pull requests (weekly schedule for scanners).
+Product CI does not rebuild on push to main:
 
 | Job | What it checks |
 |-----|---------------|


### PR DESCRIPTION
Product CI no longer rebuilds the provider on every squash to main. Curated GitHub Release notes move off main onto a one-file notes branch.

## Problem

`ci.yml` ran on both `pull_request` and `push` to `main`, so every squash-merge compiled the provider again. `release.yml` waited on that second CI via `workflow_run`. The open release-please PR also re-ran CodeQL/FOSSA on every rewrite. Curated notes required a prep PR of `RELEASE_NOTES.md` on main plus a cleanup PR.

## Change

- Recipe A: `ci.yml` and `codeql.yml` are `pull_request` + `workflow_dispatch` + weekly schedule. No merge queue, so no `merge_group`. An empty `ci.yml` list on a squash-merge SHA is expected.
- Recipe E: `release.yml` runs cheap release-please (and a no-compile Go module cache write) on push to main. GoReleaser stays the one trusted compile at `release_created`, still behind the `release` environment.
- Recipe G: required check names still report. CodeQL (`CodeQL (go)` / `CodeQL (actions)`) uses a quoted stand-in on `release-please*` heads. Optional acc, scenarios, and FOSSA skip.
- Notes: `scripts/apply-release-notes.sh` reads `release-note-<semver>` or Actions vars, edits the GitHub Release, and deletes the notes branch. Cheap `Apply release notes` workflow for re-apply. No prep PR, no cleanup PR.

## Validation

- `python3 -m unittest scripts/test_apply_release_notes.py scripts/test_workflow_triggers.py -v` (20 tests)
- `make python-test` (228 tests)
- `make actionlint-check`

Do not merge release-please #845 without an explicit human yes. After this PR squash-merges, prove with `gh run list --commit MERGE_SHA --workflow ci.yml` that the list is empty.
