### PR TITLE
fix(ci): one social-preview reminder and skip test-only nags

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -29,6 +29,18 @@ jobs:
             const issue = context.payload.issue;
             const author = issue.user.login;
 
+            // Bot reminder for the social-preview upload. Not inbox.
+            if (issue.title === 'Upload social preview image') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['social-preview', 'ready']
+              });
+              core.info('Social-preview reminder: labeled social-preview,ready');
+              return;
+            }
+
             // Check author association (OWNER, MEMBER, COLLABORATOR skip triage)
             const assoc = issue.author_association;
             const trusted = ['OWNER', 'MEMBER', 'COLLABORATOR'];

--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -96,13 +96,15 @@ jobs:
 
       - name: Check for changes
         id: diff
+        env:
+          SIGNIFICANT: ${{ steps.stats.outputs.significant }}
         run: |
           if git diff --quiet assets/; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No stat changes detected"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Stats changed, significant=${{ steps.stats.outputs.significant }}"
+            echo "Stats changed, significant=${SIGNIFICANT}"
             git diff --stat assets/
           fi
 

--- a/.github/workflows/update-social-preview.yml
+++ b/.github/workflows/update-social-preview.yml
@@ -64,6 +64,20 @@ jobs:
           echo "Data Sources: $DATASOURCES"
           echo "Tests: ${TESTS}+ (raw: $RAW_TESTS)"
 
