### PR TITLE
fix(backup): keep create-error state valid and fail 5xx acc probes

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -863,7 +863,8 @@ func coolifyAcceptsSMTPEhloDomain(t *testing.T) (ok bool, detail string) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false, fmt.Sprintf("smtp_ehlo_domain extra-key probe failed (cannot reach Coolify): %v", err)
+		accTestMissingFeature(t, "smtp_ehlo_domain extra-key probe failed (cannot reach Coolify): %v", err)
+		return false, ""
 	}
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
@@ -884,8 +885,9 @@ func coolifyAcceptsSMTPEhloDomain(t *testing.T) (ok bool, detail string) {
 			resp.StatusCode, truncateForSkip(string(raw), 200))
 	default:
 		if resp.StatusCode >= 500 {
-			return false, fmt.Sprintf("smtp_ehlo_domain extra-key probe returned HTTP %d: %s",
+			accTestMissingFeature(t, "smtp_ehlo_domain extra-key probe returned HTTP %d (server error): %s",
 				resp.StatusCode, truncateForSkip(string(raw), 200))
+			return false, ""
 		}
 		// Other 4xx still means a handler ran and did not extra-key reject.
 		return true, ""
@@ -893,10 +895,12 @@ func coolifyAcceptsSMTPEhloDomain(t *testing.T) (ok bool, detail string) {
 }
 
 // AccTestSkipIfNoSMTPEhloDomain skips when PATCH extra-key 422s
-// smtp_ehlo_domain (Coolify before #11398). Soft-skip even when
-// COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0 and extra-key 422s
-// this field. Do not use AccTestSkipIfCoolifyBelow (that helper plus
-// the flag is a hard fail on the version string).
+// smtp_ehlo_domain (Coolify before #11398). Soft-skip extra-key 422
+// even when COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0 and
+// extra-key 422s this field. Do not use AccTestSkipIfCoolifyBelow
+// (that helper plus the flag is a hard fail on the version string).
+// Transport errors and HTTP 5xx use accTestMissingFeature (hard fail
+// under REQUIRE_TIP_APIS).
 func AccTestSkipIfNoSMTPEhloDomain(t *testing.T) {
 	t.Helper()
 	ok, detail := coolifyAcceptsSMTPEhloDomain(t)

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -942,7 +942,8 @@ func coolifyAcceptsMissingBackupNotificationDays(t *testing.T) (ok bool, detail 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false, fmt.Sprintf("missing_backup_notification_days extra-key probe failed (cannot reach Coolify): %v", err)
+		accTestMissingFeature(t, "missing_backup_notification_days extra-key probe failed (cannot reach Coolify): %v", err)
+		return false, ""
 	}
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
@@ -966,8 +967,9 @@ func coolifyAcceptsMissingBackupNotificationDays(t *testing.T) (ok bool, detail 
 			resp.StatusCode, truncateForSkip(string(raw), 200))
 	default:
 		if resp.StatusCode >= 500 {
-			return false, fmt.Sprintf("missing_backup_notification_days extra-key probe returned HTTP %d: %s",
+			accTestMissingFeature(t, "missing_backup_notification_days extra-key probe returned HTTP %d (server error): %s",
 				resp.StatusCode, truncateForSkip(string(raw), 200))
+			return false, ""
 		}
 		return true, ""
 	}
@@ -975,8 +977,9 @@ func coolifyAcceptsMissingBackupNotificationDays(t *testing.T) (ok bool, detail 
 
 // AccTestSkipIfNoMissingBackupNotificationDays skips when backup create
 // extra-key 422s or 404s missing_backup_notification_days (Coolify
-// before v4.3.18, or v4.4-rc.1). Soft-skip even when
-// COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0.
+// before v4.3.18, or v4.4-rc.1). Soft-skip extra-key 422 and 404/405 even
+// when COOLIFY_REQUIRE_TIP_APIS=1: CI edge reports 4.3.0. Transport errors
+// and HTTP 5xx use accTestMissingFeature (hard fail under REQUIRE_TIP_APIS).
 func AccTestSkipIfNoMissingBackupNotificationDays(t *testing.T) {
 	t.Helper()
 	ok, detail := coolifyAcceptsMissingBackupNotificationDays(t)

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -457,6 +457,53 @@ func TestAccTestSkipIfNoMissingBackupNotificationDays_NotFound(t *testing.T) {
 	}
 }
 
+func TestAccTestSkipIfNoMissingBackupNotificationDays_ServerError(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("POST /api/v1/databases/{uuid}/backups", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"internal server error"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoMissingBackupNotificationDays(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoMissingBackupNotificationDays to skip on HTTP 500")
+	}
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "1")
+	if os.Getenv("ACC_MISSING_DAYS_PROBE_CHILD") == "1" {
+		t.Run("fatal", func(t *testing.T) {
+			AccTestSkipIfNoMissingBackupNotificationDays(t)
+		})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAccTestSkipIfNoMissingBackupNotificationDays_ServerError$")
+	cmd.Env = append(os.Environ(), "ACC_MISSING_DAYS_PROBE_CHILD=1", "COOLIFY_REQUIRE_TIP_APIS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected Fatal on HTTP 500 with COOLIFY_REQUIRE_TIP_APIS=1, child passed:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("COOLIFY_REQUIRE_TIP_APIS")) {
+		t.Fatalf("child output missing REQUIRE_TIP fatal message:\n%s", out)
+	}
+}
+
 func TestAccTestSkipIfNoPreviewDomainUpdate_PlainNotFound(t *testing.T) {
 	resetAccTestCaches()
 	defer resetAccTestCaches()

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -457,6 +457,53 @@ func TestAccTestSkipIfNoMissingBackupNotificationDays_NotFound(t *testing.T) {
 	}
 }
 
+func TestAccTestSkipIfNoSMTPEhloDomain_ServerError(t *testing.T) {
+	resetAccTestCaches()
+	defer resetAccTestCaches()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v4.3.0"})
+	})
+	mux.HandleFunc("PATCH /api/v1/notifications/email", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"internal server error"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("COOLIFY_ENDPOINT", srv.URL)
+	t.Setenv("COOLIFY_TOKEN", "test-token")
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "")
+	reached := false
+	t.Run("skip", func(t *testing.T) {
+		AccTestSkipIfNoSMTPEhloDomain(t)
+		reached = true
+	})
+	if reached {
+		t.Fatal("expected AccTestSkipIfNoSMTPEhloDomain to skip on HTTP 500")
+	}
+
+	t.Setenv("COOLIFY_REQUIRE_TIP_APIS", "1")
+	if os.Getenv("ACC_SMTP_EHLO_PROBE_CHILD") == "1" {
+		t.Run("fatal", func(t *testing.T) {
+			AccTestSkipIfNoSMTPEhloDomain(t)
+		})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAccTestSkipIfNoSMTPEhloDomain_ServerError$")
+	cmd.Env = append(os.Environ(), "ACC_SMTP_EHLO_PROBE_CHILD=1", "COOLIFY_REQUIRE_TIP_APIS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected Fatal on HTTP 500 with COOLIFY_REQUIRE_TIP_APIS=1, child passed:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("COOLIFY_REQUIRE_TIP_APIS")) {
+		t.Fatalf("child output missing REQUIRE_TIP fatal message:\n%s", out)
+	}
+}
+
 func TestAccTestSkipIfNoMissingBackupNotificationDays_ServerError(t *testing.T) {
 	resetAccTestCaches()
 	defer resetAccTestCaches()

--- a/internal/service/database/backup/helper_test.go
+++ b/internal/service/database/backup/helper_test.go
@@ -1,0 +1,31 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestNullUnknownBackupComputed_SetsComputedUnknownToNull(t *testing.T) {
+	plan := databaseBackupResourceModel{
+		Description:        types.StringUnknown(),
+		DisableLocalBackup: types.BoolUnknown(),
+		DatabasesToBackup:  types.StringUnknown(),
+		Timeout:            types.Int64Unknown(),
+	}
+
+	nullUnknownBackupComputed(&plan)
+
+	if !plan.Description.IsNull() {
+		t.Errorf("Description = %v, want Null", plan.Description)
+	}
+	if !plan.DisableLocalBackup.IsNull() {
+		t.Errorf("DisableLocalBackup = %v, want Null", plan.DisableLocalBackup)
+	}
+	if !plan.DatabasesToBackup.IsNull() {
+		t.Errorf("DatabasesToBackup = %v, want Null", plan.DatabasesToBackup)
+	}
+	if !plan.Timeout.IsNull() {
+		t.Errorf("Timeout = %v, want Null", plan.Timeout)
+	}
+}

--- a/internal/service/database/backup/resource.go
+++ b/internal/service/database/backup/resource.go
@@ -587,6 +587,15 @@ func nullUnknownBackupComputed(plan *databaseBackupResourceModel) {
 	if plan.MissingBackupNotificationSentAt.IsUnknown() {
 		plan.MissingBackupNotificationSentAt = types.StringNull()
 	}
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringNull()
+	}
+	if plan.DisableLocalBackup.IsUnknown() {
+		plan.DisableLocalBackup = types.BoolNull()
+	}
+	if plan.DatabasesToBackup.IsUnknown() {
+		plan.DatabasesToBackup = types.StringNull()
+	}
 }
 
 func flattenDatabaseBackup(b *client.DatabaseBackup, m *databaseBackupResourceModel) {


### PR DESCRIPTION
## Summary

Harden tip acc probes so Coolify 5xx is not treated as a missing field, and keep backup Create error state valid when list/refresh fails.

## Problem

`AccTestSkipIfNoMissingBackupNotificationDays` and `AccTestSkipIfNoSMTPEhloDomain` skipped on transport errors and HTTP 5xx, including under `COOLIFY_REQUIRE_TIP_APIS=1`. Preview already hard-failed those cases. A down Coolify looked like an absent API field.

`nullUnknownBackupComputed` (used after Create when list/refresh fails) left `description`, `disable_local_backup`, and `databases_to_backup` unknown. Terraform rejects unknown values in final state.

## Change

- Route missing-days and SMTP extra-key probes through `accTestMissingFeature` on transport/5xx
- Extra-key 422 and 404 stay soft-skip (CI edge version lie)
- Null the three remaining unknown computed backup fields on the Create error path
- ServerError child tests for both probes; unit test for the flatten helper

## Validation

- `go test ./internal/acctest/ -run 'TestAccTestSkipIfNoMissingBackupNotificationDays|TestAccTestSkipIfNoSMTPEhloDomain|TestAccTestSkipIfNoPreviewDomainUpdate_ServerError'`
- `go test ./internal/service/database/backup/ -run 'NullUnknown|TestAccDatabaseBackup'`

## Checklist

- [x] Commits have DCO sign-off
- [x] Tests added or updated
- [x] Targeted tests pass locally
- [x] No breaking changes to existing resources
