### PR TITLE
test: lock all nullUnknownBackupComputed fields

### DIFF
--- a/internal/service/database/backup/helper_test.go
+++ b/internal/service/database/backup/helper_test.go
@@ -8,14 +8,69 @@ import (
 
 func TestNullUnknownBackupComputed_SetsComputedUnknownToNull(t *testing.T) {
 	plan := databaseBackupResourceModel{
-		Description:        types.StringUnknown(),
-		DisableLocalBackup: types.BoolUnknown(),
-		DatabasesToBackup:  types.StringUnknown(),
-		Timeout:            types.Int64Unknown(),
+		ID:                              types.Int64Unknown(),
+		Enabled:                         types.BoolUnknown(),
+		SaveS3:                          types.BoolUnknown(),
+		DumpAll:                         types.BoolUnknown(),
+		RetainAmountLocally:             types.Int64Unknown(),
+		RetainDaysLocally:               types.Int64Unknown(),
+		RetainMaxStorageLocal:           types.Int64Unknown(),
+		RetainAmountS3:                  types.Int64Unknown(),
+		RetainDaysS3:                    types.Int64Unknown(),
+		RetainMaxStorageS3:              types.Int64Unknown(),
+		Timeout:                         types.Int64Unknown(),
+		MissingBackupNotificationDays:   types.Int64Unknown(),
+		LastExecutionAt:                 types.StringUnknown(),
+		MissingBackupNotificationSentAt: types.StringUnknown(),
+		Description:                     types.StringUnknown(),
+		DisableLocalBackup:              types.BoolUnknown(),
+		DatabasesToBackup:               types.StringUnknown(),
 	}
 
 	nullUnknownBackupComputed(&plan)
 
+	if !plan.ID.IsNull() {
+		t.Errorf("ID = %v, want Null", plan.ID)
+	}
+	if !plan.Enabled.IsNull() {
+		t.Errorf("Enabled = %v, want Null", plan.Enabled)
+	}
+	if !plan.SaveS3.IsNull() {
+		t.Errorf("SaveS3 = %v, want Null", plan.SaveS3)
+	}
+	if !plan.DumpAll.IsNull() {
+		t.Errorf("DumpAll = %v, want Null", plan.DumpAll)
+	}
+	if !plan.RetainAmountLocally.IsNull() {
+		t.Errorf("RetainAmountLocally = %v, want Null", plan.RetainAmountLocally)
+	}
+	if !plan.RetainDaysLocally.IsNull() {
+		t.Errorf("RetainDaysLocally = %v, want Null", plan.RetainDaysLocally)
+	}
+	if !plan.RetainMaxStorageLocal.IsNull() {
+		t.Errorf("RetainMaxStorageLocal = %v, want Null", plan.RetainMaxStorageLocal)
+	}
+	if !plan.RetainAmountS3.IsNull() {
+		t.Errorf("RetainAmountS3 = %v, want Null", plan.RetainAmountS3)
+	}
+	if !plan.RetainDaysS3.IsNull() {
+		t.Errorf("RetainDaysS3 = %v, want Null", plan.RetainDaysS3)
+	}
+	if !plan.RetainMaxStorageS3.IsNull() {
+		t.Errorf("RetainMaxStorageS3 = %v, want Null", plan.RetainMaxStorageS3)
+	}
+	if !plan.Timeout.IsNull() {
+		t.Errorf("Timeout = %v, want Null", plan.Timeout)
+	}
+	if !plan.MissingBackupNotificationDays.IsNull() {
+		t.Errorf("MissingBackupNotificationDays = %v, want Null", plan.MissingBackupNotificationDays)
+	}
+	if !plan.LastExecutionAt.IsNull() {
+		t.Errorf("LastExecutionAt = %v, want Null", plan.LastExecutionAt)
+	}
+	if !plan.MissingBackupNotificationSentAt.IsNull() {
+		t.Errorf("MissingBackupNotificationSentAt = %v, want Null", plan.MissingBackupNotificationSentAt)
+	}
 	if !plan.Description.IsNull() {
 		t.Errorf("Description = %v, want Null", plan.Description)
 	}
@@ -24,8 +79,5 @@ func TestNullUnknownBackupComputed_SetsComputedUnknownToNull(t *testing.T) {
 	}
 	if !plan.DatabasesToBackup.IsNull() {
 		t.Errorf("DatabasesToBackup = %v, want Null", plan.DatabasesToBackup)
-	}
-	if !plan.Timeout.IsNull() {
-		t.Errorf("Timeout = %v, want Null", plan.Timeout)
 	}
 }


### PR DESCRIPTION
This PR makes the create-error backup helper test cover every computed field the helper actually nulls.

## Problem

`nullUnknownBackupComputed` writes 17 computed attributes to null so a failed list or refresh after create cannot leave unknown values in state. The unit test only asserted four of those fields (description, disable_local_backup, databases_to_backup, timeout). A later edit could drop one of the other 13 and the test would still pass.

## Change

[`internal/service/database/backup/helper_test.go`](https://github.com/coolify-terraform/terraform-provider-coolify/blob/fix/improve-mpi-20260909-s1856/internal/service/database/backup/helper_test.go) now starts every helper-touched field as unknown and asserts each is null after the call. Fields the helper does not touch (uuid, frequency, backup_now, s3_storage_uuid) stay out of the test.

No production code change.

## Validation

```
gofmt -s -l internal/service/database/backup/helper_test.go
go test -race -count=1 ./internal/service/database/backup/ -run TestNullUnknownBackupComputed
```

Both passed locally. Commenting out one helper assignment (for example LastExecutionAt) fails the test.

## Notes

MPI cycle 2 Test Auditor follow-up after #851. Extra-key 5xx acc probes already Fatal under `COOLIFY_REQUIRE_TIP_APIS=1` from that PR.