+          OLD_R=$(sed -n 's/.*>\([0-9][0-9]*\) Resources<.*/\1/p' assets/social-preview.svg | head -1)
+          OLD_D=$(sed -n 's/.*>\([0-9][0-9]*\) Data Sources<.*/\1/p' assets/social-preview.svg | head -1)
+          {
+            echo "old_resources=$OLD_R"
+            echo "old_datasources=$OLD_D"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$OLD_R" != "$RESOURCES" ] || [ "$OLD_D" != "$DATASOURCES" ]; then
+            echo "significant=true" >> "$GITHUB_OUTPUT"
+            echo "Significant card change: resources $OLD_R->$RESOURCES datasources $OLD_D->$DATASOURCES"
+          else
+            echo "significant=false" >> "$GITHUB_OUTPUT"
+            echo "No resource/data-source change; skip upload reminder"
+          fi
+
       - name: Update SVG with live stats
         env:
           RESOURCES: ${{ steps.stats.outputs.resources }}
@@ -88,7 +102,7 @@ jobs:
             echo "No stat changes detected"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Stats changed, will create PR"
+            echo "Stats changed, significant=${{ steps.stats.outputs.significant }}"
             git diff --stat assets/
           fi
 
@@ -110,7 +124,7 @@ jobs:
           fi
 
       - name: Create PR with updated stats
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' && steps.stats.outputs.significant == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TESTS: ${{ steps.stats.outputs.tests }}
@@ -134,7 +148,7 @@ jobs:
           gh pr merge "$PR_URL" --auto --squash
 
       - name: Create upload reminder issue
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' && steps.stats.outputs.significant == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RESOURCES: ${{ steps.stats.outputs.resources }}

--- a/scripts/test_upsert_social_preview_issue.py
+++ b/scripts/test_upsert_social_preview_issue.py
@@ -44,6 +44,22 @@ class TestPlanUpsert(unittest.TestCase):
         self.assertEqual(plan["close"], [812])
 
 
+class TestListIssuesWithTitle(unittest.TestCase):
+    def test_filters_title_and_skips_search(self) -> None:
+        def gh(args: list[str]) -> str:
+            self.assertNotIn("--search", args)
+            self.assertEqual(args[args.index("--state") + 1], "open")
+            return json.dumps(
+                [
+                    {"number": 1, "title": "Unrelated"},
+                    {"number": 840, "title": usp.ISSUE_TITLE},
+                ]
+            )
+
+        got = usp.list_issues_with_title(gh, state="open", title=usp.ISSUE_TITLE)
+        self.assertEqual([i["number"] for i in got], [840])
+
+
 class TestCollectCandidates(unittest.TestCase):
     def test_unions_title_and_label_and_sorts(self) -> None:
         got = usp.collect_candidates(
@@ -84,13 +100,15 @@ class TestUpsert(unittest.TestCase):
 
         def gh(args: list[str]) -> str:
             calls.append(args)
-            if args[:2] == ["issue", "list"] and "--search" in args:
-                return json.dumps(
-                    [
-                        {"number": 812, "title": usp.ISSUE_TITLE},
-                        {"number": 774, "title": usp.ISSUE_TITLE},
-                    ]
-                )
+            if args[:2] == ["issue", "list"] and "--state" in args:
+                state = args[args.index("--state") + 1]
+                if state == "open" and "--label" not in args:
+                    return json.dumps(
+                        [
+                            {"number": 812, "title": usp.ISSUE_TITLE},
+                            {"number": 774, "title": usp.ISSUE_TITLE},
+                        ]
+                    )
             if args[:2] == ["issue", "list"]:
                 return "[]"
             return ""
@@ -104,15 +122,17 @@ class TestUpsert(unittest.TestCase):
         self.assertEqual(closes[0][2], "812")
         self.assertIn("Duplicate of #774", " ".join(closes[0]))
 
-    def test_ignores_other_titles_in_search(self) -> None:
+    def test_ignores_other_titles_in_list(self) -> None:
         def gh(args: list[str]) -> str:
-            if args[:2] == ["issue", "list"] and "--search" in args:
-                return json.dumps(
-                    [
-                        {"number": 1, "title": "Unrelated"},
-                        {"number": 774, "title": usp.ISSUE_TITLE},
-                    ]
-                )
+            if args[:2] == ["issue", "list"] and "--state" in args:
+                state = args[args.index("--state") + 1]
+                if state == "open" and "--label" not in args:
+                    return json.dumps(
+                        [
+                            {"number": 1, "title": "Unrelated"},
+                            {"number": 774, "title": usp.ISSUE_TITLE},
+                        ]
+                    )
             if args[:2] == ["issue", "list"]:
                 return "[]"
             return ""
@@ -121,6 +141,23 @@ class TestUpsert(unittest.TestCase):
         self.assertEqual(plan["canonical"], 774)
         self.assertEqual(plan["close"], [])
 
+    def test_open_list_does_not_use_search(self) -> None:
+        calls: list[list[str]] = []
+
+        def gh(args: list[str]) -> str:
+            calls.append(args)
+            if args[:2] == ["issue", "list"]:
+                return "[]"
+            if args[:2] == ["issue", "create"]:
+                return "https://github.com/org/repo/issues/900\n"
+            raise AssertionError(args)
+
+        usp.upsert("body", gh=gh)
+        lists = [c for c in calls if c[:2] == ["issue", "list"]]
+        self.assertTrue(lists)
+        for c in lists:
+            self.assertNotIn("--search", c)
+
     def test_reopens_closed_singleton(self) -> None:
         calls: list[list[str]] = []
 
@@ -128,7 +165,7 @@ class TestUpsert(unittest.TestCase):
             calls.append(args)
             if args[:2] == ["issue", "list"] and "--state" in args:
                 idx = args.index("--state")
-                if args[idx + 1] == "closed":
+                if args[idx + 1] == "closed" and "--label" not in args:
                     return json.dumps([{"number": 774, "title": usp.ISSUE_TITLE}])
             if args[:2] == ["issue", "list"]:
                 return "[]"

--- a/scripts/upsert-social-preview-issue.py
+++ b/scripts/upsert-social-preview-issue.py
@@ -6,10 +6,15 @@ social-preview and then create a new one. gh issue create did not apply
 that label (issues landed as needs-triage only), so the close query
 matched nothing and every release opened a duplicate.
 
-This script lists open issues by title and by the social-preview label,
-keeps the oldest as canonical, updates its body, and closes extras.
-If none are open, it reopens the oldest closed issue with that title
-instead of creating a new number.
+Do not use `gh issue list --search`. GitHub search is a separate index
+and often returns no hits for GitHub App installation tokens, even when
+an open issue with the exact title already exists (#840 then #854).
+
+This script lists open and closed issues through the Issues REST list
+(`gh issue list` without --search), keeps the oldest open title match
+as canonical, updates its body, and closes extras. If none are open, it
+reopens the oldest closed issue with that title instead of creating a
+new number.
 """
 
 from __future__ import annotations
@@ -56,6 +61,23 @@ def collect_candidates(
     return sorted(seen.values(), key=lambda i: int(i["number"]))
 
 
+def list_issues_with_title(gh: GhFn, *, state: str, title: str) -> list[dict[str, Any]]:
+    """REST list, not search. Filter the exact title in process."""
+    raw = gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            state,
+            "--json",
+            "number,title",
+            "--limit",
+            "100",
+        ]
+    )
+    return [i for i in parse_issues(raw) if i.get("title") == title]
+
+
 def plan_upsert(
     candidates: list[dict[str, Any]],
     closed: list[dict[str, Any]] | None = None,
@@ -82,23 +104,7 @@ def upsert(
     title: str = ISSUE_TITLE,
     label: str = LABEL,
 ) -> dict[str, Any]:
-    by_title = parse_issues(
-        gh(
-            [
-                "issue",
-                "list",
-                "--state",
-                "open",
-                "--search",
-                f'is:open in:title "{title}"',
-                "--json",
-                "number,title",
-                "--limit",
-                "50",
-            ]
-        )
-    )
-    by_title = [i for i in by_title if i.get("title") == title]
+    by_title = list_issues_with_title(gh, state="open", title=title)
     by_label = parse_issues(
         gh(
             [
@@ -111,27 +117,11 @@ def upsert(
                 "--json",
                 "number,title",
                 "--limit",
-                "50",
+                "100",
             ]
         )
     )
-    closed = parse_issues(
-        gh(
-            [
-                "issue",
-                "list",
-                "--state",
-                "closed",
-                "--search",
-                f'in:title "{title}"',
-                "--json",
-                "number,title",
-                "--limit",
-                "50",
-            ]
-        )
-    )
-    closed = [i for i in closed if i.get("title") == title]
+    closed = list_issues_with_title(gh, state="closed", title=title)
     plan = plan_upsert(collect_candidates(by_title, by_label), closed)
 
     if plan["action"] == "reopen":


### PR DESCRIPTION
The social-preview reminder job opened a second issue on every release even when one was already open.

## Problem

`upsert-social-preview-issue.py` found existing issues with `gh issue list --search`. GitHub search is a separate index. With the App installation token it returned no hits, so the job created #854 while #840 was already open. Both were labeled `needs-triage` only.

v0.1.21 also did not need a Settings upload. Resource and data-source counts stayed 57 and 70. Only the test floor moved from 1600+ to 1650+.

## Change

- List issues with REST (`gh issue list` without `--search`) and match the exact title in process.
- Open a stats PR and reminder issue only when resources or data sources change. Test-floor ticks can still update the repo description via API.
- Issue triage treats "Upload social preview image" as `social-preview` + `ready`, not inbox.

#854 was closed as a duplicate of #840. #840 was closed as not planned (no upload).

## Validation

```
python3 -m unittest scripts.test_upsert_social_preview_issue -v
actionlint .github/workflows/update-social-preview.yml .github/workflows/issue-triage.yml
```
